### PR TITLE
feat(settings): require ROBOT_CONFIG and OUTPUT_DIR in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
-# Robot config (specify a YAML file under the config/ directory)
+# Robot config (required; specify a YAML file under the config/ directory)
 # Topics, expected Hz, ROS_DOMAIN_ID, robot name, etc. are managed in YAML
 ROBOT_CONFIG=config/simulator.yaml
 
-# Recording settings
+# Recording settings (required; directory where MCAP recordings are stored)
 OUTPUT_DIR=./output
 
 # Server settings

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -82,11 +82,11 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    # Robot configuration file path
-    robot_config: str = "config/simulator.yaml"
+    # Robot configuration file path (required; must be set in .env)
+    robot_config: str
 
-    # Recording settings
-    output_dir: Path = Path("/data/output")
+    # Recording settings (required; must be set in .env)
+    output_dir: Path
 
     # Topic monitor settings
     gap_threshold_sec: Annotated[float, Field(gt=0)] = 3.0

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from app.settings import HzPattern, RobotConfig, Settings, _load_robot_config, get_settings
 
@@ -134,7 +135,7 @@ class TestSettings:
 
     def test_robot_uses_default_when_yaml_missing(self, tmp_path: Path) -> None:
         """Returns the default RobotConfig when the YAML file does not exist."""
-        s = Settings(robot_config=str(tmp_path / "missing.yaml"))
+        s = Settings(robot_config=str(tmp_path / "missing.yaml"), output_dir=tmp_path)
         robot = s.robot
         assert robot.robot_name == "Robot"
         assert robot.ros_domain_id == 0
@@ -146,7 +147,7 @@ class TestSettings:
             "robot_name: MyBot\nros_domain_id: 99\nrecording_start_delay_sec: 2.0\n",
             encoding="utf-8",
         )
-        s = Settings(robot_config=str(yaml_path))
+        s = Settings(robot_config=str(yaml_path), output_dir=tmp_path)
         assert s.robot.robot_name == "MyBot"
         assert s.robot.ros_domain_id == 99
 
@@ -154,7 +155,7 @@ class TestSettings:
         """The robot property is loaded only on first access (cached)."""
         yaml_path = tmp_path / "robot.yaml"
         yaml_path.write_text("robot_name: Cached\n", encoding="utf-8")
-        s = Settings(robot_config=str(yaml_path))
+        s = Settings(robot_config=str(yaml_path), output_dir=tmp_path)
         first = s.robot
         second = s.robot
         assert first is second  # Same instance
@@ -179,7 +180,7 @@ expected_hz_patterns:
 """,
             encoding="utf-8",
         )
-        s = Settings(robot_config=str(yaml_path))
+        s = Settings(robot_config=str(yaml_path), output_dir=tmp_path)
         assert s.robot_name == "PropTest"
         assert s.ros_domain_id == 42
         assert s.recording_discovery_timeout == 8
@@ -192,14 +193,34 @@ expected_hz_patterns:
         """Defaults to 0.0 when not specified in YAML."""
         yaml_path = tmp_path / "robot.yaml"
         yaml_path.write_text("robot_name: Foo\n", encoding="utf-8")
-        s = Settings(robot_config=str(yaml_path))
+        s = Settings(robot_config=str(yaml_path), output_dir=tmp_path)
         assert s.recording_start_delay_sec == 0.0
+
+    def test_missing_robot_config_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Raises ValidationError when ROBOT_CONFIG is not set."""
+        monkeypatch.delenv("ROBOT_CONFIG", raising=False)
+        monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+        with pytest.raises(ValidationError, match="robot_config"):
+            Settings(_env_file=None)  # type: ignore[call-arg]
+
+    def test_missing_output_dir_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Raises ValidationError when OUTPUT_DIR is not set."""
+        monkeypatch.setenv("ROBOT_CONFIG", "config/simulator.yaml")
+        monkeypatch.delenv("OUTPUT_DIR", raising=False)
+        with pytest.raises(ValidationError, match="output_dir"):
+            Settings(_env_file=None)  # type: ignore[call-arg]
 
 
 class TestGetSettings:
     """Tests for get_settings()."""
 
-    def test_returns_settings_instance(self) -> None:
+    def test_returns_settings_instance(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
         """Returns a Settings instance."""
+        monkeypatch.setenv("ROBOT_CONFIG", "config/simulator.yaml")
+        monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
         s = get_settings()
         assert isinstance(s, Settings)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -57,7 +57,7 @@ Use `ROBOT_CONFIG` in `.env` to select a robot configuration. The topic list, ex
 
 ```bash
 # .env
-ROBOT_CONFIG=config/simulator.yaml   # Default
+ROBOT_CONFIG=config/simulator.yaml   # Required: use the bundled simulator config
 # ROBOT_CONFIG=config/myrobot.yaml   # Your own physical-robot config (copy simulator.yaml as a template)
 ```
 
@@ -229,8 +229,8 @@ The `.env` file holds only infrastructure and connection settings:
 
 | Variable | Default | Description |
 |------|-----------|------|
-| `ROBOT_CONFIG` | `config/simulator.yaml` | Path to the robot configuration YAML |
-| `OUTPUT_DIR` | `./output` | Directory where recording data is stored |
+| `ROBOT_CONFIG` | _required_ | Path to the robot configuration YAML (startup fails if unset) |
+| `OUTPUT_DIR` | _required_ | Directory where recording data is stored (startup fails if unset) |
 | `HOST` | `0.0.0.0` | Server bind address |
 | `PORT` | `8000` | Server port number |
 | `DEBUG` | `false` | Debug mode (affects log level) |


### PR DESCRIPTION
## Summary
- Drop the default values for `robot_config` (`config/simulator.yaml`) and `output_dir` (`/data/output`) on `Settings`, so a missing `.env` entry now fails fast at startup with a Pydantic `ValidationError` instead of silently falling back to paths that are almost certainly wrong on a real-robot deployment.
- Update `.env.example`, `docs/SETUP.md`, and the env-vars table to mark both variables as required.
- Update affected tests to pass `output_dir` explicitly, and add coverage that confirms instantiation raises when either env var is unset.

## Test plan
- [x] `make test-backend` — 19/19 `tests/test_settings.py` pass (the 4 pre-existing failures in `tests/features/validation/test_registry.py` are unrelated `caplog` capture issues)
- [x] Confirm the dev stack still boots via `make up` (ROBOT_CONFIG / OUTPUT_DIR are already set in `docker-compose.yml`)
- [x] Confirm that removing `ROBOT_CONFIG` (or `OUTPUT_DIR`) from `.env` / shell env causes the backend to exit at startup with a clear `ValidationError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)