### PR TITLE
feat(config): expose upload_enabled on /api/config

### DIFF
--- a/backend/app/features/config/router.py
+++ b/backend/app/features/config/router.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 
 from app.features.config.memory_reader import read_limit_bytes, read_usage_bytes
 from app.features.config.schemas import ConfigResponse, HealthResponse, MemoryInfo
+from app.features.upload.service import is_upload_enabled
 from app.settings import get_settings
 
 router = APIRouter(prefix="/api", tags=["config"])
@@ -24,6 +25,7 @@ async def get_config() -> ConfigResponse:
         robot_name=settings.robot_name,
         default_topics=settings.default_topics,
         stamp_quality=settings.stamp_quality,
+        upload_enabled=is_upload_enabled(settings),
     )
 
 

--- a/backend/app/features/config/schemas.py
+++ b/backend/app/features/config/schemas.py
@@ -23,3 +23,4 @@ class ConfigResponse(BaseModel):
     robot_name: str
     default_topics: list[str]
     stamp_quality: bool
+    upload_enabled: bool

--- a/backend/app/features/upload/service.py
+++ b/backend/app/features/upload/service.py
@@ -20,9 +20,38 @@ from app.features.upload.cache import load_state
 from app.features.upload.destinations import get_active_destination
 from app.features.upload.key_template import validate_template
 from app.features.upload.schemas import UploadResponse
-from app.settings import get_settings
+from app.settings import Settings, get_settings
 
 logger = logging.getLogger(__name__)
+
+
+def _upload_availability_error(settings: Settings) -> str | None:
+    """Return why the upload feature is not usable, or ``None`` when fully configured.
+
+    Powers both ``UploadService.start()``'s early-rejection path and the
+    ``/api/config`` ``upload_enabled`` flag.
+    """
+    destination = get_active_destination(settings)
+    err = destination.configuration_error()
+    if err is not None:
+        return err
+    # configuration_error() guarantees the template is set; assert for the type checker.
+    assert settings.s3_key_template is not None
+    try:
+        validate_template(settings.s3_key_template)
+    except ValueError as e:
+        return str(e)
+    return None
+
+
+def is_upload_enabled(settings: Settings) -> bool:
+    """Whether the upload feature is fully usable.
+
+    Drives the UI's "hide upload affordances when not configured" toggle
+    via ``/api/config``. True only when the destination is configured
+    and the key template parses without error.
+    """
+    return _upload_availability_error(settings) is None
 
 
 class UploadService:
@@ -70,17 +99,9 @@ class UploadService:
         * Key template syntax is invalid (unknown placeholder, unbalanced
           braces).
         """
-        settings = get_settings()
-        destination = get_active_destination(settings)
-        err = destination.configuration_error()
+        err = _upload_availability_error(get_settings())
         if err is not None:
             return UploadResponse(status="failed", state=None, error=err)
-        # configuration_error() guarantees the template is set; assert for the type checker.
-        assert settings.s3_key_template is not None
-        try:
-            validate_template(settings.s3_key_template)
-        except ValueError as e:
-            return UploadResponse(status="failed", state=None, error=str(e))
 
         queue = get_job_queue()
         active = queue.get_active_upload_job(target)

--- a/backend/tests/features/config/test_router.py
+++ b/backend/tests/features/config/test_router.py
@@ -38,6 +38,7 @@ class TestConfig:
         assert "robot_name" in data
         assert "default_topics" in data
         assert isinstance(data["default_topics"], list)
+        assert isinstance(data["upload_enabled"], bool)
 
 
 class TestHealth:

--- a/backend/tests/features/upload/test_service.py
+++ b/backend/tests/features/upload/test_service.py
@@ -13,7 +13,7 @@ import pytest
 from app.features.jobs.models import JobStatus, JobType, UploadJob
 from app.features.jobs.service import set_job_queue
 from app.features.upload.cache import CACHE_FILENAME
-from app.features.upload.service import UploadService, get_upload_service
+from app.features.upload.service import UploadService, get_upload_service, is_upload_enabled
 from app.settings import Settings
 
 
@@ -245,3 +245,19 @@ class TestUploadServiceStart:
 class TestGetUploadService:
     def test_returns_singleton(self) -> None:
         assert get_upload_service() is get_upload_service()
+
+
+class TestIsUploadEnabled:
+    """``is_upload_enabled()`` — read-only check used by ``/api/config``."""
+
+    def test_true_when_destination_and_template_valid(self) -> None:
+        assert is_upload_enabled(_make_settings()) is True
+
+    def test_false_when_bucket_missing(self) -> None:
+        assert is_upload_enabled(_make_settings(s3_bucket=None)) is False
+
+    def test_false_when_template_missing(self) -> None:
+        assert is_upload_enabled(_make_settings(s3_key_template=None)) is False
+
+    def test_false_when_template_syntax_invalid(self) -> None:
+        assert is_upload_enabled(_make_settings(s3_key_template="x/{unknown}")) is False


### PR DESCRIPTION
## Summary

Adds `upload_enabled: bool` to `ConfigResponse` so the frontend can hide the Upload to S3 button/badge when the deployment is not set up to upload. Hardware running open-lutra without an S3 destination configured should not see upload affordances at all (per the design discussion that preceded #20).

The flag is `true` only when both checks pass:

- The active `UploadDestination`'s `configuration_error()` is `None` (`S3_BUCKET` / `S3_KEY_TEMPLATE` both set today).
- The key template parses (no unknown placeholders, no unbalanced braces).

## Implementation

- Factors the dual check out of `UploadService.start()` into a module-level `_upload_availability_error(settings)` helper, exposed as public `is_upload_enabled(settings)` for the config router. `start()` now uses the same helper so the two paths agree on what "usable" means.
- `ConfigResponse.upload_enabled: bool` (no default — matches the project's pydantic-response convention).
- `config/router.py` calls `is_upload_enabled(settings)` and threads it into the response.

## Test plan

- `TestIsUploadEnabled` — 4 cases (happy + 3 misconfigured variants).
- `test_get_config` asserts the new field is a `bool` in the JSON response.

- [x] `uv run ruff check app/ tests/` — clean
- [x] `uv run mypy app/` — clean
- [x] `uv run pytest tests/features/upload/ tests/features/config/` — 58 passed
- [x] `app/features/upload/service.py` coverage — 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)