### PR TITLE
feat(recordings): surface upload_status on each FileEntry

### DIFF
--- a/backend/app/features/recordings/scanner.py
+++ b/backend/app/features/recordings/scanner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from app.features.recordings.meta import read_recording_meta
 from app.features.recordings.schemas import FileEntry
+from app.features.upload.cache import load_state as load_upload_state
 from app.features.validation.cache import load_report as load_validation_report
 
 logger = logging.getLogger(__name__)
@@ -85,6 +86,7 @@ def _build_recording_entry(folder: Path, rel_root: Path) -> FileEntry | None:
     topic_count, start_ns, dur_ns, msg_count = read_metadata_summary(folder)
     meta = read_recording_meta(folder)
     validation_report = load_validation_report(folder)
+    upload_state = load_upload_state(folder)
     return FileEntry(
         name=folder.name,
         path=str(folder.relative_to(rel_root)),
@@ -96,6 +98,7 @@ def _build_recording_entry(folder: Path, rel_root: Path) -> FileEntry | None:
         message_count=msg_count,
         has_quality_report=has_quality_report,
         validation_overall_status=(validation_report.overall_status if validation_report else None),
+        upload_status=upload_state.status if upload_state else None,
         task_name=meta.task_name if meta else None,
         robot_config_name=meta.robot_config_name if meta else None,
         tags=meta.tags if meta else [],

--- a/backend/app/features/recordings/schemas.py
+++ b/backend/app/features/recordings/schemas.py
@@ -52,6 +52,13 @@ class FileEntry(BaseModel):
             "(pass / warn / fail / error). null when no validation report exists."
         ),
     )
+    upload_status: str | None = Field(
+        ...,
+        description=(
+            "Latest upload status from upload_state.json "
+            "(idle / uploading / uploaded / failed). null when no upload state exists."
+        ),
+    )
     task_name: str | None
     robot_config_name: str | None
     tags: list[str]

--- a/backend/tests/features/recordings/test_scanner.py
+++ b/backend/tests/features/recordings/test_scanner.py
@@ -184,6 +184,7 @@ class TestScanOutputDir:
 
         assert entries[0].has_quality_report is False
         assert entries[0].validation_overall_status is None
+        assert entries[0].upload_status is None
 
     def test_validation_overall_status_loaded(self, tmp_path: Path) -> None:
         """When validation_result.json exists, its overall_status is reflected in FileEntry."""
@@ -201,6 +202,27 @@ class TestScanOutputDir:
         entries = scan_output_dir(tmp_path)
 
         assert entries[0].validation_overall_status == "warn"
+
+    def test_upload_status_loaded(self, tmp_path: Path) -> None:
+        """When upload_state.json exists, its status is reflected in FileEntry."""
+        state = {
+            "status": "uploaded",
+            "destination": "lutra-test",
+            "key": "uploads/rec.zip",
+            "etag": '"abc"',
+            "size_bytes": 1024,
+            "bytes_transferred": 1024,
+            "uploaded_at": "2026-05-25T12:00:00+00:00",
+            "error": None,
+        }
+        _make_recording(
+            tmp_path / "rec",
+            files={"upload_state.json": json.dumps(state).encode("utf-8")},
+        )
+
+        entries = scan_output_dir(tmp_path)
+
+        assert entries[0].upload_status == "uploaded"
 
     def test_metadata_summary_included(self, tmp_path: Path) -> None:
         """When metadata.yaml is present, topic_count/recording_start_ns/duration_ns/message_count are filled in."""


### PR DESCRIPTION
## Summary

Adds `upload_status` to `FileEntry` so the recordings table can render the per-row upload badge without a second API roundtrip. The value comes from each folder's `upload_state.json` (one of `idle` / `uploading` / `uploaded` / `failed`), or `null` when no upload has ever been attempted.

- `recordings/schemas.py` — new required `upload_status: str | None` (no default, matching the project's pydantic-response convention).
- `recordings/scanner.py` — reads `upload_state.json` via `app.features.upload.cache.load_state` and threads the status through.
- `tests/features/recordings/test_scanner.py` — adds an "uploaded" fixture case and extends the flags-absent case to assert null.

In-flight progress percentage is intentionally **not** part of FileEntry — it arrives via the SSE job stream so the badge can update live without re-listing.

## Test plan

- [x] `uv run ruff check app/ tests/` — clean
- [x] `uv run mypy app/` — clean
- [x] `uv run pytest tests/features/recordings/ tests/features/upload/` — 101 passed
- [x] `app/features/recordings/scanner.py` + `schemas.py` coverage — unchanged (existing missing lines were already there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)