### PR TITLE
feat(upload): add throttled progress callback for boto3 uploads

### DIFF
--- a/backend/app/features/upload/progress.py
+++ b/backend/app/features/upload/progress.py
@@ -1,0 +1,57 @@
+"""Throttled progress callback for boto3 uploads.
+
+boto3 invokes `Callback(bytes_transferred_delta)` after each part / chunk
+finishes. For multi-GB MCAP recordings the callback fires hundreds of times
+per second; persisting on every call would thrash disk and flood SSE
+subscribers. `ThrottledProgress` accumulates the delta in memory and emits
+at most once per `interval_sec` (default 1.0 s), plus a guaranteed final
+flush on `close()`.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from threading import Lock
+
+
+class ThrottledProgress:
+    """Accumulate byte progress; emit via `on_update` at most once per interval.
+
+    Both the boto3 `Callback` invocation and `close()` are thread-safe: boto3
+    calls the callback from worker threads when multipart uploads run with
+    `max_concurrency > 1`.
+    """
+
+    def __init__(
+        self,
+        on_update: Callable[[int], None],
+        *,
+        interval_sec: float = 1.0,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._on_update = on_update
+        self._interval_sec = interval_sec
+        self._now = now
+        self._lock = Lock()
+        self._bytes = 0
+        self._last_emit = 0.0
+
+    def __call__(self, bytes_delta: int) -> None:
+        """boto3 callback entry point."""
+        with self._lock:
+            self._bytes += bytes_delta
+            current = self._now()
+            if current - self._last_emit < self._interval_sec:
+                return
+            self._last_emit = current
+            snapshot = self._bytes
+        self._on_update(snapshot)
+
+    def close(self) -> int:
+        """Flush a final update (bypasses the throttle). Returns total bytes."""
+        with self._lock:
+            snapshot = self._bytes
+            self._last_emit = self._now()
+        self._on_update(snapshot)
+        return snapshot

--- a/backend/tests/features/upload/test_progress.py
+++ b/backend/tests/features/upload/test_progress.py
@@ -1,0 +1,52 @@
+"""Tests for the throttled boto3 progress callback."""
+
+from app.features.upload.progress import ThrottledProgress
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+class TestThrottledProgress:
+    def test_emits_first_update_immediately(self) -> None:
+        seen: list[int] = []
+        clock = _Clock()
+        clock.t = 100.0  # any non-zero start
+
+        progress = ThrottledProgress(seen.append, interval_sec=1.0, now=clock)
+        progress(50)
+        assert seen == [50]
+
+    def test_throttles_subsequent_updates(self) -> None:
+        seen: list[int] = []
+        clock = _Clock()
+        clock.t = 100.0
+
+        progress = ThrottledProgress(seen.append, interval_sec=1.0, now=clock)
+        progress(50)  # emits → seen=[50]
+
+        clock.t = 100.5  # half the interval
+        progress(50)  # suppressed (still 0.5s since last emit)
+
+        clock.t = 101.5  # full interval elapsed
+        progress(50)  # emits the running total
+
+        assert seen == [50, 150]
+
+    def test_close_emits_final_value(self) -> None:
+        seen: list[int] = []
+        clock = _Clock()
+        clock.t = 100.0
+
+        progress = ThrottledProgress(seen.append, interval_sec=1.0, now=clock)
+        progress(50)
+        clock.t = 100.1
+        progress(50)  # suppressed
+        total = progress.close()
+
+        assert total == 100
+        assert seen == [50, 100]  # the final close() always fires


### PR DESCRIPTION
## Summary

Adds `app/features/upload/progress.py` with `ThrottledProgress` — a thread-safe callable that boto3's `Callback=` interface can invoke hundreds of times per second during a multi-GB upload, without thrashing disk or flooding SSE subscribers.

## Behaviour

- Accumulates the byte delta in memory; emits the running total via `on_update(int)` **at most once per `interval_sec`** (default 1.0 s).
- `close()` always fires a final emit, bypassing the throttle, so the last known total is never lost on completion.
- Both `__call__` and `close()` take a `threading.Lock` because boto3 invokes the callback from worker threads when multipart uploads run with `max_concurrency > 1`.
- The `now` parameter is injected (default `time.monotonic`) for deterministic testing with a fake clock — no `time.sleep` in tests.

## Why

Carved out of the larger upload feature as a standalone slice. Notably this module deliberately does **not** import boto3 — the only contract is the callable signature `(bytes_delta: int) -> None`, which keeps the module stdlib-only and trivially mockable in isolation.

That choice also means the same primitive will work for any other "high-frequency progress, low-frequency UI" use case the project picks up later (e.g. quality analysis progress over multi-GB MCAP).

## Not in this PR

- No boto3, no Settings, no router, no job runner.
- No SSE wiring — the `on_update` callback is intentionally provider-agnostic.

## Test plan

- [x] `uv run ruff check app/ tests/` clean
- [x] `uv run mypy app/` clean
- [x] `uv run pytest tests/features/upload/test_progress.py` — 3 passed
- [x] `app/features/upload/progress.py` at 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)