### PR TITLE
docs: add domain doc for the upload feature

### DIFF
--- a/docs/domain/index.md
+++ b/docs/domain/index.md
@@ -28,4 +28,5 @@ This repository's scope covers **MCAP recording, quality verification, and shipp
 | [DDS communication and gaps](dds_gap.md) | Why messages get lost over DDS, how it relates to QoS, and how to tune it |
 | [Quality analysis](quality_analysis.md) | Metrics, score calculation, status determination |
 | [Custom validators](custom_validators.md) | How the per-recording auto-validation works, and how to add your own rules |
+| [Upload to a destination](upload.md) | Lifecycle, the destination abstraction, key-template syntax, and failure modes |
 | [SSE stream](sse.md) | Spec for real-time data delivery (event list, connection example) |

--- a/docs/domain/upload.md
+++ b/docs/domain/upload.md
@@ -1,0 +1,174 @@
+# Upload to a Destination
+
+> How recordings are shipped from the recording machine to a configured
+> upload destination (S3-compatible today; GCS / local-network destinations
+> on the roadmap).
+>
+> Related: [Setup — S3 Upload](../SETUP.md#s3-upload-optional) | [Architecture](../ARCHITECTURE.md)
+
+## Scope
+
+After a recording stops, the MCAP file and its sidecar JSONs
+(`quality_report.json`, `validation_result.json`, `recording_meta.json`)
+sit on the recording machine's disk. The upload feature gives the
+operator a one-click path to ship that bundle to an external storage
+backend, where a downstream pipeline can pick it up for conversion /
+annotation.
+
+What is in scope:
+
+- Zip the recording folder and upload the archive as a single object.
+- Persist a per-recording state file so reloads survive a refresh / a
+  page navigation.
+- Stream byte-level progress over SSE while the upload runs.
+- Generic over the destination — S3 today via boto3, with an extension
+  point (`UploadDestination` protocol) so GCS / a local-network server
+  can be added later without touching the service / job queue layers.
+
+What is **not** in scope (out by design, per [issue #6](https://github.com/fastlabel/open-lutra/issues/6)):
+
+- Multi-destination uploads. Exactly one destination is active per
+  machine.
+- Auto-upload after recording stops. Upload is always user-initiated.
+- Resumable retry beyond what boto3's `TransferManager` already does.
+- Download / restore from the destination.
+- Bulk-upload across multiple recordings from the list page.
+
+## Lifecycle
+
+```
+User clicks "Upload"
+  │
+  └─► POST /api/upload/start
+        ├─ early-reject: destination misconfigured or template invalid
+        │   ► UploadResponse(status="failed", error="…")
+        └─ otherwise enqueue an UploadJob
+              │
+              └─► JobQueue worker picks up the job
+                    ├─ Read recording_start_ns from metadata.yaml
+                    ├─ Render destination key from S3_KEY_TEMPLATE
+                    ├─ Build / refresh <folder>/<folder>.zip
+                    ├─ Persist upload_state.json (status="uploading")
+                    ├─ destination.upload(zip, key, progress_cb)
+                    │     ├─ progress_cb emits SSE at most once per 1 s
+                    │     └─ progress_cb persists bytes_transferred to
+                    │        upload_state.json (throttled)
+                    ├─ on success:  upload_state.json status="uploaded"
+                    │               etag + uploaded_at + size_bytes
+                    └─ on exception: upload_state.json status="failed"
+                                     error=str(e) ; re-raised so the
+                                     JobQueue marks the job FAILED
+```
+
+`upload_state.json.status` is the source of truth between sessions; the
+SSE job stream is the source of truth for the *live* percent while a
+job is in flight. The frontend's `useUploadStatus(folderPath)` fuses
+both and falls back to the persisted state when no job is active.
+
+### Re-clicking after a successful upload
+
+Per issue #6 the start path **always overwrites**: there is no
+skip-if-cached short-circuit. Re-clicking the button enqueues another
+upload that writes the same key with a new ETag. The dedup guard
+(`enqueue_upload` returns the existing job if one is already running)
+prevents two simultaneous uploads of the same folder, not re-uploads
+across time.
+
+## The destination abstraction
+
+```
+app/features/upload/destinations/
+  base.py        UploadDestination Protocol + UploadResult + ProgressCallback
+  registry.py    get_active_destination(settings) → single active instance
+  s3.py          S3Destination (boto3 + any S3-compatible endpoint)
+```
+
+The job runner only sees:
+
+```python
+class UploadDestination(Protocol):
+    name: str
+    def configuration_error(self) -> str | None: ...
+    def upload(self, local_path, key, progress) -> UploadResult: ...
+```
+
+Adding a backend (e.g. GCS) is then a single new module + a registry
+update:
+
+1. Implement `GCSDestination` in `destinations/gcs.py`.
+2. Extend `get_active_destination()` to switch on a future
+   `UPLOAD_DESTINATION` setting and return the new instance.
+3. Add the relevant `GCS_*` env vars to `Settings`.
+
+The service layer, the job queue, the UI, and the persisted
+`upload_state.json` are all destination-agnostic — `state.destination`
+holds a bucket / container / host string and `state.key` holds the
+object path within it.
+
+## Key template
+
+The destination key is computed at upload time by rendering
+`S3_KEY_TEMPLATE` with these placeholders:
+
+| Placeholder | Source | Example |
+|---|---|---|
+| `{recording_name}` | the recording folder name | `rec_20260525_120000` |
+| `{yyyymmddhhmmss}` | recording start time, derived from `metadata.yaml`'s `starting_time.nanoseconds_since_epoch` (UTC) | `20260525120000` |
+
+```env
+S3_KEY_TEMPLATE=lutra-recordings/operation-files/{yyyymmddhhmmss}/{recording_name}.zip
+```
+
+`task_name` is **deliberately not a placeholder.** Task names are
+user-editable and may contain spaces or other characters that would
+require percent-encoding in an S3 key; keeping them out of the key
+keeps the convention "the key is composed of immutable identifiers
+only". `task_name` is still recorded in `recording_meta.json` inside
+the zip, so it travels with the upload — it just does not appear in
+the destination key.
+
+`validate_template` rejects unknown placeholders and unbalanced braces
+at start-time (so the operator sees the error in the UploadResponse
+rather than discovering it after a long zip).
+
+## Failure modes
+
+Every failure is recorded on `upload_state.json` and surfaced through
+`GET /api/upload` + the UploadBadge + the UploadButton's inline error
+message. The four sources of a `status="failed"` response are:
+
+| Source | Where it is raised | What the user sees |
+|---|---|---|
+| `S3_BUCKET` / `S3_KEY_TEMPLATE` not set | `S3Destination.configuration_error()` (start-path early-reject) | "S3_BUCKET is not configured" (UI: red badge) |
+| Invalid template syntax | `validate_template` (start-path early-reject) | "Unknown placeholder: …" |
+| Recording missing `metadata.yaml` start time | `_run_upload` (job worker) | "Cannot determine recording start time from metadata.yaml: …" |
+| Network / S3 SDK error | `destination.upload()` raises through `_run_upload` | The boto3 error message verbatim (e.g. `EndpointConnectionError`, `NoSuchBucket`) |
+
+Start-path early-rejects do not enqueue a job and do not write
+`upload_state.json` — the failure is only carried in the
+`UploadResponse`. The runtime-side failures (the last two rows above)
+always leave a `failed` state file behind, so a refresh still shows the
+error and the user can hit "Retry upload" without losing context.
+
+## UI integration
+
+| Where | Component | Behavior |
+|---|---|---|
+| Recording-detail header (`recordings_/$folder.tsx`) | `UploadButton` | Stateful label: `Upload` / `Uploading N%` / `Re-upload` / `Retry upload`. Click fires `POST /api/upload/start`. Inline error shown next to the button when `status="failed"`. |
+| Recording-list row (`recording-list-item.tsx`) | `UploadBadge` | Inline icon: cloud-check (uploaded), spinner + percent (uploading), cloud-off (failed), empty slot (no state). Reads `FileEntry.upload_status` for persistence + the SSE job stream for live percent — no per-row HTTP. |
+
+Both components return `null` when `useConfig().upload_enabled === false`,
+so a machine with no destination configured renders no upload affordances
+at all.
+
+`upload_enabled` is true only when both checks pass: the destination's
+`configuration_error()` returns `None` **and** `validate_template`
+succeeds on the configured `S3_KEY_TEMPLATE`. That keeps the UI from
+showing a button that would always immediately fail.
+
+## Operator setup
+
+See [Setup — S3 Upload](../SETUP.md#s3-upload-optional) for the
+environment variables (env-var-auth vs. profile-auth, TransferConfig
+overrides) and [Setup — Local Testing with MinIO](../SETUP.md#local-testing-with-minio)
+for spinning up the local MinIO sandbox.


### PR DESCRIPTION
## Summary

D2 of the upload-docs cleanup (3-PR split). Adds `docs/domain/upload.md` — the domain-knowledge counterpart to the operator how-to in `docs/SETUP.md`.

The new doc covers:

- **Scope** — what the upload feature ships, plus the intentional out-of-scope items from [issue #6](https://github.com/fastlabel/open-lutra/issues/6) (single destination per machine, no auto-upload, no resume beyond boto3 defaults, no download / restore).
- **Lifecycle** — ASCII pipeline of `POST /api/upload/start` → `UploadJob` → `destination.upload()` → persisted `upload_state.json`, with the always-overwrite rule called out explicitly.
- **The destination abstraction** — `UploadDestination` Protocol, the registry's single-active-destination model, and what it takes to add a new backend (GCS, local server).
- **Key template** — placeholders, an example, and the reason `task_name` is deliberately not one.
- **Failure modes** — the four sources of `status="failed"` (misconfigured destination / invalid template / missing metadata.yaml start time / transfer error) and where each one persists / surfaces.
- **UI integration** — UploadButton and UploadBadge with their hide-when-disabled rule.

The doc defers env-var configuration and the MinIO sandbox setup to `docs/SETUP.md` (per the project DRY rule); only one cross-link sits at the bottom. The domain index gains a row that links to it.

## Test plan

- [x] Diff inspected — `docs/domain/index.md` gains one row in the existing table; new file is 174 lines.
- No code changed, so no lint / test runs needed beyond docs review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)