### PR TITLE
feat(upload): add S3 object key template renderer

### DIFF
--- a/backend/app/features/upload/key_template.py
+++ b/backend/app/features/upload/key_template.py
@@ -1,0 +1,69 @@
+"""S3 object key template rendering.
+
+The key template comes from the `S3_KEY_TEMPLATE` env var and supports the
+following placeholders:
+
+    {task_name}        — from recording_meta.json
+    {recording_name}   — the recording folder name
+    {yyyymmddhhmmss}   — recording start time (UTC), 14-digit string
+
+Template validation rejects unknown placeholders and unbalanced braces so
+that misconfiguration surfaces as a clear upload-time error rather than
+silently producing a corrupt S3 key.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+_PLACEHOLDER_RE = re.compile(r"\{([^{}]*)\}")
+_ALLOWED_PLACEHOLDERS = frozenset({"task_name", "recording_name", "yyyymmddhhmmss"})
+
+
+class KeyTemplateError(ValueError):
+    """Raised when the template is malformed or references unknown placeholders."""
+
+
+def validate_template(template: str) -> None:
+    """Verify that every placeholder is known and braces are balanced.
+
+    Raises KeyTemplateError on any issue.
+    """
+    if template.count("{") != template.count("}"):
+        raise KeyTemplateError(f"Unbalanced braces in S3 key template: {template!r}")
+
+    for match in _PLACEHOLDER_RE.finditer(template):
+        name = match.group(1)
+        if name not in _ALLOWED_PLACEHOLDERS:
+            raise KeyTemplateError(
+                f"Unknown placeholder {{{name}}} in S3 key template. "
+                f"Allowed: {sorted(_ALLOWED_PLACEHOLDERS)}"
+            )
+
+
+def render_key(
+    template: str,
+    *,
+    task_name: str,
+    recording_name: str,
+    recording_start_ns: int,
+) -> str:
+    """Substitute placeholders into the template.
+
+    `recording_start_ns` is interpreted as nanoseconds since the Unix epoch
+    (the value stored in `metadata.yaml` by `ros2 bag record`). It is rendered
+    as a 14-digit UTC timestamp.
+
+    Raises KeyTemplateError if validation fails.
+    """
+    validate_template(template)
+
+    dt = datetime.fromtimestamp(recording_start_ns / 1_000_000_000, tz=timezone.utc)
+    yyyymmddhhmmss = dt.strftime("%Y%m%d%H%M%S")
+
+    return template.format(
+        task_name=task_name,
+        recording_name=recording_name,
+        yyyymmddhhmmss=yyyymmddhhmmss,
+    )

--- a/backend/app/features/upload/key_template.py
+++ b/backend/app/features/upload/key_template.py
@@ -3,9 +3,12 @@
 The key template comes from the `S3_KEY_TEMPLATE` env var and supports the
 following placeholders:
 
-    {task_name}        — from recording_meta.json
     {recording_name}   — the recording folder name
     {yyyymmddhhmmss}   — recording start time (UTC), 14-digit string
+
+`task_name` is intentionally NOT a placeholder. Future task names may
+contain spaces or other characters that are awkward inside an S3 key
+(URL-encoding, CLI quoting), so the key composition is kept ASCII-safe.
 
 Template validation rejects unknown placeholders and unbalanced braces so
 that misconfiguration surfaces as a clear upload-time error rather than
@@ -18,7 +21,7 @@ import re
 from datetime import datetime, timezone
 
 _PLACEHOLDER_RE = re.compile(r"\{([^{}]*)\}")
-_ALLOWED_PLACEHOLDERS = frozenset({"task_name", "recording_name", "yyyymmddhhmmss"})
+_ALLOWED_PLACEHOLDERS = frozenset({"recording_name", "yyyymmddhhmmss"})
 
 
 class KeyTemplateError(ValueError):
@@ -45,7 +48,6 @@ def validate_template(template: str) -> None:
 def render_key(
     template: str,
     *,
-    task_name: str,
     recording_name: str,
     recording_start_ns: int,
 ) -> str:
@@ -63,7 +65,6 @@ def render_key(
     yyyymmddhhmmss = dt.strftime("%Y%m%d%H%M%S")
 
     return template.format(
-        task_name=task_name,
         recording_name=recording_name,
         yyyymmddhhmmss=yyyymmddhhmmss,
     )

--- a/backend/tests/features/upload/test_key_template.py
+++ b/backend/tests/features/upload/test_key_template.py
@@ -1,0 +1,69 @@
+"""Tests for the S3 key template renderer."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.features.upload.key_template import KeyTemplateError, render_key, validate_template
+
+
+def _ns(dt: datetime) -> int:
+    return int(dt.timestamp() * 1_000_000_000)
+
+
+class TestValidateTemplate:
+    def test_accepts_known_placeholders(self) -> None:
+        validate_template("prefix/{task_name}/{yyyymmddhhmmss}/{recording_name}.zip")
+
+    def test_accepts_template_with_no_placeholders(self) -> None:
+        validate_template("static/prefix/file.zip")
+
+    def test_rejects_unknown_placeholder(self) -> None:
+        with pytest.raises(KeyTemplateError, match="Unknown placeholder"):
+            validate_template("prefix/{unknown}/file.zip")
+
+    def test_rejects_unbalanced_braces(self) -> None:
+        with pytest.raises(KeyTemplateError, match="Unbalanced braces"):
+            validate_template("prefix/{task_name/file.zip")
+
+
+class TestRenderKey:
+    def test_substitutes_all_placeholders(self) -> None:
+        ns = _ns(datetime(2026, 6, 8, 12, 34, 56, tzinfo=timezone.utc))
+        key = render_key(
+            "lutra/{task_name}/{yyyymmddhhmmss}/{recording_name}.zip",
+            task_name="pickplace",
+            recording_name="rec_001",
+            recording_start_ns=ns,
+        )
+        assert key == "lutra/pickplace/20260608123456/rec_001.zip"
+
+    def test_timestamp_is_utc(self) -> None:
+        """yyyymmddhhmmss is in UTC regardless of process timezone."""
+        ns = _ns(datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc))
+        key = render_key(
+            "{yyyymmddhhmmss}",
+            task_name="x",
+            recording_name="r",
+            recording_start_ns=ns,
+        )
+        assert key == "20260101000000"
+
+    def test_repeated_placeholder(self) -> None:
+        ns = _ns(datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc))
+        key = render_key(
+            "{task_name}/{task_name}/{recording_name}.zip",
+            task_name="x",
+            recording_name="r",
+            recording_start_ns=ns,
+        )
+        assert key == "x/x/r.zip"
+
+    def test_raises_on_invalid_template(self) -> None:
+        with pytest.raises(KeyTemplateError):
+            render_key(
+                "prefix/{bad}/file.zip",
+                task_name="x",
+                recording_name="r",
+                recording_start_ns=0,
+            )

--- a/backend/tests/features/upload/test_key_template.py
+++ b/backend/tests/features/upload/test_key_template.py
@@ -13,7 +13,7 @@ def _ns(dt: datetime) -> int:
 
 class TestValidateTemplate:
     def test_accepts_known_placeholders(self) -> None:
-        validate_template("prefix/{task_name}/{yyyymmddhhmmss}/{recording_name}.zip")
+        validate_template("prefix/{yyyymmddhhmmss}/{recording_name}.zip")
 
     def test_accepts_template_with_no_placeholders(self) -> None:
         validate_template("static/prefix/file.zip")
@@ -22,28 +22,31 @@ class TestValidateTemplate:
         with pytest.raises(KeyTemplateError, match="Unknown placeholder"):
             validate_template("prefix/{unknown}/file.zip")
 
+    def test_rejects_task_name_placeholder(self) -> None:
+        """`task_name` is intentionally not supported."""
+        with pytest.raises(KeyTemplateError, match="Unknown placeholder"):
+            validate_template("prefix/{task_name}/file.zip")
+
     def test_rejects_unbalanced_braces(self) -> None:
         with pytest.raises(KeyTemplateError, match="Unbalanced braces"):
-            validate_template("prefix/{task_name/file.zip")
+            validate_template("prefix/{recording_name/file.zip")
 
 
 class TestRenderKey:
     def test_substitutes_all_placeholders(self) -> None:
         ns = _ns(datetime(2026, 6, 8, 12, 34, 56, tzinfo=timezone.utc))
         key = render_key(
-            "lutra/{task_name}/{yyyymmddhhmmss}/{recording_name}.zip",
-            task_name="pickplace",
+            "lutra/{yyyymmddhhmmss}/{recording_name}.zip",
             recording_name="rec_001",
             recording_start_ns=ns,
         )
-        assert key == "lutra/pickplace/20260608123456/rec_001.zip"
+        assert key == "lutra/20260608123456/rec_001.zip"
 
     def test_timestamp_is_utc(self) -> None:
         """yyyymmddhhmmss is in UTC regardless of process timezone."""
         ns = _ns(datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc))
         key = render_key(
             "{yyyymmddhhmmss}",
-            task_name="x",
             recording_name="r",
             recording_start_ns=ns,
         )
@@ -52,18 +55,16 @@ class TestRenderKey:
     def test_repeated_placeholder(self) -> None:
         ns = _ns(datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc))
         key = render_key(
-            "{task_name}/{task_name}/{recording_name}.zip",
-            task_name="x",
+            "{recording_name}/{recording_name}.zip",
             recording_name="r",
             recording_start_ns=ns,
         )
-        assert key == "x/x/r.zip"
+        assert key == "r/r.zip"
 
     def test_raises_on_invalid_template(self) -> None:
         with pytest.raises(KeyTemplateError):
             render_key(
                 "prefix/{bad}/file.zip",
-                task_name="x",
                 recording_name="r",
                 recording_start_ns=0,
             )


### PR DESCRIPTION
## Summary

Adds `app/features/upload/key_template.py` — a small pure-Python module that turns the `S3_KEY_TEMPLATE` env var into a fully rendered S3 object key for a given recording.

Supported placeholders:

| Placeholder | Source |
|---|---|
| `{recording_name}` | the recording folder name |
| `{yyyymmddhhmmss}` | recording start time, **UTC**, 14 digits |

`task_name` is intentionally **not** a placeholder: it is a user-supplied label that may contain spaces or other characters that are awkward inside an S3 key (URL encoding, CLI quoting, log readability). Keeping the key composition ASCII-safe up front avoids depending on downstream task-name validation. A regression test asserts that `{task_name}` is rejected.

`validate_template()` rejects unknown placeholders and unbalanced braces so a misconfigured template fails fast at upload time with a clear error, rather than silently emitting a corrupt key.

## Why

Carved out of the larger upload feature as a standalone slice. The renderer has zero external dependencies (just stdlib `re` + `datetime`), so it can be reviewed and merged independently of the S3 client, job runner, router, and UI pieces.

The 14-digit UTC timestamp is intentional — it gives a stable, lexicographically sortable key segment per recording. Combined with the same recording's start time being used on every retry, the key is stable across upload retries (so retry == overwrite, no orphan objects).

## Not in this PR

- No `S3_KEY_TEMPLATE` setting field yet (added with the consumer in a later slice).
- No router, no job runner, no documentation.

## Test plan

- [x] `uv run ruff check app/ tests/` clean
- [x] `uv run mypy app/` clean
- [x] `uv run pytest tests/features/upload/test_key_template.py` — 9 passed
- [x] `app/features/upload/key_template.py` at 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)