### PR TITLE
feat(upload): add UploadButton and UploadBadge UI

### DIFF
--- a/frontend/src/features/recordings/ui/recording-list-item.tsx
+++ b/frontend/src/features/recordings/ui/recording-list-item.tsx
@@ -10,6 +10,7 @@ import type { FileEntry } from "@/api/generated/schemas";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { UploadBadge } from "@/features/upload";
 import { ValidationBadge } from "@/features/validation";
 import { useDeleteRecordings, useRenameRecording } from "@/hooks/use-api";
 import { useAddLog } from "@/hooks/use-topics-stream";
@@ -115,6 +116,7 @@ export function RecordingListItem({
       </div>
 
       <ValidationBadge status={entry.validation_overall_status} />
+      <UploadBadge entry={entry} />
 
       {/* Two-line text */}
       <div className="min-w-0 flex-1">

--- a/frontend/src/features/upload/__tests__/upload-badge.test.tsx
+++ b/frontend/src/features/upload/__tests__/upload-badge.test.tsx
@@ -1,0 +1,133 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConfigResponse, FileEntry, JobSchema } from "@/api/generated/schemas";
+import { UploadBadge } from "../upload-badge";
+
+const { useConfigMock, useJobsMock } = vi.hoisted(() => ({
+  useConfigMock: vi.fn<() => { data: ConfigResponse | undefined }>(() => ({ data: undefined })),
+  useJobsMock: vi.fn<() => JobSchema[]>(() => []),
+}));
+
+vi.mock("@/hooks/use-api", () => ({ useConfig: () => useConfigMock() }));
+vi.mock("@/hooks/use-jobs-stream", () => ({ useJobs: () => useJobsMock() }));
+
+function makeConfig(overrides: Partial<ConfigResponse> = {}): ConfigResponse {
+  return {
+    ros_domain_id: 0,
+    robot_name: "Robot",
+    default_topics: [],
+    stamp_quality: false,
+    upload_enabled: true,
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    name: "rec_001",
+    path: "rec_001",
+    size: 0,
+    modified_at: 0,
+    topic_count: null,
+    recording_start_ns: null,
+    duration_ns: null,
+    message_count: null,
+    has_quality_report: false,
+    validation_overall_status: null,
+    upload_status: null,
+    task_name: null,
+    robot_config_name: null,
+    tags: [],
+    ...overrides,
+  };
+}
+
+type JobOverrides = Omit<Partial<JobSchema>, "progress"> & { progress?: Partial<JobSchema["progress"]> };
+
+function makeJob(overrides: JobOverrides = {}): JobSchema {
+  const { progress = {}, ...rest } = overrides;
+  return {
+    job_id: "upl_test",
+    type: "upload",
+    folder: "rec_001",
+    status: "running",
+    progress: { step: "upload", step_label: "Uploading", current: 0, total: 1, ...progress },
+    error: null,
+    created_at: "2026-05-25T12:00:00+00:00",
+    started_at: "2026-05-25T12:00:00+00:00",
+    finished_at: null,
+    ...rest,
+  };
+}
+
+beforeEach(() => {
+  useConfigMock.mockReturnValue({ data: makeConfig() });
+  useJobsMock.mockReturnValue([]);
+});
+
+afterEach(() => {
+  useConfigMock.mockReset();
+  useJobsMock.mockReset();
+});
+
+describe("UploadBadge", () => {
+  it("renders nothing when upload_enabled is false", () => {
+    useConfigMock.mockReturnValue({ data: makeConfig({ upload_enabled: false }) });
+    const { container } = render(<UploadBadge entry={makeEntry({ upload_status: "uploaded" })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders an empty slot when no upload has happened", () => {
+    const { container } = render(<UploadBadge entry={makeEntry({ upload_status: null })} />);
+    const slot = container.firstChild as HTMLElement | null;
+    expect(slot).not.toBeNull();
+    expect(slot?.getAttribute("data-status")).toBeNull();
+    expect(slot?.querySelector("svg")).toBeNull();
+  });
+
+  it("shows the uploaded icon when entry.upload_status is uploaded", () => {
+    const { container } = render(<UploadBadge entry={makeEntry({ upload_status: "uploaded" })} />);
+    const slot = container.querySelector('[data-status="uploaded"]');
+    expect(slot).not.toBeNull();
+    expect(slot?.querySelector("svg")).not.toBeNull();
+  });
+
+  it("shows the failed icon when entry.upload_status is failed", () => {
+    const { container } = render(<UploadBadge entry={makeEntry({ upload_status: "failed" })} />);
+    const slot = container.querySelector('[data-status="failed"]');
+    expect(slot).not.toBeNull();
+  });
+
+  it("shows live progress when an active upload job matches this folder", () => {
+    useJobsMock.mockReturnValue([
+      makeJob({ folder: "rec_001", status: "running", progress: { current: 50, total: 100 } }),
+    ]);
+    const { container, getByText } = render(<UploadBadge entry={makeEntry({ upload_status: "uploaded" })} />);
+    // Live job wins over the persisted status.
+    expect(container.querySelector('[data-status="uploading"]')).not.toBeNull();
+    expect(getByText("50%")).toBeInTheDocument();
+  });
+
+  it("clamps progress to 100% when current exceeds total", () => {
+    useJobsMock.mockReturnValue([
+      makeJob({ folder: "rec_001", status: "running", progress: { current: 200, total: 100 } }),
+    ]);
+    const { getByText } = render(<UploadBadge entry={makeEntry()} />);
+    expect(getByText("100%")).toBeInTheDocument();
+  });
+
+  it("falls back to 0% when total is zero", () => {
+    useJobsMock.mockReturnValue([
+      makeJob({ folder: "rec_001", status: "running", progress: { current: 0, total: 0 } }),
+    ]);
+    const { getByText } = render(<UploadBadge entry={makeEntry()} />);
+    expect(getByText("0%")).toBeInTheDocument();
+  });
+
+  it("ignores jobs for other folders", () => {
+    useJobsMock.mockReturnValue([makeJob({ folder: "other_folder", status: "running" })]);
+    const { container } = render(<UploadBadge entry={makeEntry({ upload_status: "uploaded", name: "rec_001" })} />);
+    expect(container.querySelector('[data-status="uploaded"]')).not.toBeNull();
+    expect(container.querySelector('[data-status="uploading"]')).toBeNull();
+  });
+});

--- a/frontend/src/features/upload/__tests__/upload-button.test.tsx
+++ b/frontend/src/features/upload/__tests__/upload-button.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConfigResponse } from "@/api/generated/schemas";
+import type { UploadStatusView } from "@/hooks/use-upload-status";
+import { UploadButton } from "../upload-button";
+
+const { useConfigMock, useUploadStatusMock, startUploadMock, useStartUploadMock } = vi.hoisted(() => ({
+  useConfigMock: vi.fn<() => { data: ConfigResponse | undefined }>(() => ({ data: undefined })),
+  useUploadStatusMock: vi.fn<(folder: string | null) => UploadStatusView>(() => ({
+    status: "not_found",
+    percent: null,
+    error: null,
+  })),
+  startUploadMock: vi.fn(),
+  useStartUploadMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-api", () => ({
+  useConfig: () => useConfigMock(),
+  useStartUpload: () => useStartUploadMock(),
+}));
+vi.mock("@/hooks/use-upload-status", () => ({
+  useUploadStatus: (folder: string | null) => useUploadStatusMock(folder),
+}));
+
+function makeConfig(overrides: Partial<ConfigResponse> = {}): ConfigResponse {
+  return {
+    ros_domain_id: 0,
+    robot_name: "Robot",
+    default_topics: [],
+    stamp_quality: false,
+    upload_enabled: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useConfigMock.mockReturnValue({ data: makeConfig() });
+  useUploadStatusMock.mockReturnValue({ status: "not_found", percent: null, error: null });
+  useStartUploadMock.mockReturnValue({ mutate: startUploadMock, isPending: false });
+});
+
+afterEach(() => {
+  useConfigMock.mockReset();
+  useUploadStatusMock.mockReset();
+  useStartUploadMock.mockReset();
+  startUploadMock.mockReset();
+});
+
+describe("UploadButton", () => {
+  it("renders nothing when upload_enabled is false", () => {
+    useConfigMock.mockReturnValue({ data: makeConfig({ upload_enabled: false }) });
+    const { container } = render(<UploadButton folderPath="rec_001" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows the idle label when there is no prior upload", () => {
+    const { getByRole } = render(<UploadButton folderPath="rec_001" />);
+    expect(getByRole("button", { name: /^Upload$/ })).toBeEnabled();
+  });
+
+  it("shows the percent label while uploading and disables the click", () => {
+    useUploadStatusMock.mockReturnValue({ status: "uploading", percent: 42, error: null });
+    const { getByRole } = render(<UploadButton folderPath="rec_001" />);
+    const button = getByRole("button", { name: /Uploading 42%/ });
+    expect(button).toBeDisabled();
+  });
+
+  it("falls back to an indeterminate label while uploading without percent", () => {
+    useUploadStatusMock.mockReturnValue({ status: "uploading", percent: null, error: null });
+    const { getByRole } = render(<UploadButton folderPath="rec_001" />);
+    expect(getByRole("button", { name: /Uploading…/ })).toBeDisabled();
+  });
+
+  it("flips to Re-upload when an upload completed", () => {
+    useUploadStatusMock.mockReturnValue({ status: "uploaded", percent: null, error: null });
+    const { getByRole } = render(<UploadButton folderPath="rec_001" />);
+    expect(getByRole("button", { name: /Re-upload/ })).toBeEnabled();
+  });
+
+  it("shows the failure message alongside a Retry button when failed", () => {
+    useUploadStatusMock.mockReturnValue({ status: "failed", percent: null, error: "network down" });
+    const { getByRole, getByText } = render(<UploadButton folderPath="rec_001" />);
+    expect(getByRole("button", { name: /Retry upload/ })).toBeEnabled();
+    expect(getByText("network down")).toBeInTheDocument();
+  });
+
+  it("invokes startUpload with the folder path when clicked", () => {
+    const { getByRole } = render(<UploadButton folderPath="rec_001" />);
+    fireEvent.click(getByRole("button"));
+    expect(startUploadMock).toHaveBeenCalledWith({ params: { path: "rec_001" } });
+  });
+
+  it("disables the click while the mutation is pending", () => {
+    useStartUploadMock.mockReturnValue({ mutate: startUploadMock, isPending: true });
+    const { getByRole } = render(<UploadButton folderPath="rec_001" />);
+    expect(getByRole("button")).toBeDisabled();
+  });
+});

--- a/frontend/src/features/upload/index.ts
+++ b/frontend/src/features/upload/index.ts
@@ -1,0 +1,2 @@
+export { UploadBadge } from "./upload-badge";
+export { UploadButton } from "./upload-button";

--- a/frontend/src/features/upload/upload-badge.tsx
+++ b/frontend/src/features/upload/upload-badge.tsx
@@ -1,0 +1,71 @@
+/** Inline icon shown on a recording row to surface the latest upload state.
+ *
+ * Reserves a fixed-width slot so titles stay aligned across rows, matching
+ * `ValidationBadge`. The slot is empty when no upload has ever been attempted.
+ *
+ * Reads the persisted state from `FileEntry.upload_status` (already part of
+ * the recordings list response, so this badge does not trigger any extra HTTP
+ * traffic) and overlays the live job-stream progress when an upload is in
+ * flight for this folder.
+ *
+ * Hidden entirely when `upload_enabled` is false on `/api/config`.
+ */
+
+import { CloudCheck, CloudOff, Loader2 } from "lucide-react";
+import type { FileEntry } from "@/api/generated/schemas";
+import { useConfig } from "@/hooks/use-api";
+import { useJobs } from "@/hooks/use-jobs-stream";
+
+export function UploadBadge({ entry }: { entry: FileEntry }) {
+  // --- Server state ---
+  const { data: config } = useConfig();
+  const jobs = useJobs();
+
+  if (!config?.upload_enabled) return null;
+
+  const activeJob = jobs.find(
+    (j) => j.type === "upload" && j.folder === entry.name && (j.status === "queued" || j.status === "running"),
+  );
+
+  if (activeJob) {
+    const { current, total } = activeJob.progress;
+    const percent = total > 0 ? Math.min(100, Math.floor((current / total) * 100)) : 0;
+    return (
+      <span
+        className="inline-flex shrink-0 items-center gap-1 text-[13px] text-muted-foreground"
+        data-status="uploading"
+        title={`Uploading ${percent}%`}
+      >
+        <Loader2 size={14} className="animate-spin" />
+        <span className="tabular-nums">{percent}%</span>
+      </span>
+    );
+  }
+
+  if (entry.upload_status === "uploaded") {
+    return (
+      <span
+        className="inline-flex h-4 w-4 shrink-0 items-center justify-center"
+        data-status="uploaded"
+        title="Uploaded"
+      >
+        <CloudCheck size={14} className="text-emerald-300" />
+      </span>
+    );
+  }
+
+  if (entry.upload_status === "failed") {
+    return (
+      <span
+        className="inline-flex h-4 w-4 shrink-0 items-center justify-center"
+        data-status="failed"
+        title="Upload failed"
+      >
+        <CloudOff size={14} className="text-red-300" />
+      </span>
+    );
+  }
+
+  // idle / not_found / null — reserve an empty slot so row contents stay aligned.
+  return <span className="inline-flex h-4 w-4 shrink-0" />;
+}

--- a/frontend/src/features/upload/upload-button.tsx
+++ b/frontend/src/features/upload/upload-button.tsx
@@ -1,0 +1,68 @@
+/** Upload action button shown in the recording-detail header.
+ *
+ * Stateful label that reflects the current upload phase
+ * (Upload / Uploading N% / Re-upload / Retry) and shows the failure
+ * message inline when the last attempt failed. Driven by
+ * `useUploadStatus(folderPath)`; clicks fire `POST /api/upload/start`
+ * which always overwrites the previously uploaded object (per issue #6).
+ *
+ * Hidden entirely when `upload_enabled` is false on `/api/config`.
+ */
+
+import { AlertCircle, CloudCheck, CloudUpload, Loader2 } from "lucide-react";
+import type { ComponentType } from "react";
+import { Button } from "@/components/ui/button";
+import { useConfig, useStartUpload } from "@/hooks/use-api";
+import { type UploadStatus, useUploadStatus } from "@/hooks/use-upload-status";
+
+type IconComponent = ComponentType<{ size?: number; className?: string }>;
+
+function buildLabel(
+  status: UploadStatus,
+  percent: number | null,
+): { Icon: IconComponent; text: string; spin?: boolean } {
+  switch (status) {
+    case "uploading":
+      return { Icon: Loader2, text: percent === null ? "Uploading…" : `Uploading ${percent}%`, spin: true };
+    case "uploaded":
+      return { Icon: CloudCheck, text: "Re-upload" };
+    case "failed":
+      return { Icon: AlertCircle, text: "Retry upload" };
+    default:
+      return { Icon: CloudUpload, text: "Upload" };
+  }
+}
+
+export function UploadButton({ folderPath }: { folderPath: string }) {
+  // --- Server state ---
+  const { data: config } = useConfig();
+  const { status, percent, error } = useUploadStatus(folderPath);
+  const { mutate: startUpload, isPending } = useStartUpload();
+
+  if (!config?.upload_enabled) return null;
+
+  const disabled = status === "uploading" || isPending;
+  const { Icon, text, spin } = buildLabel(status, percent);
+  const failed = status === "failed";
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        type="button"
+        size="sm"
+        variant={failed ? "destructive" : "outline"}
+        disabled={disabled}
+        onClick={() => startUpload({ params: { path: folderPath } })}
+        title={failed ? (error ?? "Upload failed") : text}
+      >
+        <Icon size={14} className={spin ? "animate-spin" : undefined} />
+        <span>{text}</span>
+      </Button>
+      {failed && error && (
+        <span className="max-w-[18rem] truncate text-[13px] text-red-300" title={error}>
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/routes/recordings_.$folder.tsx
+++ b/frontend/src/routes/recordings_.$folder.tsx
@@ -10,6 +10,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { QualitySummary } from "@/features/quality-summary";
 import { QualityTimeline, useQualityTimelineStore } from "@/features/quality-timeline";
+import { UploadButton } from "@/features/upload";
 import { ValidationSummary } from "@/features/validation";
 
 /** Compute the display range for a loss event (minimum 0.5 seconds). */
@@ -83,6 +84,7 @@ function McapDetailPage() {
         <span className="flex items-center gap-1.5 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
           {folderPath.split("/").pop() ?? folder}
         </span>
+        <UploadButton folderPath={folderPath} />
         <TabsList className="ml-auto -my-2 self-stretch">
           <TabsTrigger value="quality">Quality Analytics</TabsTrigger>
           <TabsTrigger value="validation">Validation</TabsTrigger>


### PR DESCRIPTION
## Summary

Wraps up the upload feature by surfacing it in the UI. Both components hide themselves when `useConfig().upload_enabled` is false, so machines without an S3 destination configured see no upload affordances.

### Components

**`features/upload/upload-button.tsx`** — recording-detail header action. Stateful label reflects the current phase: "Upload" / "Uploading N%" / "Re-upload" / "Retry upload". Driven by `useUploadStatus(folderPath)`; clicks fire `POST /api/upload/start`, which always overwrites the previously uploaded object (per issue #6). The failure message is shown inline next to the button when the last attempt failed.

**`features/upload/upload-badge.tsx`** — inline icon for each row in the recordings list. Reads the persisted status from `FileEntry.upload_status` (already in the list response, so no per-row HTTP) and overlays live `percent` from the SSE job stream when an upload is in flight. Reserves a fixed-width slot to keep titles aligned (matches `ValidationBadge`).

### Wiring

- `recordings_.$folder.tsx` mounts the button between the title span and the `TabsList` in the detail-page header.
- `recording-list-item.tsx` mounts the badge right after `ValidationBadge` so both row-level outcome icons sit together.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec biome check src/` — 133 files, no findings
- [x] `pnpm exec vitest run` — 196 passed (16 new cases across badge + button)
- [x] `make up` smoke test: stack came up cleanly; `/api/config` returned `upload_enabled: false` (no S3 config in dev defaults) and the upload-related elements were correctly hidden.

Full browser verification of the visible states (uploading / uploaded / failed) still warrants a manual pass once `S3_BUCKET` / `S3_KEY_TEMPLATE` are populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)