### PR TITLE
docs: round out upload coverage in CLAUDE.md, TECH_STACK.md, SETUP.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ make format-backend    # Format (ruff)
 make format-frontend   # Format (biome)
 make generate          # Regenerate API types (requires: backend running)
 make build             # Build Docker images
+make minio-up          # Start the local MinIO sandbox + auto-create the bucket (for upload-feature testing)
+make minio-down        # Stop the local MinIO sandbox
 make prod-up           # Production start (host network)
 ```
 
@@ -54,9 +56,10 @@ A **hybrid architecture** is used:
 - **Loss detection is IQR-based**: Instead of a fixed multiplier, uses a statistical threshold (`Q3 + 1.5×IQR`) to detect per-frame losses. Recorded as `LossEvent` (severity=minor/major) and used for per-topic status determination.
 - **Image/Joint detection is automatic**: Determined by structure (presence of `format` + `data` fields), not by hard-coded message type names. Also supports vendor-specific or user-defined message types that nest a `JointState` inside a `joint_state` field. See [examples/custom_ros2_messages/](examples/custom_ros2_messages/) for how to plug in custom message packages.
 - **Video preview is MCAP → MP4 conversion**: When the Preview on the recording detail page is opened, per-camera MP4s are generated from the MCAP and persisted in the recording directory. FPS is fixed at 30 (`backend/app/features/media/video_generator.py:VIDEO_FPS`). Frames are piped to ffmpeg one at a time to keep memory usage constant.
-- **Feature boundaries follow the "recording lifecycle"**: `recordings` (directory operations) / `analysis` (quality and timeline; persistent findings) / `media` (MP4 / Joint data generation for preview) / `validation` (per-recording rule checks) are managed as independent features.
+- **Feature boundaries follow the "recording lifecycle"**: `recordings` (directory operations) / `analysis` (quality and timeline; persistent findings) / `media` (MP4 / Joint data generation for preview) / `validation` (per-recording rule checks) / `upload` (zip + ship to an `UploadDestination`) are managed as independent features.
 - **MCAP I/O is consolidated in `backend/app/infra/mcap/`**: Centralizes `make_reader` + `DecoderFactory` initialization, header.stamp-preferred timestamp normalization, and image/Joint structure detection. All consumers in analysis / media read MCAP through this layer.
 - **Validation takes a ValidationContext as input**: After a recording stops, quality → validation runs automatically as a chain in JobQueue, and results are saved to `validation_result.json`. `ValidationContext` is a frozen dataclass bundling `QualityReport` / `recording_dir` / `mcap_path` / `recording_meta`; it also exposes the MCAP path so validators can read raw frames with `MCAPReader` when needed (if you only need aggregated values, `ctx.report` is enough). Builtins live in `backend/app/features/validation/builtins/` with their params controlled by `active_set.py`; user-defined validators go in `backend/app/features/validation/custom/` registered via `@register_validator` and applied on restart. See [docs/domain/custom_validators.md](docs/domain/custom_validators.md) for how to add a custom validator.
+- **Upload destinations are pluggable behind a Protocol**: The upload feature is generic over the storage backend. `UploadDestination` (in `backend/app/features/upload/destinations/base.py`) defines `configuration_error()` + `upload(local_path, key, progress) -> UploadResult`; `S3Destination` is the only implementation today (also covers MinIO / R2 / LocalStack via `AWS_ENDPOINT_URL`), and the registry returns a single active destination per machine. Adding a new backend (GCS, local-network server) means one new module under `destinations/` + a registry update — `UploadService` / `JobQueue` / `UploadState` are destination-agnostic. See [docs/domain/upload.md](docs/domain/upload.md) for the lifecycle, key-template syntax, and failure modes.
 
 ## Frontend Architecture
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -300,6 +300,12 @@ AWS_ENDPOINT_URL=http://minio:9000
 
 The backend reaches MinIO via the compose-internal hostname `minio:9000`. From the host (browser, `aws s3` CLI), use `http://localhost:9000` instead. The bucket name and the root credentials are configurable via `S3_BUCKET`, `MINIO_ROOT_USER`, and `MINIO_ROOT_PASSWORD` in `.env`.
 
+After editing `.env`, restart the backend so the new values are picked up — `env_file` is read on container start, so plain `make up` against an already-running stack will keep the old values:
+
+```bash
+make restart
+```
+
 ---
 
 ## Simulator

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -13,6 +13,7 @@
 | rclpy | (ROS2 Humble) | Topic subscription / real-time monitoring |
 | mcap / mcap-ros2-support | 1.1+ | MCAP file analysis / CDR deserialization |
 | Pillow | 10.0+ | Image processing |
+| boto3 | 1.34+ | S3 client for the upload feature (also covers any S3-compatible endpoint: MinIO / R2 / LocalStack) |
 | uv | latest | Package manager |
 
 ## Frontend
@@ -41,6 +42,7 @@
 | Docker Compose | Development / production environments |
 | nginx | Production frontend serving + API reverse proxy |
 | CycloneDDS | ROS2 DDS communication |
+| MinIO (pgsty/minio) | Local S3-compatible sandbox for testing the upload feature (`make minio-up`) |
 
 ## Dev Tools
 


### PR DESCRIPTION
## Summary

D3 (final) of the upload-docs cleanup. Catches the spots the previous two PRs intentionally left for last.

- **`CLAUDE.md`**
  - Adds `make minio-up` / `make minio-down` to the Development Commands block.
  - Extends the "feature boundaries" line to include `upload`, so the sibling-feature listing matches what the codebase actually ships.
  - Adds a new Key Technical Decision entry covering the `UploadDestination` Protocol — why upload destinations are a plug-in point and where to look when adding GCS / a local-network backend.
- **`docs/TECH_STACK.md`**
  - Adds `boto3 1.34+` to the backend library table.
  - Adds MinIO (pgsty/minio) to the infrastructure table, so the local sandbox is discoverable from the tech-stack overview.
- **`docs/SETUP.md`**
  - Adds a brief restart-after-editing-`.env` note inside the MinIO section. `env_file` is read on container start, so a plain `make up` against an already-running stack keeps the stale values — this was the most common pitfall noticed during smoke testing.

## Test plan

- [x] Diff inspected — markdown unchanged outside the listed sections.
- No code changed, so no lint / test runs needed beyond docs review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)