### PR TITLE
refactor(upload): generalize UploadState fields (s3_bucket/s3_key → destination/key)

### DIFF
--- a/backend/app/features/upload/models.py
+++ b/backend/app/features/upload/models.py
@@ -17,11 +17,17 @@ class UploadState(BaseModel):
 
     Fields are required (no defaults) so JSON written by older versions
     surfaces as a parse error instead of silently defaulting to zero values.
+
+    `destination` and `key` are backend-agnostic: for the S3 backend they
+    map to bucket name and object key; future backends (GCS / local server)
+    fill in equivalents (bucket + object name, host + path). `etag` is the
+    backend's result identifier (S3 ETag, GCS generation, local hash) and
+    is `None` when the backend does not return one.
     """
 
     status: UploadStatus
-    s3_bucket: str | None
-    s3_key: str | None
+    destination: str | None
+    key: str | None
     etag: str | None
     size_bytes: int | None
     bytes_transferred: int

--- a/backend/tests/features/upload/test_cache.py
+++ b/backend/tests/features/upload/test_cache.py
@@ -11,8 +11,8 @@ from app.features.upload.models import UploadState
 def _make_state() -> UploadState:
     return UploadState(
         status="uploaded",
-        s3_bucket="lutra-test",
-        s3_key="prefix/recording.zip",
+        destination="lutra-test",
+        key="prefix/recording.zip",
         etag='"abc-1"',
         size_bytes=1024,
         bytes_transferred=1024,
@@ -29,8 +29,8 @@ class TestSaveLoad:
         loaded = load_state(tmp_path)
         assert loaded is not None
         assert loaded.status == "uploaded"
-        assert loaded.s3_bucket == "lutra-test"
-        assert loaded.s3_key == "prefix/recording.zip"
+        assert loaded.destination == "lutra-test"
+        assert loaded.key == "prefix/recording.zip"
         assert loaded.etag == '"abc-1"'
         assert loaded.size_bytes == 1024
         assert loaded.bytes_transferred == 1024


### PR DESCRIPTION
## Summary

- Renames `UploadState.s3_bucket` → `destination` and `UploadState.s3_key` → `key` so the persisted state file is not S3-shaped.
- `etag` stays — documented as the backend-agnostic result identifier (S3 ETag, GCS generation, local hash; None when the backend does not return one).

This is **step 1** of generalizing the upload feature for future GCS / local-server backends (issue #6). The S3-specific `Settings` env vars (`S3_BUCKET`, `S3_KEY_TEMPLATE`, `AWS_*`) intentionally keep their names — they belong to the S3 backend's configuration and will move next to its implementation when the `backends/` registry lands in the follow-up PR.

No callers exist yet (UploadService has not been added), so this rename has no runtime impact beyond what `tests/features/upload/test_cache.py` already covers.

## Test plan

- [x] `uv run ruff check app/ tests/` — clean
- [x] `uv run mypy app/` — clean (83 files)
- [x] `uv run pytest tests/features/upload/ -v` — 30 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)