### PR TITLE
feat(upload): add UploadService facade + /api/upload endpoints

### DIFF
--- a/backend/app/features/upload/router.py
+++ b/backend/app/features/upload/router.py
@@ -1,0 +1,38 @@
+"""Upload API endpoints."""
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Depends
+
+from app.dependencies import require_dir
+from app.features.upload.schemas import UploadResponse
+from app.features.upload.service import get_upload_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/upload", tags=["upload"])
+
+
+@router.get("", response_model=UploadResponse, operation_id="getUpload")
+async def get_upload(  # pragma: no cover
+    target: Path = Depends(require_dir),
+) -> UploadResponse:
+    """Return the current upload state (no side effects).
+
+    Trigger an upload via ``POST /api/upload/start``.
+    """
+    return await get_upload_service().get(target)
+
+
+@router.post("/start", response_model=UploadResponse, operation_id="startUpload")
+async def start_upload(  # pragma: no cover
+    target: Path = Depends(require_dir),
+) -> UploadResponse:
+    """Trigger an upload.
+
+    Idempotent: returns the existing job's status when one is already
+    running. When no job is active this always overwrites the previously
+    uploaded object (no skip-if-cached, per issue #6).
+    """
+    return await get_upload_service().start(target)

--- a/backend/app/features/upload/schemas.py
+++ b/backend/app/features/upload/schemas.py
@@ -1,0 +1,28 @@
+"""API schemas for upload endpoints.
+
+Domain models live in ``models.py``. This module only wraps them for HTTP responses.
+"""
+
+from pydantic import BaseModel, Field
+
+from app.features.upload.models import UploadState
+
+
+class UploadResponse(BaseModel):
+    """Response for ``GET /api/upload`` and ``POST /api/upload/start``.
+
+    ``status`` reflects the current upload phase as observed by the service:
+
+    * ``uploaded`` — persisted ``upload_state.json`` carries that status.
+    * ``uploading`` — persisted state with that status, or an active job in
+      the queue.
+    * ``failed`` — persisted state with that status, the last job ended in
+      failure, or the start path rejected the request (e.g. destination
+      misconfigured).
+    * ``idle`` — persisted state explicitly marked as idle.
+    * ``not_found`` — no persisted state and no active job.
+    """
+
+    status: str = Field(..., pattern=r"^(idle|uploading|uploaded|failed|not_found)$")
+    state: UploadState | None
+    error: str | None

--- a/backend/app/features/upload/service.py
+++ b/backend/app/features/upload/service.py
@@ -1,0 +1,103 @@
+"""API facade for the upload feature.
+
+Delegates actual execution to the JobQueue in ``app/features/jobs/``.
+This module only assembles HTTP responses, mirroring ``ValidationService``.
+
+Benefits of using the job queue:
+
+* Active uploads are visible in the StatusBar.
+* Duplicate uploads on the same folder are prevented by the queue's
+  per-folder dedup.
+* A single worker serializes upload I/O.
+"""
+
+import logging
+from pathlib import Path
+
+from app.features.jobs.models import JobStatus
+from app.features.jobs.service import get_job_queue
+from app.features.upload.cache import load_state
+from app.features.upload.destinations import get_active_destination
+from app.features.upload.key_template import validate_template
+from app.features.upload.schemas import UploadResponse
+from app.settings import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+class UploadService:
+    """Upload API facade. Execution is delegated to the job queue."""
+
+    async def get(self, target: Path) -> UploadResponse:
+        """Return the current upload state (no side effects).
+
+        Resolution order:
+
+        1. Persisted ``upload_state.json`` if present — its status (uploaded /
+           uploading / failed / idle) is reported directly.
+        2. Active job in the queue: ``uploading`` while queued/running,
+           ``failed`` when the last job ended in failure.
+        3. ``not_found`` otherwise.
+        """
+        state = load_state(target)
+        if state is not None:
+            return UploadResponse(status=state.status, state=state, error=state.error)
+
+        queue = get_job_queue()
+        active = queue.get_active_upload_job(target)
+        if active is not None and active.status in (JobStatus.QUEUED, JobStatus.RUNNING):
+            return UploadResponse(status="uploading", state=None, error=None)
+        if active is not None and active.status == JobStatus.FAILED:
+            return UploadResponse(
+                status="failed",
+                state=None,
+                error=active.error or "Upload failed",
+            )
+
+        return UploadResponse(status="not_found", state=None, error=None)
+
+    async def start(self, target: Path) -> UploadResponse:
+        """Trigger an upload.
+
+        Always overwrites the previously uploaded object (per issue #6 — no
+        skip-if-cached). If a job is already active for ``target``, returns
+        the existing job's status without enqueueing a second one.
+
+        Early rejections (returns ``status="failed"`` without touching the
+        queue):
+
+        * Destination is not configured (S3_BUCKET / S3_KEY_TEMPLATE unset).
+        * Key template syntax is invalid (unknown placeholder, unbalanced
+          braces).
+        """
+        settings = get_settings()
+        destination = get_active_destination(settings)
+        err = destination.configuration_error()
+        if err is not None:
+            return UploadResponse(status="failed", state=None, error=err)
+        # configuration_error() guarantees the template is set; assert for the type checker.
+        assert settings.s3_key_template is not None
+        try:
+            validate_template(settings.s3_key_template)
+        except ValueError as e:
+            return UploadResponse(status="failed", state=None, error=str(e))
+
+        queue = get_job_queue()
+        active = queue.get_active_upload_job(target)
+        if active is not None and active.status in (JobStatus.QUEUED, JobStatus.RUNNING):
+            return UploadResponse(status="uploading", state=load_state(target), error=None)
+
+        await queue.enqueue_upload(target)
+        return UploadResponse(status="uploading", state=load_state(target), error=None)
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+_upload_service_singleton = UploadService()
+
+
+def get_upload_service() -> UploadService:
+    """Return the global UploadService instance."""
+    return _upload_service_singleton

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from app.features.recording import ROS2BagRecorder
 from app.features.recording.router import router as recording_router
 from app.features.recordings.router import router as recordings_router
 from app.features.topics.router import router as topics_router
+from app.features.upload.router import router as upload_router
 from app.features.validation import load_custom_validators
 from app.features.validation.router import router as validation_router
 from app.infra.ros2 import ROS2Command
@@ -94,6 +95,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(media_router)
     app.include_router(jobs_router)
     app.include_router(validation_router)
+    app.include_router(upload_router)
 
     # Serve the built frontend (production mode)
     if FRONTEND_DIR.is_dir():

--- a/backend/tests/features/upload/test_service.py
+++ b/backend/tests/features/upload/test_service.py
@@ -1,0 +1,247 @@
+"""Tests for UploadService (the API facade)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.features.jobs.models import JobStatus, JobType, UploadJob
+from app.features.jobs.service import set_job_queue
+from app.features.upload.cache import CACHE_FILENAME
+from app.features.upload.service import UploadService, get_upload_service
+from app.settings import Settings
+
+
+def _make_settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "robot_config": "config/simulator.yaml",
+        "output_dir": "/tmp",
+        "s3_bucket": "lutra-test",
+        "s3_key_template": "uploads/{recording_name}.zip",
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def _write_state(
+    directory: Path,
+    *,
+    status: str,
+    destination: str | None = "lutra-test",
+    key: str | None = "uploads/rec.zip",
+    etag: str | None = '"abc"',
+    size_bytes: int | None = 1024,
+    bytes_transferred: int = 1024,
+    uploaded_at: datetime | None = datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc),
+    error: str | None = None,
+) -> None:
+    payload = {
+        "status": status,
+        "destination": destination,
+        "key": key,
+        "etag": etag,
+        "size_bytes": size_bytes,
+        "bytes_transferred": bytes_transferred,
+        "uploaded_at": uploaded_at.isoformat() if uploaded_at else None,
+        "error": error,
+    }
+    (directory / CACHE_FILENAME).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _make_job(target: Path, status: JobStatus, error: str | None = None) -> UploadJob:
+    return UploadJob(
+        job_id="upl_test",
+        type=JobType.UPLOAD,
+        folder=target.name,
+        status=status,
+        error=error,
+        target_path=target,
+    )
+
+
+@pytest.fixture
+def mock_queue() -> Iterator[MagicMock]:
+    """A mock JobQueue registered as the global singleton for the test."""
+    queue = MagicMock()
+    queue.enqueue_upload = AsyncMock()
+    set_job_queue(queue)
+    yield queue
+    set_job_queue(None)  # type: ignore[arg-type]
+
+
+class TestUploadServiceGet:
+    """``UploadService.get()`` — read-only state lookup."""
+
+    async def test_returns_uploaded_when_state_uploaded(
+        self,
+        tmp_path: Path,
+        mock_queue: MagicMock,
+    ) -> None:
+        _write_state(tmp_path, status="uploaded")
+        mock_queue.get_active_upload_job.return_value = None
+
+        response = await UploadService().get(tmp_path)
+        assert response.status == "uploaded"
+        assert response.state is not None
+        assert response.state.etag == '"abc"'
+        assert response.error is None
+
+    async def test_returns_failed_from_persisted_state(
+        self,
+        tmp_path: Path,
+        mock_queue: MagicMock,
+    ) -> None:
+        _write_state(tmp_path, status="failed", error="network down", etag=None, uploaded_at=None)
+        mock_queue.get_active_upload_job.return_value = None
+
+        response = await UploadService().get(tmp_path)
+        assert response.status == "failed"
+        assert response.error == "network down"
+
+    async def test_returns_uploading_when_job_running(
+        self,
+        tmp_path: Path,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_queue.get_active_upload_job.return_value = _make_job(tmp_path, JobStatus.RUNNING)
+
+        response = await UploadService().get(tmp_path)
+        assert response.status == "uploading"
+        assert response.state is None
+
+    async def test_returns_uploading_when_job_queued(
+        self,
+        tmp_path: Path,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_queue.get_active_upload_job.return_value = _make_job(tmp_path, JobStatus.QUEUED)
+
+        response = await UploadService().get(tmp_path)
+        assert response.status == "uploading"
+
+    async def test_returns_failed_when_job_failed(
+        self,
+        tmp_path: Path,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_queue.get_active_upload_job.return_value = _make_job(
+            tmp_path,
+            JobStatus.FAILED,
+            error="boom",
+        )
+
+        response = await UploadService().get(tmp_path)
+        assert response.status == "failed"
+        assert response.error == "boom"
+
+    async def test_returns_failed_with_default_message_when_no_detail(
+        self,
+        tmp_path: Path,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_queue.get_active_upload_job.return_value = _make_job(
+            tmp_path,
+            JobStatus.FAILED,
+            error=None,
+        )
+
+        response = await UploadService().get(tmp_path)
+        assert response.status == "failed"
+        assert response.error == "Upload failed"
+
+    async def test_returns_not_found_when_nothing(
+        self,
+        tmp_path: Path,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_queue.get_active_upload_job.return_value = None
+
+        response = await UploadService().get(tmp_path)
+        assert response.status == "not_found"
+        assert response.state is None
+
+
+class TestUploadServiceStart:
+    """``UploadService.start()`` — trigger upload."""
+
+    async def test_enqueues_when_configured_and_no_active_job(
+        self,
+        tmp_path: Path,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_queue.get_active_upload_job.return_value = None
+
+        with patch("app.features.upload.service.get_settings", return_value=_make_settings()):
+            response = await UploadService().start(tmp_path)
+
+        assert response.status == "uploading"
+        mock_queue.enqueue_upload.assert_awaited_once_with(tmp_path)
+
+    async def test_overwrites_existing_uploaded_state(
+        self,
+        tmp_path: Path,
+        mock_queue: MagicMock,
+    ) -> None:
+        """Per issue #6, ``start()`` always enqueues; an existing ``uploaded`` state is no shortcut."""
+        _write_state(tmp_path, status="uploaded")
+        mock_queue.get_active_upload_job.return_value = None
+
+        with patch("app.features.upload.service.get_settings", return_value=_make_settings()):
+            response = await UploadService().start(tmp_path)
+
+        assert response.status == "uploading"
+        mock_queue.enqueue_upload.assert_awaited_once_with(tmp_path)
+
+    async def test_returns_uploading_when_job_running(
+        self,
+        tmp_path: Path,
+        mock_queue: MagicMock,
+    ) -> None:
+        mock_queue.get_active_upload_job.return_value = _make_job(tmp_path, JobStatus.RUNNING)
+
+        with patch("app.features.upload.service.get_settings", return_value=_make_settings()):
+            response = await UploadService().start(tmp_path)
+
+        assert response.status == "uploading"
+        mock_queue.enqueue_upload.assert_not_called()
+
+    async def test_returns_failed_when_destination_unconfigured(
+        self,
+        tmp_path: Path,
+        mock_queue: MagicMock,
+    ) -> None:
+        with patch(
+            "app.features.upload.service.get_settings",
+            return_value=_make_settings(s3_bucket=None),
+        ):
+            response = await UploadService().start(tmp_path)
+
+        assert response.status == "failed"
+        assert response.error == "S3_BUCKET is not configured"
+        mock_queue.enqueue_upload.assert_not_called()
+
+    async def test_returns_failed_when_template_invalid(
+        self,
+        tmp_path: Path,
+        mock_queue: MagicMock,
+    ) -> None:
+        with patch(
+            "app.features.upload.service.get_settings",
+            return_value=_make_settings(s3_key_template="bad/{unknown_placeholder}"),
+        ):
+            response = await UploadService().start(tmp_path)
+
+        assert response.status == "failed"
+        assert response.error is not None
+        assert "unknown_placeholder" in response.error
+        mock_queue.enqueue_upload.assert_not_called()
+
+
+class TestGetUploadService:
+    def test_returns_singleton(self) -> None:
+        assert get_upload_service() is get_upload_service()


### PR DESCRIPTION
## Summary

Step 3 (service side) of generalizing the upload feature (issue #6). Sits on top of the JobQueue runtime path that landed in #22.

- **`schemas.py`** — `UploadResponse` with status literal of the five states (`idle` / `uploading` / `uploaded` / `failed` / `not_found`), nullable embedded `UploadState`, and nullable `error`.
- **`service.py`** — `UploadService.get()` / `start()` + module-level `get_upload_service()` singleton, mirroring `ValidationService`.
  - `get()` resolves the current phase from (1) the persisted `upload_state.json`, (2) the active job in the queue, falling back to `not_found`.
  - `start()` **always overwrites** (per issue #6 — no skip-if-cached), but rejects early without touching the queue when the destination is misconfigured or the key template fails to parse. An already-running job for the same folder is reported back without enqueueing a duplicate.
- **`router.py`** — `GET /api/upload` and `POST /api/upload/start` (`operation_id` set so orval generates `useGetUpload` and `useStartUpload`). Endpoint bodies are HTTP glue and carry `# pragma: no cover` per project convention.
- **`main.py`** — register `upload_router` alongside the other features.

## Test plan

Tests (`tests/features/upload/test_service.py`) mirror `test_service.py` for validation:

- 7 cases on `get()` covering all states (uploaded / failed-persisted / uploading-running / uploading-queued / failed-job / failed-default / not_found).
- 5 cases on `start()` covering enqueue, overwrite-existing-uploaded, in-flight-deduplication, misconfigured-destination, invalid-template.
- 1 case on the singleton.

- [x] `uv run ruff check app/ tests/` — clean
- [x] `uv run mypy app/` — clean (89 files)
- [x] `uv run pytest tests/features/upload/` — 54 passed
- [x] `app/features/upload/service.py` / `schemas.py` coverage — 100%
- `router.py` is 0% locally because the `app.main`-driven tests gate on `pytest.importorskip("rclpy")` and only run inside the dev container; matches `validation/router.py`'s profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)