### PR TITLE
feat(upload): wire UploadJob into the job queue

### DIFF
--- a/backend/app/features/jobs/models.py
+++ b/backend/app/features/jobs/models.py
@@ -33,6 +33,7 @@ class JobType(str, Enum):
     QUALITY = "quality"  # quality_report.json generation
     TIMELINE = "timeline"  # timeline_data.json generation
     VALIDATION = "validation"  # validation_result.json generation
+    UPLOAD = "upload"  # zip + upload to the configured UploadDestination
 
 
 @dataclass
@@ -111,6 +112,18 @@ class ValidationJob(Job):
 
     Loads the QualityReport, runs all validators via ValidationRunner, and generates
     validation_result.json. Used in the auto-chain after recording stops or for manual re-runs.
+    """
+
+    target_path: Path | None = None
+
+
+@dataclass
+class UploadJob(Job):
+    """Upload execution job.
+
+    Zips the recording folder and sends the archive to the configured
+    `UploadDestination` (today: S3). Persists progress in
+    `upload_state.json` so the UI can survive page reloads mid-upload.
     """
 
     target_path: Path | None = None

--- a/backend/app/features/jobs/service.py
+++ b/backend/app/features/jobs/service.py
@@ -7,6 +7,8 @@ Job types:
   - `GenerateMediaJob`: MCAP -> MP4 + telemetry.json conversion
   - `QualityJob`:       quality_report.json generation
   - `TimelineJob`:      timeline_data.json generation
+  - `ValidationJob`:    validation_result.json generation
+  - `UploadJob`:        zip recording + ship to the configured upload destination
 """
 
 import asyncio
@@ -28,6 +30,7 @@ from app.features.jobs.models import (
     JobType,
     QualityJob,
     TimelineJob,
+    UploadJob,
     ValidationJob,
 )
 from app.features.jobs.schemas import JobChangeEvent, JobEvent, JobSchema, QueueSnapshotData, QueueSnapshotEvent
@@ -74,6 +77,7 @@ class JobQueue:
             JobType.QUALITY: {},
             JobType.TIMELINE: {},
             JobType.VALIDATION: {},
+            JobType.UPLOAD: {},
         }
         self._subscribers: set[asyncio.Queue[JobEvent]] = set()
         self._worker_task: asyncio.Task[None] | None = None
@@ -177,6 +181,33 @@ class JobQueue:
         logger.info("ValidationJob added: %s (%s)", job.job_id, folder.name)
         return job
 
+    async def enqueue_upload(self, folder: Path) -> UploadJob:
+        """Enqueue an upload job (zip + ship to the configured destination).
+
+        If an active job already exists for the same folder, return it (prevents
+        duplicate execution).
+        """
+        async with self._lock:
+            existing_id = self._active_folders[JobType.UPLOAD].get(str(folder))
+            if existing_id and existing_id in self._jobs:
+                existing = self._jobs[existing_id]
+                if isinstance(existing, UploadJob):
+                    return existing
+
+            job = UploadJob(
+                job_id=f"upl_{uuid.uuid4().hex[:12]}",
+                type=JobType.UPLOAD,
+                folder=folder.name,
+                progress=JobProgress(step="queued", step_label="Waiting", current=0, total=1),
+                target_path=folder,
+            )
+            self._register_active(JobType.UPLOAD, folder, job)
+
+        await self._queue.put(job)
+        await self._broadcast(EVENT_JOB_ADDED, job)
+        logger.info("UploadJob added: %s (%s)", job.job_id, folder.name)
+        return job
+
     async def enqueue_timeline(self, folder: Path) -> TimelineJob:
         """Enqueue a timeline data generation job.
 
@@ -246,6 +277,10 @@ class JobQueue:
         """Return the in-progress/queued validation job for the specified folder."""
         return self._get_active_job(JobType.VALIDATION, folder)
 
+    def get_active_upload_job(self, folder: Path) -> Job | None:
+        """Return the in-progress/queued upload job for the specified folder."""
+        return self._get_active_job(JobType.UPLOAD, folder)
+
     def list_jobs(self) -> list[Job]:
         """Return active jobs combined with recent history."""
         active = [j for j in self._jobs.values() if j.status in (JobStatus.QUEUED, JobStatus.RUNNING)]
@@ -313,6 +348,8 @@ class JobQueue:
                 await self._run_timeline(job)
             elif isinstance(job, ValidationJob):
                 await self._run_validation(job)
+            elif isinstance(job, UploadJob):
+                await self._run_upload(job)
             else:  # pragma: no cover
                 raise ValueError(f"Unknown job type: {job.type}")
 
@@ -457,6 +494,101 @@ class JobQueue:
             recording_meta=meta,
         )
         await asyncio.to_thread(save_validation_report, target, report)
+
+    async def _run_upload(self, job: UploadJob) -> None:
+        """Zip the recording folder and ship it to the configured destination.
+
+        Persists `upload_state.json` at every stage (uploading -> uploaded /
+        failed) so reloads mid-upload recover gracefully. Per issue #6, this
+        path always overwrites (no skip-if-cached); duplicate dispatches are
+        prevented one level up by `enqueue_upload`.
+        """
+        target = job.target_path
+        if target is None:  # pragma: no cover
+            raise ValueError(f"UploadJob.target_path is not set: {job.job_id}")
+
+        from app.features.recordings.scanner import read_metadata_summary
+        from app.features.upload.cache import save_state
+        from app.features.upload.destinations import get_active_destination
+        from app.features.upload.key_template import render_key
+        from app.features.upload.models import UploadState
+        from app.features.upload.progress import ThrottledProgress
+        from app.features.upload.zip_builder import build_zip
+        from app.settings import get_settings
+
+        settings = get_settings()
+        destination = get_active_destination(settings)
+        err = destination.configuration_error()
+        if err is not None:
+            raise RuntimeError(err)
+        # configuration_error() guarantees these are set; assert for the type checker.
+        assert settings.s3_bucket is not None
+        assert settings.s3_key_template is not None
+
+        _, recording_start_ns, _, _ = read_metadata_summary(target)
+        if recording_start_ns is None:
+            raise FileNotFoundError(
+                f"Cannot determine recording start time from metadata.yaml: {target.name}",
+            )
+        key = render_key(
+            settings.s3_key_template,
+            recording_name=target.name,
+            recording_start_ns=recording_start_ns,
+        )
+
+        job.progress = JobProgress(step="zip", step_label="Building zip", current=0, total=1)
+        await self._broadcast(EVENT_JOB_PROGRESS, job)
+        zip_path = await asyncio.to_thread(build_zip, target)
+        zip_size = zip_path.stat().st_size
+
+        state = UploadState(
+            status="uploading",
+            destination=settings.s3_bucket,
+            key=key,
+            etag=None,
+            size_bytes=zip_size,
+            bytes_transferred=0,
+            uploaded_at=None,
+            error=None,
+        )
+        await asyncio.to_thread(save_state, target, state)
+
+        loop = asyncio.get_running_loop()
+
+        def on_progress(bytes_transferred: int) -> None:
+            """Throttled progress callback invoked from boto3 worker threads."""
+            state.bytes_transferred = bytes_transferred
+            save_state(target, state)
+            job.progress = JobProgress(
+                step="upload",
+                step_label="Uploading",
+                current=bytes_transferred,
+                total=max(zip_size, 1),
+            )
+            asyncio.run_coroutine_threadsafe(
+                self._broadcast(EVENT_JOB_PROGRESS, job),
+                loop,
+            )
+
+        throttled = ThrottledProgress(on_progress)
+
+        try:
+            result = await asyncio.to_thread(destination.upload, zip_path, key, throttled)
+            throttled.close()
+            final = state.model_copy(
+                update={
+                    "status": "uploaded",
+                    "etag": result.etag,
+                    "size_bytes": result.size_bytes,
+                    "bytes_transferred": result.size_bytes,
+                    "uploaded_at": datetime.now(timezone.utc),
+                },
+            )
+            await asyncio.to_thread(save_state, target, final)
+        except Exception as e:
+            failed = state.model_copy(update={"status": "failed", "error": str(e) or e.__class__.__name__})
+            await asyncio.to_thread(save_state, target, failed)
+            raise
 
     async def _run_timeline(self, job: TimelineJob) -> None:
         """Run timeline data generation (`build_and_save_timeline`).

--- a/backend/tests/features/jobs/test_upload_job.py
+++ b/backend/tests/features/jobs/test_upload_job.py
@@ -1,0 +1,234 @@
+"""Tests for the upload-related parts of the JobQueue.
+
+These cover only the upload-specific enqueue / discovery / runner paths.
+The rest of JobQueue (media / quality / timeline / validation) keeps its
+existing testing strategy.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.features.jobs.models import JobStatus, JobType, UploadJob
+from app.features.jobs.service import JobQueue
+from app.features.upload.cache import load_state
+from app.features.upload.destinations.base import UploadResult
+from app.settings import Settings
+
+
+def _make_settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "robot_config": "config/simulator.yaml",
+        "output_dir": "/tmp",
+        "s3_bucket": "lutra-test",
+        "s3_key_template": "uploads/{recording_name}.zip",
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def _write_metadata_yaml(directory: Path, *, start_ns: int | None = 1_700_000_000_000_000_000) -> None:
+    """Write a minimal metadata.yaml so `read_metadata_summary` returns a start time."""
+    if start_ns is None:
+        directory.joinpath("metadata.yaml").write_text("rosbag2_bagfile_information:\n", encoding="utf-8")
+        return
+    directory.joinpath("metadata.yaml").write_text(
+        "rosbag2_bagfile_information:\n"
+        f"  starting_time:\n    nanoseconds_since_epoch: {start_ns}\n"
+        "  duration:\n    nanoseconds: 1000000000\n"
+        "  message_count: 0\n",
+        encoding="utf-8",
+    )
+
+
+def _seed_recording(directory: Path) -> None:
+    """Put a couple of files in the folder so `build_zip` produces a non-empty archive."""
+    (directory / "rec_0.mcap").write_bytes(b"\x00" * 16)
+    (directory / "metadata.yaml")  # caller writes this separately
+
+
+class TestEnqueueUpload:
+    async def test_enqueue_creates_active_job(self, tmp_path: Path) -> None:
+        queue = JobQueue()
+        job = await queue.enqueue_upload(tmp_path)
+
+        assert isinstance(job, UploadJob)
+        assert job.type == JobType.UPLOAD
+        assert job.target_path == tmp_path
+        assert job.folder == tmp_path.name
+        assert job.status == JobStatus.QUEUED
+        assert job.job_id.startswith("upl_")
+
+        active = queue.get_active_upload_job(tmp_path)
+        assert active is not None
+        assert active.job_id == job.job_id
+
+    async def test_enqueue_is_idempotent(self, tmp_path: Path) -> None:
+        """Re-enqueueing the same folder returns the existing job."""
+        queue = JobQueue()
+        first = await queue.enqueue_upload(tmp_path)
+        second = await queue.enqueue_upload(tmp_path)
+
+        assert first.job_id == second.job_id
+
+    async def test_get_active_returns_none_when_no_job(self, tmp_path: Path) -> None:
+        queue = JobQueue()
+        assert queue.get_active_upload_job(tmp_path) is None
+
+
+class TestRunUpload:
+    """Direct invocation of JobQueue._run_upload()."""
+
+    async def test_writes_uploaded_state_on_success(self, tmp_path: Path) -> None:
+        """Happy path: zip + upload + final UploadState with etag persisted."""
+        _seed_recording(tmp_path)
+        _write_metadata_yaml(tmp_path)
+
+        destination = MagicMock()
+        destination.configuration_error.return_value = None
+        destination.upload.return_value = UploadResult(size_bytes=4096, etag='"abc-1"')
+
+        queue = JobQueue()
+        job = await queue.enqueue_upload(tmp_path)
+
+        with (
+            patch("app.settings.get_settings", return_value=_make_settings()),
+            patch(
+                "app.features.upload.destinations.get_active_destination",
+                return_value=destination,
+            ),
+        ):
+            await queue._run_upload(job)
+
+        destination.upload.assert_called_once()
+        args = destination.upload.call_args.args
+        assert args[0] == tmp_path / f"{tmp_path.name}.zip"
+        # Key was rendered from the template (uploads/{recording_name}.zip).
+        assert args[1] == f"uploads/{tmp_path.name}.zip"
+
+        state = load_state(tmp_path)
+        assert state is not None
+        assert state.status == "uploaded"
+        assert state.destination == "lutra-test"
+        assert state.key == f"uploads/{tmp_path.name}.zip"
+        assert state.etag == '"abc-1"'
+        assert state.size_bytes == 4096
+        assert state.bytes_transferred == 4096
+        assert state.uploaded_at is not None
+        assert state.uploaded_at <= datetime.now(timezone.utc)
+        assert state.error is None
+
+    async def test_writes_failed_state_on_exception(self, tmp_path: Path) -> None:
+        """On upload failure, status flips to `failed` with the exception message."""
+        _seed_recording(tmp_path)
+        _write_metadata_yaml(tmp_path)
+
+        destination = MagicMock()
+        destination.configuration_error.return_value = None
+        destination.upload.side_effect = RuntimeError("network unreachable")
+
+        queue = JobQueue()
+        job = await queue.enqueue_upload(tmp_path)
+
+        with (
+            patch("app.settings.get_settings", return_value=_make_settings()),
+            patch(
+                "app.features.upload.destinations.get_active_destination",
+                return_value=destination,
+            ),
+            pytest.raises(RuntimeError, match="network unreachable"),
+        ):
+            await queue._run_upload(job)
+
+        state = load_state(tmp_path)
+        assert state is not None
+        assert state.status == "failed"
+        assert state.error == "network unreachable"
+        assert state.uploaded_at is None
+
+    async def test_raises_when_destination_misconfigured(self, tmp_path: Path) -> None:
+        """If `destination.configuration_error()` returns a string, fail fast."""
+        _seed_recording(tmp_path)
+        _write_metadata_yaml(tmp_path)
+
+        destination = MagicMock()
+        destination.configuration_error.return_value = "S3_BUCKET is not configured"
+
+        queue = JobQueue()
+        job = await queue.enqueue_upload(tmp_path)
+
+        with (
+            patch("app.settings.get_settings", return_value=_make_settings(s3_bucket=None)),
+            patch(
+                "app.features.upload.destinations.get_active_destination",
+                return_value=destination,
+            ),
+            pytest.raises(RuntimeError, match="S3_BUCKET is not configured"),
+        ):
+            await queue._run_upload(job)
+
+        destination.upload.assert_not_called()
+        # No state file written when the precondition fails before zip creation.
+        assert load_state(tmp_path) is None
+
+    async def test_raises_when_metadata_missing_start_time(self, tmp_path: Path) -> None:
+        """`render_key` requires recording_start_ns; fail if metadata.yaml does not carry it."""
+        _seed_recording(tmp_path)
+        _write_metadata_yaml(tmp_path, start_ns=None)
+
+        destination = MagicMock()
+        destination.configuration_error.return_value = None
+
+        queue = JobQueue()
+        job = await queue.enqueue_upload(tmp_path)
+
+        with (
+            patch("app.settings.get_settings", return_value=_make_settings()),
+            patch(
+                "app.features.upload.destinations.get_active_destination",
+                return_value=destination,
+            ),
+            pytest.raises(FileNotFoundError, match=r"metadata\.yaml"),
+        ):
+            await queue._run_upload(job)
+
+        destination.upload.assert_not_called()
+        assert load_state(tmp_path) is None
+
+    async def test_progress_callback_persists_intermediate_state(self, tmp_path: Path) -> None:
+        """The throttled progress callback updates `bytes_transferred` in upload_state.json."""
+        _seed_recording(tmp_path)
+        _write_metadata_yaml(tmp_path)
+
+        destination = MagicMock()
+        destination.configuration_error.return_value = None
+
+        def fake_upload(local_path: Path, key: str, progress: object) -> UploadResult:
+            # Simulate boto3 invoking the callback with byte-deltas.
+            assert callable(progress)
+            progress(2048)
+            progress.close()  # type: ignore[attr-defined]
+            return UploadResult(size_bytes=2048, etag='"final"')
+
+        destination.upload.side_effect = fake_upload
+
+        queue = JobQueue()
+        job = await queue.enqueue_upload(tmp_path)
+
+        with (
+            patch("app.settings.get_settings", return_value=_make_settings()),
+            patch(
+                "app.features.upload.destinations.get_active_destination",
+                return_value=destination,
+            ),
+        ):
+            await queue._run_upload(job)
+
+        state = load_state(tmp_path)
+        assert state is not None
+        assert state.status == "uploaded"
+        assert state.bytes_transferred == 2048


### PR DESCRIPTION
## Summary

Step 3 (queue side) of generalizing the upload feature (issue #6). Adds the runtime path that zips a recording folder and ships it through the configured `UploadDestination`. The next PR layers `UploadService` on top of this.

**`app/features/jobs/models.py`**
- New `JobType.UPLOAD` enum value and `UploadJob` dataclass (mirrors `ValidationJob`).

**`app/features/jobs/service.py`**
- `enqueue_upload(folder)` — idempotent per folder; returns the existing job if one is already active. Job ID prefix: `upl_`.
- `get_active_upload_job(folder)` — for the upcoming `UploadService` to gate the start path on.
- Dispatch branch in `_execute()` routing `UploadJob` to `_run_upload`.
- `_run_upload(job)` — orchestrates:
  1. Resolves the active `UploadDestination` via the registry; gates on `configuration_error()` (S3_BUCKET / S3_KEY_TEMPLATE must be set).
  2. Reads `recording_start_ns` from `metadata.yaml`; fails clearly when it cannot be determined (the key template requires it).
  3. Renders the destination key via `render_key()`.
  4. Builds the zip on a worker thread; persists initial `upload_state.json` with `status=uploading`.
  5. Runs `destination.upload()` on a worker thread, threading a `ThrottledProgress` callback that updates `upload_state.json` and broadcasts job progress at most once per second.
  6. On success: persists final state with `status=uploaded`, `etag`, `uploaded_at`.
  7. On failure: persists `status=failed` + `error` before re-raising so the JobQueue marks the job FAILED.

Per issue #6 this path always overwrites (no skip-if-cached); duplicate dispatch is prevented one level up by `enqueue_upload`.

## Test plan

`backend/tests/features/jobs/test_upload_job.py` mirrors `test_validation_job.py`. 8 cases covering:

- enqueue happy path + idempotency
- `get_active_upload_job` happy + missing
- `_run_upload` writes `status=uploaded` with etag on success
- `_run_upload` writes `status=failed` + error on exception and re-raises
- destination misconfigured → fail fast without writing state
- metadata.yaml missing `starting_time` → fail with a clear error
- progress callback persists intermediate `bytes_transferred`

- [x] `uv run ruff check app/ tests/` — clean
- [x] `uv run mypy app/` — clean (86 files)
- [x] `uv run pytest tests/features/jobs/ tests/features/upload/` — 58 passed
- [x] `app/features/upload/*` coverage — 100% (unchanged); `app/features/jobs/models.py` — 100% (UploadJob added is just a dataclass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)