### PR TITLE
feat(recording-page): polish layout (Stop toggle, minimize monitor pane, narrow-sidebar Hz)

### DIFF
--- a/frontend/src/features/live-topics/ui/preview-pane.tsx
+++ b/frontend/src/features/live-topics/ui/preview-pane.tsx
@@ -17,9 +17,8 @@ function PreviewHeader({ count }: { count: number }) {
 
   return (
     <div className="flex items-center justify-between border-b border-border px-3 py-2">
-      <span className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">Live Preview</span>
-      <div className="flex items-center gap-3">
-        {count > 0 && <span className="text-xs text-muted-foreground">{count}/4</span>}
+      <div className="flex items-center gap-6">
+        <span className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">Live Preview</span>
         <div className="flex items-center gap-1.5">
           <Label htmlFor="stop-live-monitor" className="text-[13px] text-muted-foreground cursor-pointer">
             Stop while recording
@@ -27,6 +26,7 @@ function PreviewHeader({ count }: { count: number }) {
           <Switch id="stop-live-monitor" checked={stopLiveMonitor} onCheckedChange={setStopLiveMonitor} />
         </div>
       </div>
+      {count > 0 && <span className="text-xs text-muted-foreground">{count}/4</span>}
     </div>
   );
 }

--- a/frontend/src/features/live-topics/ui/topic-list.tsx
+++ b/frontend/src/features/live-topics/ui/topic-list.tsx
@@ -135,9 +135,12 @@ export function TopicList() {
         )}
       </div>
 
-      {/* Topic list (clicking the empty area clears the entire preview; disabled while Live) */}
+      {/* Topic list (clicking the empty area clears the entire preview; disabled while Live).
+          The `[&_[data-slot=scroll-area-viewport]>div]:!block` override forces the Radix Viewport's
+          inner wrapper to be block-level (its default `display: table` lets the row grow with content
+          and breaks the topic-name truncation when the sidebar is narrow). */}
       <ScrollArea
-        className="flex-1"
+        className="flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block"
         onClick={() => {
           if (!isLive) clearPreviewedTopics();
         }}

--- a/frontend/src/features/monitor/index.ts
+++ b/frontend/src/features/monitor/index.ts
@@ -1,1 +1,1 @@
-export { MonitorTabs } from "./monitor-tabs";
+export { MonitorTabs, MonitorTabsHeader } from "./monitor-tabs";

--- a/frontend/src/features/monitor/monitor-tabs.tsx
+++ b/frontend/src/features/monitor/monitor-tabs.tsx
@@ -1,6 +1,8 @@
 /** Monitor tabs: switches between the Loss Rate chart (default) and Log views. */
 
-import { Activity, ScrollText } from "lucide-react";
+import { Activity, PanelBottomClose, PanelBottomOpen, ScrollText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { type BottomTab, usePanelStore } from "@/stores/panel-store";
 import { LogViewer } from "./log-viewer";
 import { LossRateChart } from "./loss-rate-chart";
@@ -10,32 +12,59 @@ const tabs: { id: BottomTab; label: string; icon: React.ReactNode }[] = [
   { id: "log", label: "Log", icon: <ScrollText size={13} /> },
 ];
 
-export function MonitorTabs() {
-  const activeTab = usePanelStore((state) => state.bottomTab);
-  const setTab = usePanelStore((state) => state.setBottomTab);
+/** Tab header (tab buttons + minimize/restore toggle).
+ *
+ * Rendered alone as the minimized bar at the bottom of the screen,
+ * or as the header of the full tab panel.
+ */
+export function MonitorTabsHeader({ placement = "in-panel" }: { placement?: "in-panel" | "bottom-bar" } = {}) {
+  const activeTab = usePanelStore((s) => s.bottomTab);
+  const setTab = usePanelStore((s) => s.setBottomTab);
+  const minimized = usePanelStore((s) => s.bottomPaneMinimized);
+  const toggleMinimized = usePanelStore((s) => s.toggleBottomPaneMinimized);
+
+  const borderClass = placement === "bottom-bar" ? "border-t border-border" : "border-b border-border";
 
   return (
-    <div className="flex h-full flex-col bg-background">
-      {/* Tab header */}
-      <div className="flex items-center border-b border-border">
+    <div className={`flex items-center justify-between ${borderClass}`}>
+      <div className="flex items-center">
         {tabs.map((tab) => (
           <button
             key={tab.id}
             type="button"
             className={`flex items-center gap-1.5 px-3 py-1.5 text-sm font-semibold uppercase tracking-wider transition-colors ${
-              activeTab === tab.id
+              !minimized && activeTab === tab.id
                 ? "text-foreground border-b-2 border-foreground"
                 : "text-muted-foreground hover:text-foreground/70"
             }`}
-            onClick={() => setTab(tab.id)}
+            onClick={() => {
+              setTab(tab.id);
+              if (minimized) usePanelStore.getState().setBottomPaneMinimized(false);
+            }}
           >
             {tab.icon}
             {tab.label}
           </button>
         ))}
       </div>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-6 w-6 mr-1" onClick={toggleMinimized}>
+            {minimized ? <PanelBottomOpen size={13} /> : <PanelBottomClose size={13} />}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top">{minimized ? "Restore panel" : "Minimize to bottom"}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
 
-      {/* Tab content */}
+export function MonitorTabs() {
+  const activeTab = usePanelStore((state) => state.bottomTab);
+
+  return (
+    <div className="flex h-full flex-col bg-background">
+      <MonitorTabsHeader />
       <div className="flex-1 overflow-hidden">{activeTab === "loss-rate" ? <LossRateChart /> : <LogViewer />}</div>
     </div>
   );

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -6,7 +6,7 @@ import { Group, Panel } from "react-resizable-panels";
 import { updateSubscriptions } from "@/api/generated/topics/topics";
 import { ResizeHandleH, ResizeHandleV } from "@/components/ui/resize-handle";
 import { LiveTopicPreview, LiveTopics, useLiveTopicsStore } from "@/features/live-topics";
-import { MonitorTabs } from "@/features/monitor";
+import { MonitorTabs, MonitorTabsHeader } from "@/features/monitor";
 import { RecordingCompletionBanner, RecordingControl, useRecordingStore } from "@/features/recording";
 import { useConfig, useIsRecording } from "@/hooks/use-api";
 import { useTopicsStream } from "@/hooks/use-topics-stream";
@@ -34,9 +34,17 @@ function RecorderPage() {
 
   // --- Render-only state ---
   const topicsSidebarOpen = usePanelStore((s) => s.topicsSidebarOpen);
+  const bottomPaneMinimized = usePanelStore((s) => s.bottomPaneMinimized);
 
-  // Right side (PREVIEW + QUALITY/LOG): renders the same vertical split regardless of sidebar open/closed state.
-  const rightSide = (
+  // Right side (PREVIEW + QUALITY/LOG): vertical split when expanded, or PREVIEW + thin tab bar when minimized.
+  const rightSide = bottomPaneMinimized ? (
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1">
+        <LiveTopicPreview />
+      </div>
+      <MonitorTabsHeader placement="bottom-bar" />
+    </div>
+  ) : (
     <Group orientation="vertical" style={{ height: "100%" }}>
       <Panel defaultSize="65%" minSize="30%" id="preview">
         <LiveTopicPreview />

--- a/frontend/src/stores/panel-store.ts
+++ b/frontend/src/stores/panel-store.ts
@@ -7,12 +7,16 @@ export type BottomTab = "loss-rate" | "log";
 interface PanelStore {
   /** Active tab of the bottom panel. */
   bottomTab: BottomTab;
+  /** Whether the bottom panel (Loss Rate / Log) is minimized to the bottom of the screen. */
+  bottomPaneMinimized: boolean;
   /** Visibility of the TanStack Query DevTools (development only). */
   showQueryDevtools: boolean;
   /** Open/closed state of the recording page's left sidebar (Topics). */
   topicsSidebarOpen: boolean;
 
   setBottomTab: (tab: BottomTab) => void;
+  setBottomPaneMinimized: (minimized: boolean) => void;
+  toggleBottomPaneMinimized: () => void;
   toggleQueryDevtools: () => void;
   toggleTopicsSidebar: () => void;
 }
@@ -21,10 +25,14 @@ export const usePanelStore = create<PanelStore>()(
   devtools(
     (set) => ({
       bottomTab: "loss-rate",
+      bottomPaneMinimized: false,
       showQueryDevtools: false,
       topicsSidebarOpen: true,
 
       setBottomTab: (tab) => set({ bottomTab: tab }, false, "setBottomTab"),
+      setBottomPaneMinimized: (minimized) => set({ bottomPaneMinimized: minimized }, false, "setBottomPaneMinimized"),
+      toggleBottomPaneMinimized: () =>
+        set((state) => ({ bottomPaneMinimized: !state.bottomPaneMinimized }), false, "toggleBottomPaneMinimized"),
       toggleQueryDevtools: () =>
         set((state) => ({ showQueryDevtools: !state.showQueryDevtools }), false, "toggleQueryDevtools"),
       toggleTopicsSidebar: () =>


### PR DESCRIPTION
## Summary
- Reposition the **Stop while recording** toggle next to the **LIVE PREVIEW** label with adequate spacing; move the `{count}/4` badge to the right.
- Add a minimize toggle to the top-right of the **LOSS RATE / LOG** pane. Minimizing collapses the bottom panel to a thin bar pinned to the screen bottom; clicking a tab or the restore icon re-opens it.
- Fix the **TOPICS** sidebar so the Hz column stays visible at narrow widths. The topic name truncates with ellipsis and the existing `title` attribute supplies the full-name hover tooltip — they now actually work because Radix `ScrollArea`'s inner `display: table` wrapper is overridden to `display: block`.

## Test plan
- [x] `LIVE PREVIEW` header shows the toggle right next to the title with comfortable spacing; `{count}/4` sits on the right when 1+ topics are previewed.
- [x] Minimize button collapses the LOSS RATE / LOG panel to a slim bar; restore button (or clicking a tab) brings it back. State survives within the session.
- [x] Drag the TOPICS sidebar narrow — Hz/loss/auto stays fully visible, topic name shows ellipsis, hover reveals the full name.
- [x] `make lint-frontend` and `make test-frontend` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)