### PR TITLE
docs: prepare runway for bulk-upload and additional UploadDestinations

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -351,6 +351,8 @@ Clicking the details panel header navigates to the MCAP detail page (`/recording
 - This makes "filter or search to narrow down, then bulk-delete with one button" possible with minimal operations.
 - The count on each filter tab updates in real time to reflect the breakdown within the current search hits.
 
+**Where bulk actions live**: bulk-action buttons are individual components under `frontend/src/features/recordings/ui/bulk-*.tsx` (today: `bulk-delete-button.tsx`) and mounted inside `features/recordings-table/recordings-table.tsx`. They read the selected set from `useRecordingsStore.checkedFolders` (a Zustand store inside the `recordings` feature). Add new bulk actions by mirroring this pattern.
+
 #### MCAP detail page (`/recordings/:folder`) — integrated timeline view
 
 ```

--- a/docs/domain/upload.md
+++ b/docs/domain/upload.md
@@ -32,7 +32,20 @@ What is **not** in scope (out by design, per [issue #6](https://github.com/fastl
 - Auto-upload after recording stops. Upload is always user-initiated.
 - Resumable retry beyond what boto3's `TransferManager` already does.
 - Download / restore from the destination.
-- Bulk-upload across multiple recordings from the list page.
+
+Out of scope for the initial drop but on the near-term roadmap (no
+design baked in yet — both decisions sit with whoever picks them up):
+
+- **Bulk upload from the recordings list page.** Mounted next to
+  `<BulkDeleteButton />` in `recordings-table.tsx`; reads the selected
+  set from `useRecordingsStore.checkedFolders`. The JobQueue is
+  single-worker with per-folder dedup, so either implementation shape
+  (N `POST /api/upload/start` calls from the frontend, or one new
+  endpoint that enqueues `N` jobs server-side) ends up serialized the
+  same way — pick whichever fits the rest of the UI's mutation
+  patterns better.
+- **Non-S3 destinations** (local-network server, GCS, …). See "The
+  destination abstraction" below for the extension recipe.
 
 ## Lifecycle
 
@@ -92,13 +105,39 @@ class UploadDestination(Protocol):
     def upload(self, local_path, key, progress) -> UploadResult: ...
 ```
 
-Adding a backend (e.g. GCS) is then a single new module + a registry
-update:
+Adding a backend (e.g. a local-network server, GCS) is a small,
+well-bounded change:
 
-1. Implement `GCSDestination` in `destinations/gcs.py`.
-2. Extend `get_active_destination()` to switch on a future
-   `UPLOAD_DESTINATION` setting and return the new instance.
-3. Add the relevant `GCS_*` env vars to `Settings`.
+1. **Implement the destination.** New module under `destinations/`
+   (e.g. `destinations/local.py`) with a class that fulfils the
+   `UploadDestination` Protocol. Set `name = "local"` on the class —
+   it is read by diagnostics and (eventually) by selection logic.
+2. **Add settings.** Whatever env vars the backend needs (host /
+   credentials / path prefix) go on `Settings` in
+   `backend/app/settings.py`. Follow the existing S3 pattern:
+   `str | None = None` for optional fields, no defaults on values
+   the operator must supply.
+3. **Wire up selection.** `get_active_destination(settings)` in
+   `destinations/registry.py` currently hard-returns `S3Destination`.
+   Introduce `UPLOAD_DESTINATION` on `Settings` (allowed values:
+   `"s3"` / `"local"` / …; default `"s3"` so existing deployments
+   keep working) and switch on it.
+4. **Generalise the availability check.** `_upload_availability_error`
+   in `upload/service.py` today calls `validate_template(
+   settings.s3_key_template)` directly — that lives outside the
+   Protocol because S3 happens to use a key template. If the new
+   destination does not use a key template, push that validation into
+   the destination's `configuration_error()` (or a similar Protocol
+   method) so the service layer stops naming S3 fields.
+5. **Mirror the tests.** Drop a sibling test file under
+   `backend/tests/features/upload/destinations/` named after the
+   destination (e.g. `test_local.py`), following `test_s3.py` for the
+   test-class layout (`TestConfigurationError`, `TestUpload`, plus
+   any private-helper tests). 100% coverage on the new module is
+   expected — see `docs/DEVELOPMENT.md` for the coverage gate.
+6. **Update operator-facing docs.** Add an env-var table for the new
+   destination to `docs/SETUP.md` (mirror the S3 Upload section) so
+   the operator knows what to set.
 
 The service layer, the job queue, the UI, and the persisted
 `upload_state.json` are all destination-agnostic — `state.destination`


### PR DESCRIPTION
## Summary

Doc-only follow-up so two near-term tasks — **bulk upload from the recordings list page** and **a non-S3 UploadDestination (local-network / GCS / …)** — can be picked up cleanly in a separate session without reading conversation history.

A doc audit against the merged-as-of-today docs surfaced these gaps:

- `docs/domain/upload.md` listed *"Bulk-upload across multiple recordings from the list page"* under "out of scope" — a future session would correctly read that as "this is declared unsupported" instead of "this is the next thing to add."
- The "Add a new destination" recipe was three lines that glossed over: the new `UPLOAD_DESTINATION` env var's allowed values, the fact that `_upload_availability_error` currently hard-codes the S3 key-template check, the test-directory mirror, and the operator-doc update step.
- `docs/ARCHITECTURE.md` "Recordings list page" mentioned *bulk-delete* in passing but never named where bulk-action components live or which store carries the selected set.

## Changes

- **`docs/domain/upload.md`**
  - Out-of-scope list reshuffled into two halves: "out by design" (multi-destination, auto-upload, resume, download/restore) and "on the near-term roadmap" (bulk upload, non-S3 destinations).
  - Bulk-upload entry calls out the mount point, the selection source, and the JobQueue-serialisation reason both implementation shapes (N calls vs. server-side bulk endpoint) are equally valid.
  - "Add a new destination" recipe expanded from 3 steps to 6, including the `UPLOAD_DESTINATION` setting shape, the `_upload_availability_error` generalisation note, the test-directory mirror, and the SETUP.md update reminder.
- **`docs/ARCHITECTURE.md` "Recordings list page"**
  - One paragraph naming `features/recordings/ui/bulk-*.tsx` as the file pattern, `recordings-table.tsx` as the mount point, and `useRecordingsStore.checkedFolders` as the selection source.

## Test plan

- [x] Diff inspected; markdown intact, no inadvertent line breaks.
- No code change, so no lint / test runs needed beyond docs review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)