### PR TITLE
feat(upload): add recording-folder zip builder

### DIFF
--- a/backend/app/features/upload/zip_builder.py
+++ b/backend/app/features/upload/zip_builder.py
@@ -1,0 +1,66 @@
+"""Bundle a recording folder into a single zip file.
+
+The zip is written to `<recording_dir>/<recording_dir.name>.zip` and persisted
+after upload — re-running the upload skips re-zipping when the inputs have not
+changed (the zip is regenerated whenever any source file's mtime is newer than
+the zip's, to handle artifacts produced after a previous zip).
+"""
+
+from __future__ import annotations
+
+import logging
+import zipfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_COMPRESSION_LEVEL = 6  # zipfile default for ZIP_DEFLATED
+
+
+def build_zip(recording_dir: Path) -> Path:
+    """Zip every file directly inside `recording_dir` into `<dir>/<dir.name>.zip`.
+
+    The zip itself is skipped during enumeration so re-runs are idempotent.
+    Returns the zip path.
+    """
+    zip_path = recording_dir / f"{recording_dir.name}.zip"
+
+    members = _collect_members(recording_dir, zip_path)
+    if _zip_is_fresh(zip_path, members):
+        logger.info("Zip is up to date, skipping rebuild: %s", zip_path)
+        return zip_path
+
+    # Write atomically: build a temp zip, then rename. Prevents leaving a
+    # half-written zip if the process is killed mid-write.
+    tmp_path = zip_path.with_suffix(".zip.tmp")
+    with zipfile.ZipFile(
+        tmp_path,
+        mode="w",
+        compression=zipfile.ZIP_DEFLATED,
+        compresslevel=_COMPRESSION_LEVEL,
+    ) as zf:
+        for member in members:
+            zf.write(member, arcname=member.name)
+    tmp_path.replace(zip_path)
+    logger.info("Built zip: %s (%d files)", zip_path, len(members))
+    return zip_path
+
+
+def _collect_members(recording_dir: Path, zip_path: Path) -> list[Path]:
+    """Return files directly inside `recording_dir`, excluding the zip itself."""
+    members: list[Path] = []
+    for entry in sorted(recording_dir.iterdir()):
+        if not entry.is_file():
+            continue
+        if entry == zip_path or entry.name.endswith(".zip.tmp"):
+            continue
+        members.append(entry)
+    return members
+
+
+def _zip_is_fresh(zip_path: Path, members: list[Path]) -> bool:
+    """True when the zip exists and is newer than every member."""
+    if not zip_path.exists():
+        return False
+    zip_mtime = zip_path.stat().st_mtime
+    return all(m.stat().st_mtime <= zip_mtime for m in members)

--- a/backend/tests/features/upload/test_zip_builder.py
+++ b/backend/tests/features/upload/test_zip_builder.py
@@ -1,0 +1,102 @@
+"""Tests for the recording-folder zip builder."""
+
+import os
+import zipfile
+from pathlib import Path
+
+from app.features.upload.zip_builder import build_zip
+
+
+def _populate(folder: Path) -> None:
+    (folder / "data.mcap").write_bytes(b"binary-data")
+    (folder / "metadata.yaml").write_text("starting_time:\n  nanoseconds_since_epoch: 0\n", encoding="utf-8")
+    (folder / "recording_meta.json").write_text('{"task_name": "x"}', encoding="utf-8")
+
+
+class TestBuildZip:
+    def test_creates_zip_with_all_files(self, tmp_path: Path) -> None:
+        rec = tmp_path / "rec_001"
+        rec.mkdir()
+        _populate(rec)
+
+        zip_path = build_zip(rec)
+        assert zip_path == rec / "rec_001.zip"
+        assert zip_path.exists()
+        with zipfile.ZipFile(zip_path) as zf:
+            names = sorted(zf.namelist())
+        assert names == ["data.mcap", "metadata.yaml", "recording_meta.json"]
+
+    def test_excludes_zip_itself(self, tmp_path: Path) -> None:
+        """A previously-built zip in the folder is not bundled into the new zip."""
+        rec = tmp_path / "rec_001"
+        rec.mkdir()
+        _populate(rec)
+        zip_path = build_zip(rec)
+        # Force the zip's mtime to be older than the sources so we trigger a rebuild.
+        old = zip_path.stat().st_mtime - 100
+        os.utime(zip_path, (old, old))
+
+        zip_path = build_zip(rec)
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert "rec_001.zip" not in names
+
+    def test_skips_rebuild_when_fresh(self, tmp_path: Path) -> None:
+        """If the zip is newer than every source file, build_zip is a no-op."""
+        rec = tmp_path / "rec_001"
+        rec.mkdir()
+        _populate(rec)
+
+        zip_path = build_zip(rec)
+        # Bump zip mtime far into the future so it is fresher than sources.
+        future = zip_path.stat().st_mtime + 100
+        os.utime(zip_path, (future, future))
+        mtime_before = zip_path.stat().st_mtime
+
+        rebuilt = build_zip(rec)
+        assert rebuilt == zip_path
+        assert zip_path.stat().st_mtime == mtime_before  # unchanged
+
+    def test_rebuilds_when_source_changed(self, tmp_path: Path) -> None:
+        """Updating a source file's content (with newer mtime) triggers a rebuild."""
+        rec = tmp_path / "rec_001"
+        rec.mkdir()
+        _populate(rec)
+
+        zip_path = build_zip(rec)
+        old_zip_mtime = zip_path.stat().st_mtime
+
+        # Replace content and force a newer mtime on the source.
+        (rec / "data.mcap").write_bytes(b"updated-payload")
+        future = old_zip_mtime + 100
+        os.utime(rec / "data.mcap", (future, future))
+
+        rebuilt = build_zip(rec)
+        with zipfile.ZipFile(rebuilt) as zf:
+            assert zf.read("data.mcap") == b"updated-payload"
+
+    def test_ignores_subdirectories(self, tmp_path: Path) -> None:
+        """Only files directly inside the recording folder are zipped."""
+        rec = tmp_path / "rec_001"
+        rec.mkdir()
+        (rec / "a.mcap").write_bytes(b"x")
+        sub = rec / "sub"
+        sub.mkdir()
+        (sub / "nested.txt").write_text("y", encoding="utf-8")
+
+        zip_path = build_zip(rec)
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert names == ["a.mcap"]
+
+    def test_ignores_temp_zip(self, tmp_path: Path) -> None:
+        """A stale .zip.tmp from a crashed run is not bundled."""
+        rec = tmp_path / "rec_001"
+        rec.mkdir()
+        (rec / "data.mcap").write_bytes(b"x")
+        (rec / "rec_001.zip.tmp").write_bytes(b"stale")
+
+        zip_path = build_zip(rec)
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert "rec_001.zip.tmp" not in names


### PR DESCRIPTION
## Summary

Adds `app/features/upload/zip_builder.py` — a stdlib-only helper that bundles every file directly inside a recording folder into `<recording_dir>/<recording_dir.name>.zip` using `ZIP_DEFLATED` at compression level 6.

## Design highlights

- **Persisted alongside the recording.** The zip lives in the recording folder itself, not a scratch dir, so subsequent uploads can reuse it.
- **mtime-based freshness.** If the zip is newer than every source file, `build_zip` is a no-op. Touching any source forces a rebuild. This keeps repeated upload triggers cheap without needing checksums.
- **Self-exclusion.** The zip itself and any stale `<name>.zip.tmp` from a crashed prior run are skipped during member enumeration, so re-runs never recurse into earlier outputs.
- **Atomic writes.** The zip is written to `<name>.zip.tmp` and then `Path.replace()` atomically into place. A process killed mid-write never leaves a half-written zip behind.
- **Flat layout.** Only files directly inside the recording directory are bundled; subdirectories are skipped (matches what `ros2 bag record` produces).

## Why

Carved out of the larger upload feature as a standalone slice. The builder is stdlib-only (`zipfile` + `pathlib`), so it can be reviewed, tested, and merged independently of the S3 client, settings, router, and UI pieces.

The single-zip-per-recording approach lets the eventual upload step deal with one S3 object per recording rather than orchestrating multipart re-upload of a tree of files — much simpler error handling and a stable object key.

## Not in this PR

- No boto3, no Settings changes, no router, no job runner.
- No bulk-upload or auto-upload triggers.

## Test plan

- [x] `uv run ruff check app/ tests/` clean
- [x] `uv run mypy app/` clean
- [x] `uv run pytest tests/features/upload/test_zip_builder.py` — 6 passed
- [x] `app/features/upload/zip_builder.py` at 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)