### PR TITLE
feat(upload): persist UploadState as upload_state.json per recording

### DIFF
--- a/backend/app/features/upload/cache.py
+++ b/backend/app/features/upload/cache.py
@@ -1,0 +1,41 @@
+"""Load and save `upload_state.json`.
+
+Stored alongside `quality_report.json` / `validation_result.json` in the
+recording directory.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+from app.features.upload.models import UploadState
+
+logger = logging.getLogger(__name__)
+
+CACHE_FILENAME = "upload_state.json"
+
+
+def save_state(directory: Path, state: UploadState) -> None:
+    """Persist the UploadState as upload_state.json."""
+    path = directory / CACHE_FILENAME
+    path.write_text(
+        json.dumps(state.model_dump(mode="json"), indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def load_state(directory: Path) -> UploadState | None:
+    """Read upload_state.json if present.
+
+    Returns None when the file is missing or unreadable (only a warning
+    is logged in the latter case).
+    """
+    path = directory / CACHE_FILENAME
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return UploadState.model_validate(data)
+    except (json.JSONDecodeError, ValueError, OSError) as e:
+        logger.warning("Failed to read upload state: %s (%s)", path, e)
+        return None

--- a/backend/app/features/upload/models.py
+++ b/backend/app/features/upload/models.py
@@ -1,0 +1,29 @@
+"""Domain models for the upload feature.
+
+`UploadState` is persisted as `upload_state.json` inside each recording
+folder, mirroring how validation persists `validation_result.json`.
+"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+UploadStatus = Literal["idle", "uploading", "uploaded", "failed"]
+
+
+class UploadState(BaseModel):
+    """Persisted upload state for one recording.
+
+    Fields are required (no defaults) so JSON written by older versions
+    surfaces as a parse error instead of silently defaulting to zero values.
+    """
+
+    status: UploadStatus
+    s3_bucket: str | None
+    s3_key: str | None
+    etag: str | None
+    size_bytes: int | None
+    bytes_transferred: int
+    uploaded_at: datetime | None
+    error: str | None

--- a/backend/tests/features/upload/test_cache.py
+++ b/backend/tests/features/upload/test_cache.py
@@ -1,0 +1,49 @@
+"""Tests for upload_state.json load/save."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.features.upload.cache import CACHE_FILENAME, load_state, save_state
+from app.features.upload.models import UploadState
+
+
+def _make_state() -> UploadState:
+    return UploadState(
+        status="uploaded",
+        s3_bucket="lutra-test",
+        s3_key="prefix/recording.zip",
+        etag='"abc-1"',
+        size_bytes=1024,
+        bytes_transferred=1024,
+        uploaded_at=datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc),
+        error=None,
+    )
+
+
+class TestSaveLoad:
+    def test_roundtrip(self, tmp_path: Path) -> None:
+        original = _make_state()
+        save_state(tmp_path, original)
+
+        loaded = load_state(tmp_path)
+        assert loaded is not None
+        assert loaded.status == "uploaded"
+        assert loaded.s3_bucket == "lutra-test"
+        assert loaded.s3_key == "prefix/recording.zip"
+        assert loaded.etag == '"abc-1"'
+        assert loaded.size_bytes == 1024
+        assert loaded.bytes_transferred == 1024
+        assert loaded.uploaded_at == datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc)
+        assert loaded.error is None
+
+    def test_load_nonexistent_returns_none(self, tmp_path: Path) -> None:
+        assert load_state(tmp_path) is None
+
+    def test_load_corrupted_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / CACHE_FILENAME).write_text("{not valid json", encoding="utf-8")
+        assert load_state(tmp_path) is None
+
+    def test_load_invalid_schema_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / CACHE_FILENAME).write_text(json.dumps({"unexpected": "field"}), encoding="utf-8")
+        assert load_state(tmp_path) is None


### PR DESCRIPTION
## Summary

Adds the domain model and on-disk persistence for the upload feature, mirroring how validation persists `validation_result.json`.

### `app/features/upload/models.py`

- `UploadStatus = Literal["idle", "uploading", "uploaded", "failed"]`
- `UploadState` (pydantic `BaseModel`) with these fields: `status`, `s3_bucket`, `s3_key`, `etag`, `size_bytes`, `bytes_transferred`, `uploaded_at`, `error`.
- All fields are **required (no defaults)**, per the project's pydantic convention. This is deliberate: it makes a stale `upload_state.json` written by an older schema fail loudly at parse time, rather than silently zero-filling missing fields.

### `app/features/upload/cache.py`

- `save_state(directory, state)` writes pretty-printed `upload_state.json` next to the recording.
- `load_state(directory)` returns the parsed `UploadState`, or `None` when the file is missing / unreadable / schema-mismatched. Unreadable cases log a warning so failures are observable but never crash the caller.

## Why

Carved out of the larger upload feature as a standalone slice. Depends only on pydantic (already in the project) + stdlib `json`, so it can be reviewed and merged independently of the S3 client, settings, router, and UI pieces.

The "return `None` on corrupt cache" policy follows the same defensive pattern as the existing validation cache — recording detail pages should keep rendering even when a state file is stale or truncated.

## Not in this PR

- No Settings, no boto3, no router, no job runner.
- No FileEntry surfacing yet (the scanner will start reading `load_state(...)` in a later slice).

## Test plan

- [x] `uv run ruff check app/ tests/` clean
- [x] `uv run mypy app/` clean
- [x] `uv run pytest tests/features/upload/test_cache.py` — 4 passed
- [x] `app/features/upload/cache.py` and `models.py` both at 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)