### PR TITLE
chore(docker): forward .env into the backend container via env_file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,12 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: open-lutra-backend
+    # Forward .env into the container so optional features can read their
+    # settings without each variable needing an explicit `environment:` entry.
+    # Hardcoded `environment:` values below still override matching .env keys.
+    env_file:
+      - path: .env
+        required: false
     environment:
       - CYCLONEDDS_URI=file:///cyclonedds.xml
       - OUTPUT_DIR=/data/output


### PR DESCRIPTION
## Summary

- Adds `env_file: .env` to the `backend` service in `docker-compose.yml`, so every key declared in the user's `.env` is visible inside the container — not just the handful currently listed under `environment:`.
- Sets `required: false` so a missing `.env` does not block `docker compose up` on fresh clones.
- Hardcoded `environment:` values still take precedence on conflict, so existing behaviour (`OUTPUT_DIR=/data/output`, etc.) is unchanged.

## Why

Today every optional setting that the backend wants to read from the host's `.env` needs an explicit `- FOO=${FOO:-}` line under the backend service's `environment:` block. That works but makes adding any new optional setting a two-step change (add to `Settings`, add to compose).

With `env_file:`, new optional settings only need to land in `Settings` — the compose file does not need to be touched again. The first concrete consumer of this will be the upcoming S3 upload feature (`S3_BUCKET`, `AWS_*`, etc.) but the change is feature-agnostic.

## Test plan

- [x] `docker compose config backend` shows the new env_file directive merged in.
- [x] Add an arbitrary key to `.env` (e.g. `FOO=bar`); `docker compose exec backend env | grep FOO` shows `FOO=bar` inside the container.
- [x] Pre-existing hardcoded values still win: `.env` containing `OUTPUT_DIR=./host-path` does not override the container's `OUTPUT_DIR=/data/output`.
- [x] `make up` from a clean clone (no `.env`) still succeeds — the directive is `required: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)