### PR TITLE
feat(validation): show details JSON as accordion on recording detail

### DIFF
--- a/frontend/src/features/validation/__tests__/validation-summary.test.tsx
+++ b/frontend/src/features/validation/__tests__/validation-summary.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ValidationResponse } from "@/api/generated/schemas";
 import { ValidationSummary } from "../validation-summary";
@@ -164,6 +164,75 @@ describe("ValidationSummary", () => {
     useValidationMock.mockReturnValue({ data: undefined, isLoading: true });
     render(<ValidationSummary selectedFolder="rec_001" />);
     expect(screen.getByText(/Running validators/i)).toBeInTheDocument();
+  });
+
+  it("toggles formatted details JSON when a row with details is clicked", () => {
+    useValidationMock.mockReturnValue({
+      data: {
+        status: "ready",
+        report: {
+          overall_status: "fail",
+          results: [
+            {
+              validator_name: "required_topics_present",
+              source: "builtin",
+              source_module: null,
+              status: "fail",
+              message: "Missing required topics",
+              details: { missing_topics: ["/cam/front"], required_topics: ["/cam/front", "/joint_states"] },
+            },
+          ],
+          task_name: null,
+          executed_at: "2026-05-25T00:00:00",
+        },
+        error: null,
+      },
+      isLoading: false,
+    });
+    render(<ValidationSummary selectedFolder="rec_001" />);
+
+    // Collapsed by default — JSON not visible.
+    expect(screen.queryByText(/missing_topics/)).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole("button", { name: /required_topics_present/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    // Formatted JSON appears with both keys visible.
+    expect(screen.getByText(/"missing_topics"/)).toBeInTheDocument();
+    expect(screen.getByText(/"\/cam\/front"/)).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText(/"missing_topics"/)).not.toBeInTheDocument();
+  });
+
+  it("does not render a toggle for rows without details", () => {
+    useValidationMock.mockReturnValue({
+      data: {
+        status: "ready",
+        report: {
+          overall_status: "pass",
+          results: [
+            {
+              validator_name: "required_topics_present",
+              source: "builtin",
+              source_module: null,
+              status: "pass",
+              message: "All required topics present",
+              details: null,
+            },
+          ],
+          task_name: null,
+          executed_at: "2026-05-25T00:00:00",
+        },
+        error: null,
+      },
+      isLoading: false,
+    });
+    render(<ValidationSummary selectedFolder="rec_001" />);
+    expect(screen.queryByRole("button", { name: /required_topics_present/i })).not.toBeInTheDocument();
   });
 
   it("shows the no-results message when status is unknown / report is not fetched", () => {

--- a/frontend/src/features/validation/validation-summary.tsx
+++ b/frontend/src/features/validation/validation-summary.tsx
@@ -5,8 +5,8 @@
  * (idempotent) so users do not have to push a button to see results.
  */
 
-import { Loader2 } from "lucide-react";
-import { useEffect } from "react";
+import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
 import type { ValidationResponse, ValidationResultItem } from "@/api/generated/schemas";
 import { useStartValidation, useValidation } from "@/hooks/use-api";
 import { isValidationStatus, ValidationStatusBadge } from "./ui/status-badge";
@@ -44,9 +44,22 @@ function StatusMessage({
 }
 
 function ValidationResultRow({ item }: { item: ValidationResultItem }) {
+  // --- Render-only state ---
+  const [expanded, setExpanded] = useState(false);
+
   const status = isValidationStatus(item.status) ? item.status : "error";
-  return (
-    <div className="flex items-start gap-2 border-b border-border px-3 py-2 last:border-b-0">
+  const hasDetails = item.details !== null && Object.keys(item.details).length > 0;
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+
+  const header = (
+    <div className="flex items-start gap-2 px-3 py-2 text-left">
+      <div className="pt-0.5">
+        {hasDetails ? (
+          <Chevron size={12} className="text-muted-foreground" aria-hidden="true" />
+        ) : (
+          <span className="inline-block h-3 w-3" aria-hidden="true" />
+        )}
+      </div>
       <div className="pt-0.5">
         <ValidationStatusBadge status={status} size="sm" />
       </div>
@@ -66,6 +79,28 @@ function ValidationResultRow({ item }: { item: ValidationResultItem }) {
         </div>
         {item.message && <p className="mt-0.5 text-[13px] text-muted-foreground">{item.message}</p>}
       </div>
+    </div>
+  );
+
+  return (
+    <div className="border-b border-border last:border-b-0">
+      {hasDetails ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          className="block w-full hover:bg-muted/20"
+        >
+          {header}
+        </button>
+      ) : (
+        header
+      )}
+      {hasDetails && expanded && (
+        <pre className="mx-3 mb-2 ml-9 overflow-x-auto whitespace-pre rounded bg-muted/40 px-2 py-1.5 text-[13px] text-muted-foreground">
+          {JSON.stringify(item.details, null, 2)}
+        </pre>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- The Validation tab on `/recordings/{name}` now renders each row as an accordion: when a `RecordingValidator` returns `details`, clicking the row reveals a formatted JSON block (`JSON.stringify(details, null, 2)` in a `<pre>`). Previously, `details` was persisted to `validation_result.json` and exposed via `GET /api/validation` but never surfaced in the UI.
- Rows without `details` (the typical pass case) stay non-clickable and chevron-less, keeping the panel quiet.
- Backend / OpenAPI / orval schemas unchanged — `ValidationResultItem.details` was already available on the wire.

## Test plan
- [x] `pnpm exec vitest run src/features/validation` (18/18 passed, including 2 new cases: toggle behaviour + no-toggle for null details)
- [x] `pnpm exec biome check src/features/validation/`
- [x] Manual: open a recording whose validator returns `details` (e.g. drop a custom validator under `backend/app/features/validation/custom/` that returns `details={...}`), confirm the row reveals the formatted JSON on click and collapses again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)