### PR TITLE
feat(lerobot-export): require explicit field path and type in source …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
-  workflow_dispatch:
+    branches: [main, "feat/**", "fix/**", "chore/**"]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/backend/app/features/analysis/models.py
+++ b/backend/app/features/analysis/models.py
@@ -93,8 +93,12 @@ class TopicQuality(BaseModel):
     timestamp_source: str = Field(..., description="Timestamp source (header_stamp/log_time)")
     avg_message_size_bytes: int
     size_stats: MessageSizeStats
-    start_delay_sec: float = Field(..., description="Delay from recording start to this topic's first message (seconds)")
-    end_early_sec: float = Field(..., description="Empty interval from this topic's last message to recording end (seconds)")
+    start_delay_sec: float = Field(
+        ..., description="Delay from recording start to this topic's first message (seconds)"
+    )
+    end_early_sec: float = Field(
+        ..., description="Empty interval from this topic's last message to recording end (seconds)"
+    )
     status: str
 
     @classmethod
@@ -191,7 +195,9 @@ class TopicQuality(BaseModel):
         major_loss_count = sum(1 for le in loss_events if le.severity == "major")
 
         # Continuity score (computed from loss_events, more accurate than legacy gaps)
-        loss_total_sec = sum(le.duration_sec for le in loss_events) if loss_events else sum(g.duration_sec for g in gaps)
+        loss_total_sec = (
+            sum(le.duration_sec for le in loss_events) if loss_events else sum(g.duration_sec for g in gaps)
+        )
         topic_duration = timestamps[-1] - timestamps[0]
         continuity = max(0.0, 1.0 - (loss_total_sec / topic_duration)) if topic_duration > 0 else 1.0
 

--- a/backend/app/features/lerobot_export/config_loader.py
+++ b/backend/app/features/lerobot_export/config_loader.py
@@ -16,6 +16,8 @@ from app.settings import get_settings
 if TYPE_CHECKING:
     from app.settings import RecordingConfig
 
+_VALID_FIELD_TYPES = ("list", "number", "struct")
+
 
 def has_active_config(recording: RecordingConfig | None = None) -> bool:
     """Return True if the active recording config declares a `lerobot_export` mapping."""
@@ -75,10 +77,21 @@ def parse_config(data: dict[str, Any]) -> ExportConfig:
 
 
 def _parse_source(source: dict[str, Any]) -> SourceConfig:
+    for required in ("topic", "field", "type"):
+        if required not in source:
+            raise ValueError(f"Source {source.get('topic', '?')!r} must specify {required!r}")
+    field_type = source["type"]
+    if field_type not in _VALID_FIELD_TYPES:
+        raise ValueError(
+            f"Source {source['topic']!r}: type {field_type!r} is invalid; "
+            f"must be one of {_VALID_FIELD_TYPES}"
+        )
     return SourceConfig(
         topic=source["topic"],
-        field=source.get("field"),
+        field=source["field"],
+        type=field_type,
         indices=source.get("indices"),
+        keys=source.get("keys"),
         names=source.get("names"),
         interpolation=source.get("interpolation", "linear"),
     )

--- a/backend/app/features/lerobot_export/config_loader.py
+++ b/backend/app/features/lerobot_export/config_loader.py
@@ -83,8 +83,7 @@ def _parse_source(source: dict[str, Any]) -> SourceConfig:
     field_type = source["type"]
     if field_type not in _VALID_FIELD_TYPES:
         raise ValueError(
-            f"Source {source['topic']!r}: type {field_type!r} is invalid; "
-            f"must be one of {_VALID_FIELD_TYPES}"
+            f"Source {source['topic']!r}: type {field_type!r} is invalid; must be one of {_VALID_FIELD_TYPES}"
         )
     if field_type in ("list", "number") and "field" not in source:
         raise ValueError(f"Source {source['topic']!r}: type {field_type!r} requires 'field'")

--- a/backend/app/features/lerobot_export/config_loader.py
+++ b/backend/app/features/lerobot_export/config_loader.py
@@ -77,7 +77,7 @@ def parse_config(data: dict[str, Any]) -> ExportConfig:
 
 
 def _parse_source(source: dict[str, Any]) -> SourceConfig:
-    for required in ("topic", "field", "type"):
+    for required in ("topic", "type"):
         if required not in source:
             raise ValueError(f"Source {source.get('topic', '?')!r} must specify {required!r}")
     field_type = source["type"]
@@ -86,13 +86,15 @@ def _parse_source(source: dict[str, Any]) -> SourceConfig:
             f"Source {source['topic']!r}: type {field_type!r} is invalid; "
             f"must be one of {_VALID_FIELD_TYPES}"
         )
+    if field_type in ("list", "number") and "field" not in source:
+        raise ValueError(f"Source {source['topic']!r}: type {field_type!r} requires 'field'")
     if field_type == "list" and "indices" not in source:
         raise ValueError(f"Source {source['topic']!r}: type 'list' requires 'indices'")
     if field_type == "struct" and "keys" not in source:
         raise ValueError(f"Source {source['topic']!r}: type 'struct' requires 'keys'")
     return SourceConfig(
         topic=source["topic"],
-        field=source["field"],
+        field=source.get("field"),
         type=field_type,
         indices=source.get("indices"),
         keys=source.get("keys"),

--- a/backend/app/features/lerobot_export/config_loader.py
+++ b/backend/app/features/lerobot_export/config_loader.py
@@ -86,6 +86,10 @@ def _parse_source(source: dict[str, Any]) -> SourceConfig:
             f"Source {source['topic']!r}: type {field_type!r} is invalid; "
             f"must be one of {_VALID_FIELD_TYPES}"
         )
+    if field_type == "list" and "indices" not in source:
+        raise ValueError(f"Source {source['topic']!r}: type 'list' requires 'indices'")
+    if field_type == "struct" and "keys" not in source:
+        raise ValueError(f"Source {source['topic']!r}: type 'struct' requires 'keys'")
     return SourceConfig(
         topic=source["topic"],
         field=source["field"],

--- a/backend/app/features/lerobot_export/converter.py
+++ b/backend/app/features/lerobot_export/converter.py
@@ -230,7 +230,7 @@ def _interpolate_source(
     source_data = [
         TimestampedValue(
             timestamp_ns=msg.timestamp_ns,
-            value=extract_field_data(msg.decoded, source.field, source.indices),
+            value=extract_field_data(msg.decoded, source.field, source.type, source.indices, source.keys),
         )
         for msg in messages
     ]
@@ -248,7 +248,7 @@ def _probe_sources(
         messages = probe_messages.get(src.topic) or []
         if not messages:
             raise ValueError(f"No messages for topic: {src.topic}")
-        sample = extract_field_data(messages[0].decoded, src.field, src.indices)
+        sample = extract_field_data(messages[0].decoded, src.field, src.type, src.indices, src.keys)
         dim = len(sample)
         if src.names:
             names.extend(src.names)

--- a/backend/app/features/lerobot_export/extract.py
+++ b/backend/app/features/lerobot_export/extract.py
@@ -21,7 +21,7 @@ _VALID_FIELD_TYPES = ("list", "number", "struct")
 
 def extract_field_data(
     decoded: Any,
-    field: str,
+    field: str | None,
     field_type: str,
     indices: list[int] | None = None,
     keys: list[str] | None = None,
@@ -30,7 +30,9 @@ def extract_field_data(
 
     Traverses `field` as a dot-separated attribute path (e.g.
     "joint_state.position", "gripper_pos", "pose.position"), then extracts
-    values according to `field_type`:
+    values according to `field_type`. When `field` is None, extraction is
+    applied directly to the decoded message (used for struct types where the
+    message itself is the target object, e.g. geometry_msgs/Point).
 
     - "number": scalar float/int → 1-element array.
     - "list":   numeric sequence → elements selected by `indices` (required);
@@ -46,7 +48,7 @@ def extract_field_data(
         raise ValueError(f"Unknown field type {field_type!r}; must be one of {_VALID_FIELD_TYPES}")
 
     obj: Any = decoded
-    for part in field.split("."):
+    for part in (field.split(".") if field is not None else []):
         try:
             obj = getattr(obj, part)
         except AttributeError as e:
@@ -57,15 +59,15 @@ def extract_field_data(
 
     if field_type == "struct":
         if keys is None:
-            raise ValueError(f"Field {field!r} has type 'struct' but 'keys' is not specified")
+            raise ValueError(f"Source field {field!r} has type 'struct' but 'keys' is not specified")
         try:
             return np.array([float(getattr(obj, k)) for k in keys], dtype=np.float64)
         except AttributeError as e:
-            raise ValueError(f"Field {field!r}: {e}") from e
+            raise ValueError(f"Source field {field!r}: {e}") from e
 
     # type == "list"
     if indices is None:
-        raise ValueError(f"Field {field!r} has type 'list' but 'indices' is not specified")
+        raise ValueError(f"Source field {field!r} has type 'list' but 'indices' is not specified")
     arr = np.asarray(list(obj), dtype=np.float64)
     return np.array([arr[i] if 0 <= i < len(arr) else 0.0 for i in indices], dtype=np.float64)
 

--- a/backend/app/features/lerobot_export/extract.py
+++ b/backend/app/features/lerobot_export/extract.py
@@ -48,7 +48,7 @@ def extract_field_data(
         raise ValueError(f"Unknown field type {field_type!r}; must be one of {_VALID_FIELD_TYPES}")
 
     obj: Any = decoded
-    for part in (field.split(".") if field is not None else []):
+    for part in field.split(".") if field is not None else []:
         try:
             obj = getattr(obj, part)
         except AttributeError as e:

--- a/backend/app/features/lerobot_export/extract.py
+++ b/backend/app/features/lerobot_export/extract.py
@@ -49,8 +49,8 @@ def extract_field_data(
     for part in field.split("."):
         try:
             obj = getattr(obj, part)
-        except AttributeError:
-            raise ValueError(f"Message has no field {field!r} (missing attribute {part!r})")
+        except AttributeError as e:
+            raise ValueError(f"Message has no field {field!r} (missing attribute {part!r})") from e
 
     if field_type == "number":
         return np.array([float(obj)], dtype=np.float64)
@@ -61,7 +61,7 @@ def extract_field_data(
         try:
             return np.array([float(getattr(obj, k)) for k in keys], dtype=np.float64)
         except AttributeError as e:
-            raise ValueError(f"Field {field!r}: {e}")
+            raise ValueError(f"Field {field!r}: {e}") from e
 
     # type == "list"
     if indices is None:

--- a/backend/app/features/lerobot_export/extract.py
+++ b/backend/app/features/lerobot_export/extract.py
@@ -1,8 +1,8 @@
 """Field extraction and image decoding for LeRobot export.
 
-Both are structure-based (no ROS2 type names), matching the rest of the project
-(`app/infra/mcap`). `extract_field_data` reads a numeric vector from a decoded
-message; `decode_ros_image` turns an Image / CompressedImage into an RGB ndarray.
+`extract_field_data` resolves a dot-separated field path on a decoded message
+and returns a float64 ndarray according to an explicit type declaration.
+`decode_ros_image` turns an Image / CompressedImage into an RGB ndarray.
 """
 
 from __future__ import annotations
@@ -13,48 +13,60 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from PIL import Image
 
-from app.infra.mcap import extract_joint_positions
-
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+
+_VALID_FIELD_TYPES = ("list", "number", "struct")
 
 
 def extract_field_data(
     decoded: Any,
-    field: str | None,
+    field: str,
+    field_type: str,
     indices: list[int] | None = None,
+    keys: list[str] | None = None,
 ) -> NDArray[np.float64]:
     """Extract a float vector from a decoded telemetry message.
 
-    When `field` is None, the vector is detected by structure: joint positions
-    via `extract_joint_positions` (which also handles nested `joint_state` and
-    composite `neck_joint_state` custom messages), falling back to a `data`
-    field (Float*MultiArray or scalar std_msgs/Float64). Set `field` to override
-    (e.g. "velocity", "effort", "data", or a custom attribute).
+    Traverses `field` as a dot-separated attribute path (e.g.
+    "joint_state.position", "gripper_pos", "pose.position"), then extracts
+    values according to `field_type`:
 
-    Scalar sources (e.g. a `std_msgs/Float64` gripper value) are normalized to a
-    length-1 vector. Out-of-range `indices` are filled with 0.0 to keep a
-    fixed-length vector.
+    - "number": scalar float/int → 1-element array.
+    - "list":   numeric sequence → elements selected by `indices` (required);
+                out-of-range indices are filled with 0.0.
+    - "struct": named-field object (e.g. geometry_msgs/Point) → attributes
+                named by `keys` extracted in order (required).
 
     Raises:
-        ValueError: When no vector can be extracted, or `field` is absent.
+        ValueError: When the path is not found, `field_type` is unknown, or
+            `indices` / `keys` is missing for "list" / "struct" respectively.
     """
-    if field is None:
-        raw: Any = extract_joint_positions(decoded)
-        if not len(raw) and hasattr(decoded, "data"):
-            raw = decoded.data
-    else:
-        raw = getattr(decoded, field, None)
-        if raw is None:
-            raise ValueError(f"Message has no field {field!r}")
+    if field_type not in _VALID_FIELD_TYPES:
+        raise ValueError(f"Unknown field type {field_type!r}; must be one of {_VALID_FIELD_TYPES}")
 
-    # np.atleast_1d normalizes scalars (std_msgs/Float64 .data) to shape (1,)
-    # while leaving list/array sources as a flat vector.
-    arr = np.atleast_1d(np.asarray(raw, dtype=np.float64))
-    if field is None and arr.size == 0:
-        raise ValueError("Cannot extract a vector (no joint position or 'data' field); set 'field' in the config")
+    obj: Any = decoded
+    for part in field.split("."):
+        try:
+            obj = getattr(obj, part)
+        except AttributeError:
+            raise ValueError(f"Message has no field {field!r} (missing attribute {part!r})")
+
+    if field_type == "number":
+        return np.array([float(obj)], dtype=np.float64)
+
+    if field_type == "struct":
+        if keys is None:
+            raise ValueError(f"Field {field!r} has type 'struct' but 'keys' is not specified")
+        try:
+            return np.array([float(getattr(obj, k)) for k in keys], dtype=np.float64)
+        except AttributeError as e:
+            raise ValueError(f"Field {field!r}: {e}")
+
+    # type == "list"
     if indices is None:
-        return arr
+        raise ValueError(f"Field {field!r} has type 'list' but 'indices' is not specified")
+    arr = np.asarray(list(obj), dtype=np.float64)
     return np.array([arr[i] if 0 <= i < len(arr) else 0.0 for i in indices], dtype=np.float64)
 
 

--- a/backend/app/features/lerobot_export/models.py
+++ b/backend/app/features/lerobot_export/models.py
@@ -8,11 +8,15 @@ features. Kept separate from API schemas (schemas.py).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Literal
 
 DEFAULT_INTERPOLATION = "linear"
 DEFAULT_SYNC_TOLERANCE_MS = 50.0
 DEFAULT_IMAGE_TOLERANCE_MS = 200.0
 DEFAULT_TIME_RANGE = "intersection"
+
+
+FieldType = Literal["list", "number", "struct"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -21,17 +25,26 @@ class SourceConfig:
 
     Attributes:
         topic: ROS2 topic name.
-        field: Attribute to extract. None uses the sensor's default for the
-            topic's message type (e.g. `position` for JointState, `data` for
-            Float*MultiArray); set it to override (e.g. `velocity`).
-        indices: Indices to keep (None = all).
+        field: Dot-separated attribute path to extract (e.g.
+            "joint_state.position", "gripper_pos", "pose.position").
+        type: Value type at the resolved path.
+            - "list": numeric sequence; `indices` is required.
+            - "number": scalar float/int; wrapped as a 1-element array.
+            - "struct": named-field object (e.g. geometry_msgs/Point);
+              `keys` is required.
+        indices: Elements to keep (required when type == "list"); out-of-range
+            indices are filled with 0.0 to keep a fixed-length vector.
+        keys: Attribute names to extract in order (required when
+            type == "struct").
         names: Per-dimension labels recorded into info.json (None = auto).
         interpolation: "linear" or "nearest".
     """
 
     topic: str
-    field: str | None = None
+    field: str
+    type: FieldType
     indices: list[int] | None = None
+    keys: list[str] | None = None
     names: list[str] | None = None
     interpolation: str = DEFAULT_INTERPOLATION
 

--- a/backend/app/features/lerobot_export/models.py
+++ b/backend/app/features/lerobot_export/models.py
@@ -26,12 +26,15 @@ class SourceConfig:
     Attributes:
         topic: ROS2 topic name.
         field: Dot-separated attribute path to extract (e.g.
-            "joint_state.position", "gripper_pos", "pose.position").
+            "joint_state.position", "gripper_pos", "pose.position"). None
+            means apply extraction directly to the decoded message itself
+            (used for struct types where the top-level message is the target,
+            e.g. geometry_msgs/Point published as a standalone topic).
         type: Value type at the resolved path.
             - "list": numeric sequence; `indices` is required.
             - "number": scalar float/int; wrapped as a 1-element array.
             - "struct": named-field object (e.g. geometry_msgs/Point);
-              `keys` is required.
+              `keys` is required. `field` may be None.
         indices: Elements to keep (required when type == "list"); out-of-range
             indices are filled with 0.0 to keep a fixed-length vector.
         keys: Attribute names to extract in order (required when
@@ -41,7 +44,7 @@ class SourceConfig:
     """
 
     topic: str
-    field: str
+    field: str | None
     type: FieldType
     indices: list[int] | None = None
     keys: list[str] | None = None

--- a/backend/app/features/lerobot_export/writer.py
+++ b/backend/app/features/lerobot_export/writer.py
@@ -42,6 +42,7 @@ DATA_PATH_TEMPLATE = "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet
 VIDEO_PATH_TEMPLATE = "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4"
 EPISODES_PATH_TEMPLATE = "meta/episodes/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
 
+
 class FrameSink(Protocol):
     """Structural type for the per-camera video encoder (so tests can inject a fake)."""
 

--- a/backend/app/features/media/mcap_converter.py
+++ b/backend/app/features/media/mcap_converter.py
@@ -137,9 +137,7 @@ def convert_mcap(  # pragma: no cover
                 generated_files.append("telemetry.json")
                 logger.info("telemetry.json generation complete: %d frames", len(frame_timestamps))
             else:
-                logger.warning(
-                    "Cannot build JointState mapping: %s (skipping telemetry.json)", mcap_dir.name
-                )
+                logger.warning("Cannot build JointState mapping: %s (skipping telemetry.json)", mcap_dir.name)
         else:
             logger.info("No JointState topics: %s (skipping telemetry.json)", mcap_dir.name)
 
@@ -345,9 +343,7 @@ def _stream_generate_mp4(
         # Also remove incomplete file on ffmpeg error
         if output_path.exists():
             output_path.unlink()
-        raise MediaError(
-            f"ffmpeg failed (code={proc.returncode}): {stderr_bytes.decode('utf-8', errors='replace')}"
-        )
+        raise MediaError(f"ffmpeg failed (code={proc.returncode}): {stderr_bytes.decode('utf-8', errors='replace')}")
 
 
 @dataclass

--- a/backend/app/features/media/schemas.py
+++ b/backend/app/features/media/schemas.py
@@ -19,4 +19,6 @@ class VideoResponse(BaseModel):
     videos: list[str]
     progress: VideoProgress | None
     error: str | None
-    job_id: str | None = Field(..., description="ID of the in-flight generation job (subscribe to progress via SSE /api/jobs/stream)")
+    job_id: str | None = Field(
+        ..., description="ID of the in-flight generation job (subscribe to progress via SSE /api/jobs/stream)"
+    )

--- a/backend/app/features/recording/router.py
+++ b/backend/app/features/recording/router.py
@@ -120,7 +120,6 @@ def _notify_log(severity: LogSeverity, message: str) -> None:  # pragma: no cove
         logger.debug("Skipping log add because LogManager is not initialized: %s", e)
 
 
-
 def _get_qos_overrides() -> dict[str, str] | None:  # pragma: no cover
     """Fetch QoS information for subscribed topics from TopicMonitorService.
 

--- a/backend/app/features/recording/service.py
+++ b/backend/app/features/recording/service.py
@@ -265,7 +265,9 @@ class ROS2BagRecorder:
                 )
 
         if self._start_delay_sec > 0:
-            logger.info("Delaying recording start by %.2f s (waiting for camera publish ramp-up)", self._start_delay_sec)
+            logger.info(
+                "Delaying recording start by %.2f s (waiting for camera publish ramp-up)", self._start_delay_sec
+            )
             time.sleep(self._start_delay_sec)
 
         record.resume()

--- a/backend/app/features/topics/router.py
+++ b/backend/app/features/topics/router.py
@@ -68,8 +68,7 @@ async def stream_topic_image(
                 yield (
                     b"--frame\r\n"
                     b"Content-Type: image/jpeg\r\n"
-                    b"Content-Length: " + str(len(raw)).encode() + b"\r\n\r\n"
-                    + raw + b"\r\n"
+                    b"Content-Length: " + str(len(raw)).encode() + b"\r\n\r\n" + raw + b"\r\n"
                 )
             # Live mode: 30fps, otherwise 2fps
             is_live = monitor.is_live(topic)

--- a/backend/app/infra/mcap/messages.py
+++ b/backend/app/infra/mcap/messages.py
@@ -15,11 +15,7 @@ def is_image_message(decoded: Any) -> bool:
     Detection is based on the presence of `format` + `data` (bytes) fields and
     does not depend on the message type name (e.g., `sensor_msgs/msg/Image`).
     """
-    return (
-        hasattr(decoded, "format")
-        and hasattr(decoded, "data")
-        and isinstance(decoded.data, (bytes, bytearray))
-    )
+    return hasattr(decoded, "format") and hasattr(decoded, "data") and isinstance(decoded.data, (bytes, bytearray))
 
 
 def extract_joint_positions(decoded: Any) -> list[float]:

--- a/backend/tests/features/analysis/test_models.py
+++ b/backend/tests/features/analysis/test_models.py
@@ -184,9 +184,12 @@ class TestLossEvents:
         """For evenly spaced timestamps, loss_events is empty."""
         ts = [i * 0.01 for i in range(200)]  # 100 Hz, perfect
         tq = TopicQuality.from_timestamps(
-            name="/t", msg_type="sensor_msgs/msg/JointState",
-            timestamps=ts, sizes=[100] * len(ts),
-            recording_start=0.0, duration_sec=2.0,
+            name="/t",
+            msg_type="sensor_msgs/msg/JointState",
+            timestamps=ts,
+            sizes=[100] * len(ts),
+            recording_start=0.0,
+            duration_sec=2.0,
             timestamp_source="header_stamp",
         )
         assert tq.loss_events == []
@@ -199,9 +202,12 @@ class TestLossEvents:
         # ts[24]=0.24 -> next is 0.26 (20 ms later, one frame lost)
         ts += [0.26 + i * 0.01 for i in range(25)]
         tq = TopicQuality.from_timestamps(
-            name="/t", msg_type="sensor_msgs/msg/JointState",
-            timestamps=ts, sizes=[100] * len(ts),
-            recording_start=0.0, duration_sec=0.5,
+            name="/t",
+            msg_type="sensor_msgs/msg/JointState",
+            timestamps=ts,
+            sizes=[100] * len(ts),
+            recording_start=0.0,
+            duration_sec=0.5,
             timestamp_source="header_stamp",
         )
         assert len(tq.loss_events) >= 1
@@ -213,9 +219,12 @@ class TestLossEvents:
         # 100 Hz: 10 ms interval, with a gap after 50 ms
         ts = [i * 0.01 for i in range(50)] + [0.5 + 0.06 + i * 0.01 for i in range(50)]
         tq = TopicQuality.from_timestamps(
-            name="/t", msg_type="sensor_msgs/msg/JointState",
-            timestamps=ts, sizes=[100] * len(ts),
-            recording_start=0.0, duration_sec=1.1,
+            name="/t",
+            msg_type="sensor_msgs/msg/JointState",
+            timestamps=ts,
+            sizes=[100] * len(ts),
+            recording_start=0.0,
+            duration_sec=1.1,
             timestamp_source="header_stamp",
         )
         major_events = [e for e in tq.loss_events if e.severity == "major"]
@@ -226,9 +235,12 @@ class TestLossEvents:
         """timestamp_source is recorded in the report."""
         ts = [i * 0.01 for i in range(20)]
         tq = TopicQuality.from_timestamps(
-            name="/t", msg_type="sensor_msgs/msg/JointState",
-            timestamps=ts, sizes=[100] * len(ts),
-            recording_start=0.0, duration_sec=0.2,
+            name="/t",
+            msg_type="sensor_msgs/msg/JointState",
+            timestamps=ts,
+            sizes=[100] * len(ts),
+            recording_start=0.0,
+            duration_sec=0.2,
             timestamp_source="header_stamp",
         )
         assert tq.timestamp_source == "header_stamp"
@@ -237,9 +249,12 @@ class TestLossEvents:
         """loss_events is empty when there are fewer than 4 intervals (IQR cannot be computed)."""
         ts = [0.0, 0.01, 0.02]
         tq = TopicQuality.from_timestamps(
-            name="/t", msg_type="sensor_msgs/msg/JointState",
-            timestamps=ts, sizes=[100] * len(ts),
-            recording_start=0.0, duration_sec=0.02,
+            name="/t",
+            msg_type="sensor_msgs/msg/JointState",
+            timestamps=ts,
+            sizes=[100] * len(ts),
+            recording_start=0.0,
+            duration_sec=0.02,
             timestamp_source="header_stamp",
         )
         assert tq.loss_events == []

--- a/backend/tests/features/lerobot_export/test_config_loader.py
+++ b/backend/tests/features/lerobot_export/test_config_loader.py
@@ -63,6 +63,18 @@ def test_parse_source_invalid_type_raises() -> None:
         parse_config(data)
 
 
+def test_parse_source_list_without_indices_raises() -> None:
+    data = {**_VALID, "action": [{"topic": "/cmd", "field": "position", "type": "list"}]}
+    with pytest.raises(ValueError, match="indices"):
+        parse_config(data)
+
+
+def test_parse_source_struct_without_keys_raises() -> None:
+    data = {**_VALID, "action": [{"topic": "/cmd", "field": "pose.position", "type": "struct"}]}
+    with pytest.raises(ValueError, match="keys"):
+        parse_config(data)
+
+
 def test_parse_source_keys_stored() -> None:
     data = {
         **_VALID,

--- a/backend/tests/features/lerobot_export/test_config_loader.py
+++ b/backend/tests/features/lerobot_export/test_config_loader.py
@@ -3,24 +3,24 @@
 import pytest
 
 from app.features.lerobot_export.config_loader import has_active_config, load_active_config, parse_config
-from app.settings import RecordingConfig
+from app.settings import RobotConfig
 
 _VALID = {
     "fps": 20,
     "robot_type": "demo",
     "images": {"cam": "/img"},
-    "observation": {"state": [{"topic": "/state", "field": "position"}]},
-    "action": [{"topic": "/cmd", "field": "position", "interpolation": "nearest"}],
+    "observation": {"state": [{"topic": "/state", "field": "position", "type": "list", "indices": [0, 1]}]},
+    "action": [{"topic": "/cmd", "field": "position", "type": "list", "indices": [0, 1], "interpolation": "nearest"}],
 }
 
 
 def test_has_active_config() -> None:
-    assert has_active_config(RecordingConfig(lerobot_export=_VALID)) is True
-    assert has_active_config(RecordingConfig()) is False
+    assert has_active_config(RobotConfig(lerobot_export=_VALID)) is True
+    assert has_active_config(RobotConfig()) is False
 
 
 def test_load_active_config() -> None:
-    config = load_active_config(RecordingConfig(lerobot_export=_VALID))
+    config = load_active_config(RobotConfig(lerobot_export=_VALID))
     assert config.fps == 20
     assert config.robot_type == "demo"
     assert config.images == {"cam": "/img"}
@@ -30,12 +30,12 @@ def test_load_active_config() -> None:
 
 def test_load_active_config_not_configured() -> None:
     with pytest.raises(ValueError, match="No `lerobot_export`"):
-        load_active_config(RecordingConfig())
+        load_active_config(RobotConfig())
 
 
 def test_load_active_config_malformed() -> None:
     with pytest.raises(ValueError, match="images"):
-        load_active_config(RecordingConfig(lerobot_export={"observation": {}, "action": []}))
+        load_active_config(RobotConfig(lerobot_export={"observation": {}, "action": []}))
 
 
 @pytest.mark.parametrize("missing", ["images", "observation", "action"])
@@ -45,17 +45,29 @@ def test_parse_config_missing_key(missing: str) -> None:
         parse_config(data)
 
 
-def test_parse_config_invalid_time_range() -> None:
-    with pytest.raises(ValueError, match="time_range"):
-        parse_config({**_VALID, "time_range": "middle"})
+def test_parse_source_missing_field_raises() -> None:
+    data = {**_VALID, "action": [{"topic": "/cmd", "type": "list", "indices": [0]}]}
+    with pytest.raises(ValueError, match="'field'"):
+        parse_config(data)
 
 
-def test_parse_config_observation_not_a_mapping() -> None:
-    # Structural error (observation is a list) must normalize to ValueError, not 500.
-    with pytest.raises(ValueError, match="Malformed"):
-        parse_config({**_VALID, "observation": [{"topic": "/state"}]})
+def test_parse_source_missing_type_raises() -> None:
+    data = {**_VALID, "action": [{"topic": "/cmd", "field": "position", "indices": [0]}]}
+    with pytest.raises(ValueError, match="'type'"):
+        parse_config(data)
 
 
-def test_parse_config_source_missing_topic() -> None:
-    with pytest.raises(ValueError, match="Malformed"):
-        parse_config({**_VALID, "action": [{"field": "position"}]})
+def test_parse_source_invalid_type_raises() -> None:
+    data = {**_VALID, "action": [{"topic": "/cmd", "field": "position", "type": "vector", "indices": [0]}]}
+    with pytest.raises(ValueError, match="vector"):
+        parse_config(data)
+
+
+def test_parse_source_keys_stored() -> None:
+    data = {
+        **_VALID,
+        "action": [{"topic": "/cmd", "field": "pose.position", "type": "struct", "keys": ["x", "y", "z"]}],
+    }
+    config = parse_config(data)
+    assert config.action[0].keys == ["x", "y", "z"]
+    assert config.action[0].type == "struct"

--- a/backend/tests/features/lerobot_export/test_config_loader.py
+++ b/backend/tests/features/lerobot_export/test_config_loader.py
@@ -3,7 +3,7 @@
 import pytest
 
 from app.features.lerobot_export.config_loader import has_active_config, load_active_config, parse_config
-from app.settings import RobotConfig
+from app.settings import RecordingConfig
 
 _VALID = {
     "fps": 20,
@@ -15,12 +15,12 @@ _VALID = {
 
 
 def test_has_active_config() -> None:
-    assert has_active_config(RobotConfig(lerobot_export=_VALID)) is True
-    assert has_active_config(RobotConfig()) is False
+    assert has_active_config(RecordingConfig(lerobot_export=_VALID)) is True
+    assert has_active_config(RecordingConfig()) is False
 
 
 def test_load_active_config() -> None:
-    config = load_active_config(RobotConfig(lerobot_export=_VALID))
+    config = load_active_config(RecordingConfig(lerobot_export=_VALID))
     assert config.fps == 20
     assert config.robot_type == "demo"
     assert config.images == {"cam": "/img"}
@@ -30,12 +30,12 @@ def test_load_active_config() -> None:
 
 def test_load_active_config_not_configured() -> None:
     with pytest.raises(ValueError, match="No `lerobot_export`"):
-        load_active_config(RobotConfig())
+        load_active_config(RecordingConfig())
 
 
 def test_load_active_config_malformed() -> None:
     with pytest.raises(ValueError, match="images"):
-        load_active_config(RobotConfig(lerobot_export={"observation": {}, "action": []}))
+        load_active_config(RecordingConfig(lerobot_export={"observation": {}, "action": []}))
 
 
 @pytest.mark.parametrize("missing", ["images", "observation", "action"])

--- a/backend/tests/features/lerobot_export/test_converter.py
+++ b/backend/tests/features/lerobot_export/test_converter.py
@@ -69,7 +69,7 @@ def test_probe_feature_spec() -> None:
                 SourceConfig(topic="/state", field="position", type="list", indices=[0, 1], names=["a", "b"]),
             ]
         },
-    action=[SourceConfig(topic="/cmd", field="position", type="list", indices=[0, 1])]
+        action=[SourceConfig(topic="/cmd", field="position", type="list", indices=[0, 1])],
     )
     messages = {
         "/img": [image_message(0, size=4)],

--- a/backend/tests/features/lerobot_export/test_converter.py
+++ b/backend/tests/features/lerobot_export/test_converter.py
@@ -13,8 +13,8 @@ MS = 1_000_000  # nanoseconds per millisecond
 def _config(**overrides: object) -> ExportConfig:
     base: dict = {
         "images": {"cam": "/img"},
-        "observation": {"state": [SourceConfig(topic="/state", field="position")]},
-        "action": [SourceConfig(topic="/cmd", field="position")],
+        "observation": {"state": [SourceConfig(topic="/state", field="position", type="list", indices=[0])]},
+        "action": [SourceConfig(topic="/cmd", field="position", type="list", indices=[0])],
         "sync_tolerance_ms": 1000.0,
         "image_tolerance_ms": 1000.0,
     }
@@ -66,9 +66,10 @@ def test_probe_feature_spec() -> None:
     config = _config(
         observation={
             "state": [
-                SourceConfig(topic="/state", field="position", names=["a", "b"]),
+                SourceConfig(topic="/state", field="position", type="list", indices=[0, 1], names=["a", "b"]),
             ]
         },
+    action=[SourceConfig(topic="/cmd", field="position", type="list", indices=[0, 1])]
     )
     messages = {
         "/img": [image_message(0, size=4)],
@@ -163,8 +164,8 @@ def test_iter_episode_frames_multi_source_concat() -> None:
     config = _config(
         observation={
             "state": [
-                SourceConfig(topic="/state", field="position"),
-                SourceConfig(topic="/cmd", field="position"),
+                SourceConfig(topic="/state", field="position", type="list", indices=[0, 1]),
+                SourceConfig(topic="/cmd", field="position", type="list", indices=[0]),
             ]
         },
     )

--- a/backend/tests/features/lerobot_export/test_extract.py
+++ b/backend/tests/features/lerobot_export/test_extract.py
@@ -11,6 +11,7 @@ from ._fakes import FakeFloatArray, FakeJointState, FakeRawImage, make_image_mes
 
 # --- extract_field_data: type=number ---
 
+
 def test_extract_number_scalar_float() -> None:
     msg = SimpleNamespace(gripper_pos=0.75)
     assert extract_field_data(msg, "gripper_pos", "number").tolist() == [0.75]
@@ -22,6 +23,7 @@ def test_extract_number_via_dot_path() -> None:
 
 
 # --- extract_field_data: type=list ---
+
 
 def test_extract_list_with_indices() -> None:
     msg = FakeJointState(position=[0.0, 1.0, 2.0, 3.0])
@@ -45,6 +47,7 @@ def test_extract_list_missing_indices_raises() -> None:
 
 
 # --- extract_field_data: type=struct ---
+
 
 def test_extract_struct_with_keys() -> None:
     msg = SimpleNamespace(pose=SimpleNamespace(position=SimpleNamespace(x=1.0, y=2.0, z=3.0)))
@@ -78,6 +81,7 @@ def test_extract_struct_key_not_found_raises() -> None:
 
 # --- error cases ---
 
+
 def test_extract_missing_field_raises() -> None:
     with pytest.raises(ValueError, match="has no field"):
         extract_field_data(FakeJointState(position=[0.0]), "effort", "list", indices=[0])
@@ -95,6 +99,7 @@ def test_extract_unknown_type_raises() -> None:
 
 
 # --- decode_ros_image ---
+
 
 def test_decode_compressed_image() -> None:
     msg = make_image_message(height=3, width=4, value=200)

--- a/backend/tests/features/lerobot_export/test_extract.py
+++ b/backend/tests/features/lerobot_export/test_extract.py
@@ -52,6 +52,13 @@ def test_extract_struct_with_keys() -> None:
     assert result.tolist() == [1.0, 2.0, 3.0]
 
 
+def test_extract_struct_no_field_applies_keys_to_decoded() -> None:
+    # geometry_msgs/Point published as top-level: field=None, keys on decoded directly
+    msg = SimpleNamespace(x=-0.183, y=0.481, z=0.274)
+    result = extract_field_data(msg, None, "struct", keys=["x", "y", "z"])
+    assert result.tolist() == pytest.approx([-0.183, 0.481, 0.274])
+
+
 def test_extract_struct_partial_keys() -> None:
     msg = SimpleNamespace(pos=SimpleNamespace(x=5.0, y=6.0, z=7.0))
     assert extract_field_data(msg, "pos", "struct", keys=["x", "z"]).tolist() == [5.0, 7.0]

--- a/backend/tests/features/lerobot_export/test_extract.py
+++ b/backend/tests/features/lerobot_export/test_extract.py
@@ -9,7 +9,6 @@ from app.features.lerobot_export.extract import decode_ros_image, extract_field_
 
 from ._fakes import FakeFloatArray, FakeJointState, FakeRawImage, make_image_message, make_png_bytes
 
-
 # --- extract_field_data: type=number ---
 
 def test_extract_number_scalar_float() -> None:

--- a/backend/tests/features/lerobot_export/test_extract.py
+++ b/backend/tests/features/lerobot_export/test_extract.py
@@ -10,50 +10,85 @@ from app.features.lerobot_export.extract import decode_ros_image, extract_field_
 from ._fakes import FakeFloatArray, FakeJointState, FakeRawImage, make_image_message, make_png_bytes
 
 
-def test_extract_default_joint_position() -> None:
+# --- extract_field_data: type=number ---
+
+def test_extract_number_scalar_float() -> None:
+    msg = SimpleNamespace(gripper_pos=0.75)
+    assert extract_field_data(msg, "gripper_pos", "number").tolist() == [0.75]
+
+
+def test_extract_number_via_dot_path() -> None:
+    msg = SimpleNamespace(arm=SimpleNamespace(speed=1.5))
+    assert extract_field_data(msg, "arm.speed", "number").tolist() == [1.5]
+
+
+# --- extract_field_data: type=list ---
+
+def test_extract_list_with_indices() -> None:
     msg = FakeJointState(position=[0.0, 1.0, 2.0, 3.0])
-    assert extract_field_data(msg, field=None).tolist() == [0.0, 1.0, 2.0, 3.0]
+    assert extract_field_data(msg, "position", "list", indices=[3, 1]).tolist() == [3.0, 1.0]
 
 
-def test_extract_default_nested_joint_state() -> None:
-    msg = SimpleNamespace(joint_state=SimpleNamespace(position=[7.0, 8.0]))
-    assert extract_field_data(msg, field=None).tolist() == [7.0, 8.0]
+def test_extract_list_dot_path() -> None:
+    msg = SimpleNamespace(joint_state=FakeJointState(position=[10.0, 20.0, 30.0]))
+    assert extract_field_data(msg, "joint_state.position", "list", indices=[0, 2]).tolist() == [10.0, 30.0]
 
 
-def test_extract_default_falls_back_to_data() -> None:
-    assert extract_field_data(FakeFloatArray(data=[1.5, 2.5]), field=None).tolist() == [1.5, 2.5]
-
-
-def test_extract_default_no_vector() -> None:
-    with pytest.raises(ValueError, match="Cannot extract a vector"):
-        extract_field_data(SimpleNamespace(header="x"), field=None)
-
-
-def test_extract_explicit_field_with_indices() -> None:
-    msg = FakeJointState(position=[0.0], velocity=[5.0, 6.0, 7.0])
-    assert extract_field_data(msg, field="velocity", indices=[2, 0]).tolist() == [7.0, 5.0]
-
-
-def test_extract_indices_out_of_range_padded() -> None:
+def test_extract_list_indices_out_of_range_padded() -> None:
     msg = FakeFloatArray(data=[1.0, 2.0])
-    assert extract_field_data(msg, field="data", indices=[0, 5]).tolist() == [1.0, 0.0]
+    assert extract_field_data(msg, "data", "list", indices=[0, 5]).tolist() == [1.0, 0.0]
 
 
-def test_extract_explicit_field_missing() -> None:
+def test_extract_list_missing_indices_raises() -> None:
+    msg = FakeJointState(position=[0.0, 1.0])
+    with pytest.raises(ValueError, match="indices"):
+        extract_field_data(msg, "position", "list")
+
+
+# --- extract_field_data: type=struct ---
+
+def test_extract_struct_with_keys() -> None:
+    msg = SimpleNamespace(pose=SimpleNamespace(position=SimpleNamespace(x=1.0, y=2.0, z=3.0)))
+    result = extract_field_data(msg, "pose.position", "struct", keys=["x", "y", "z"])
+    assert result.tolist() == [1.0, 2.0, 3.0]
+
+
+def test_extract_struct_partial_keys() -> None:
+    msg = SimpleNamespace(pos=SimpleNamespace(x=5.0, y=6.0, z=7.0))
+    assert extract_field_data(msg, "pos", "struct", keys=["x", "z"]).tolist() == [5.0, 7.0]
+
+
+def test_extract_struct_missing_keys_raises() -> None:
+    msg = SimpleNamespace(pos=SimpleNamespace(x=1.0))
+    with pytest.raises(ValueError, match="keys"):
+        extract_field_data(msg, "pos", "struct")
+
+
+def test_extract_struct_key_not_found_raises() -> None:
+    msg = SimpleNamespace(pos=SimpleNamespace(x=1.0))
+    with pytest.raises(ValueError, match="pos"):
+        extract_field_data(msg, "pos", "struct", keys=["x", "w"])
+
+
+# --- error cases ---
+
+def test_extract_missing_field_raises() -> None:
     with pytest.raises(ValueError, match="has no field"):
-        extract_field_data(FakeJointState(position=[0.0]), field="effort")
+        extract_field_data(FakeJointState(position=[0.0]), "effort", "list", indices=[0])
 
 
-def test_extract_explicit_scalar_field() -> None:
-    # std_msgs/Float64 .data is a scalar (e.g. gripper openness) → length-1 vector.
-    msg = SimpleNamespace(data=0.55)
-    assert extract_field_data(msg, field="data").tolist() == [0.55]
+def test_extract_missing_dot_path_raises() -> None:
+    with pytest.raises(ValueError, match="has no field"):
+        extract_field_data(SimpleNamespace(a=SimpleNamespace()), "a.b.c", "number")
 
 
-def test_extract_default_scalar_data() -> None:
-    # Structure detection falls back to a scalar `data` field.
-    assert extract_field_data(SimpleNamespace(data=0.55), field=None).tolist() == [0.55]
+def test_extract_unknown_type_raises() -> None:
+    msg = FakeJointState(position=[0.0])
+    with pytest.raises(ValueError, match="Unknown field type"):
+        extract_field_data(msg, "position", "vector", indices=[0])
 
+
+# --- decode_ros_image ---
 
 def test_decode_compressed_image() -> None:
     msg = make_image_message(height=3, width=4, value=200)

--- a/backend/tests/features/lerobot_export/test_models.py
+++ b/backend/tests/features/lerobot_export/test_models.py
@@ -4,7 +4,7 @@ from app.features.lerobot_export.models import ExportConfig, SourceConfig
 
 
 def _src(topic: str) -> SourceConfig:
-    return SourceConfig(topic=topic, field="position")
+    return SourceConfig(topic=topic, field="position", type="list", indices=[0])
 
 
 def test_all_topics_dedupes_and_preserves_order() -> None:

--- a/backend/tests/features/lerobot_export/test_router.py
+++ b/backend/tests/features/lerobot_export/test_router.py
@@ -12,8 +12,8 @@ _MAPPING = {
     "fps": 15,
     "robot_type": "demo",
     "images": {"cam": "/img"},
-    "observation": {"state": [{"topic": "/s", "field": "position"}]},
-    "action": [{"topic": "/c", "field": "position"}],
+    "observation": {"state": [{"topic": "/s", "field": "position", "type": "list", "indices": [0]}]},
+    "action": [{"topic": "/c", "field": "position", "type": "list", "indices": [0]}],
 }
 
 

--- a/backend/tests/features/lerobot_export/test_service.py
+++ b/backend/tests/features/lerobot_export/test_service.py
@@ -33,8 +33,8 @@ class FakeSink:
 def _config(**overrides: object) -> ExportConfig:
     base: dict = {
         "images": {"cam": "/img"},
-        "observation": {"state": [SourceConfig(topic="/state", field="position")]},
-        "action": [SourceConfig(topic="/cmd", field="position")],
+        "observation": {"state": [SourceConfig(topic="/state", field="position", type="list", indices=[0])]},
+        "action": [SourceConfig(topic="/cmd", field="position", type="list", indices=[0])],
         "fps": 10,
         "robot_type": "demo",
         "sync_tolerance_ms": 1000.0,

--- a/backend/tests/features/lerobot_export/test_validation.py
+++ b/backend/tests/features/lerobot_export/test_validation.py
@@ -42,7 +42,9 @@ def test_read_recorded_topic_counts_missing_file(tmp_path: Path) -> None:
 
 
 def test_read_recorded_topic_counts_unparseable(tmp_path: Path) -> None:
-    tmp_path.joinpath("metadata.yaml").write_text("rosbag2_bagfile_information:\n  topics_with_message_count: [", "utf-8")
+    tmp_path.joinpath("metadata.yaml").write_text(
+        "rosbag2_bagfile_information:\n  topics_with_message_count: [", "utf-8"
+    )
     assert read_recorded_topic_counts(tmp_path) == {}
 
 

--- a/backend/tests/features/lerobot_export/test_validation.py
+++ b/backend/tests/features/lerobot_export/test_validation.py
@@ -16,8 +16,8 @@ from app.features.lerobot_export.validation import (
 def _config() -> ExportConfig:
     return ExportConfig(
         images={"cam": "/img"},
-        observation={"state": [SourceConfig(topic="/state")]},
-        action=[SourceConfig(topic="/cmd")],
+        observation={"state": [SourceConfig(topic="/state", field="position", type="list", indices=[0])]},
+        action=[SourceConfig(topic="/cmd", field="position", type="list", indices=[0])],
     )
 
 

--- a/backend/tests/features/recording/test_service.py
+++ b/backend/tests/features/recording/test_service.py
@@ -74,9 +74,7 @@ class TestStart:
         with pytest.raises(RecorderError, match="ros2 command not found"):
             recorder.start(topics=["/topic"])
 
-    def test_start_mkdir_oserror_raises(
-        self, recorder: ROS2BagRecorder, mock_ros2: MagicMock
-    ) -> None:
+    def test_start_mkdir_oserror_raises(self, recorder: ROS2BagRecorder, mock_ros2: MagicMock) -> None:
         """A failure to create the output directory raises RecorderError."""
         with (
             patch.object(Path, "mkdir", side_effect=OSError("Permission denied")),
@@ -136,9 +134,7 @@ class TestStartWithQoSOverrides:
 class TestStartDiscovery:
     """Tests for waiting on DDS discovery."""
 
-    def test_start_calls_wait_for_subscriptions(
-        self, recorder: ROS2BagRecorder, mock_ros2: MagicMock
-    ) -> None:
+    def test_start_calls_wait_for_subscriptions(self, recorder: ROS2BagRecorder, mock_ros2: MagicMock) -> None:
         """start() calls wait_for_subscriptions."""
         mock_record = mock_ros2.bag_record.return_value
         mock_record.wait_for_subscriptions.return_value = ["/topic"]
@@ -148,9 +144,7 @@ class TestStartDiscovery:
         mock_record.wait_for_subscriptions.assert_called_once_with(["/topic"], 10)
         mock_record.resume.assert_called_once()
 
-    def test_start_resumes_even_on_partial_discovery(
-        self, recorder: ROS2BagRecorder, mock_ros2: MagicMock
-    ) -> None:
+    def test_start_resumes_even_on_partial_discovery(self, recorder: ROS2BagRecorder, mock_ros2: MagicMock) -> None:
         """Starts recording even when only some topics could be subscribed."""
         mock_record = mock_ros2.bag_record.return_value
         mock_record.wait_for_subscriptions.return_value = ["/topic_a"]
@@ -160,9 +154,7 @@ class TestStartDiscovery:
         mock_record.resume.assert_called_once()
         assert recorder.is_recording is True
 
-    def test_start_skips_discovery_when_timeout_zero(
-        self, settings: MagicMock, mock_ros2: MagicMock
-    ) -> None:
+    def test_start_skips_discovery_when_timeout_zero(self, settings: MagicMock, mock_ros2: MagicMock) -> None:
         """When discovery_timeout=0, recording starts immediately without waiting."""
         settings.recording_discovery_timeout = 0
         rec = ROS2BagRecorder(settings, mock_ros2)
@@ -177,9 +169,7 @@ class TestStartDiscovery:
 class TestStartDelay:
     """Tests for recording_start_delay_sec."""
 
-    def test_start_delay_sleeps_before_resume(
-        self, settings: MagicMock, mock_ros2: MagicMock
-    ) -> None:
+    def test_start_delay_sleeps_before_resume(self, settings: MagicMock, mock_ros2: MagicMock) -> None:
         """When start_delay_sec > 0, time.sleep is called before resume."""
         settings.recording_start_delay_sec = 2.0
         rec = ROS2BagRecorder(settings, mock_ros2)
@@ -191,9 +181,7 @@ class TestStartDelay:
         mock_sleep.assert_called_once_with(2.0)
         mock_record.resume.assert_called_once()
 
-    def test_start_delay_zero_skips_sleep(
-        self, settings: MagicMock, mock_ros2: MagicMock
-    ) -> None:
+    def test_start_delay_zero_skips_sleep(self, settings: MagicMock, mock_ros2: MagicMock) -> None:
         """When start_delay_sec = 0, time.sleep is not called."""
         settings.recording_start_delay_sec = 0.0
         rec = ROS2BagRecorder(settings, mock_ros2)
@@ -203,9 +191,7 @@ class TestStartDelay:
 
         mock_sleep.assert_not_called()
 
-    def test_start_delay_applies_after_discovery(
-        self, settings: MagicMock, mock_ros2: MagicMock
-    ) -> None:
+    def test_start_delay_applies_after_discovery(self, settings: MagicMock, mock_ros2: MagicMock) -> None:
         """start_delay_sec is applied after wait_for_subscriptions."""
         settings.recording_start_delay_sec = 1.5
         rec = ROS2BagRecorder(settings, mock_ros2)
@@ -307,9 +293,7 @@ class TestGetStatus:
 class TestMetaWrite:
     """Tests for writing recording_meta.json."""
 
-    def test_meta_written_on_start(
-        self, settings: MagicMock, mock_ros2: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_meta_written_on_start(self, settings: MagicMock, mock_ros2: MagicMock, tmp_path: Path) -> None:
         """On successful start(), recording_meta.json is written to the output folder."""
         settings.output_dir = tmp_path
 
@@ -367,9 +351,7 @@ class TestMetaWrite:
         data = json.loads((output / "recording_meta.json").read_text(encoding="utf-8"))
         assert data["recording_config_name"] == "myrobot"
 
-    def test_meta_write_failure_does_not_break_recording(
-        self, recorder: ROS2BagRecorder
-    ) -> None:
+    def test_meta_write_failure_does_not_break_recording(self, recorder: ROS2BagRecorder) -> None:
         """Recording continues even if writing recording_meta.json fails (output dir not created).
 
         conftest's output_dir=/tmp/test_output exists, but the mock bag_record does not
@@ -383,9 +365,7 @@ class TestMetaWrite:
 class TestDetectCrash:
     """Tests for detecting abnormal process termination."""
 
-    def test_crash_detected_on_get_status(
-        self, recorder: ROS2BagRecorder, mock_ros2: MagicMock
-    ) -> None:
+    def test_crash_detected_on_get_status(self, recorder: ROS2BagRecorder, mock_ros2: MagicMock) -> None:
         """Abnormal process termination is detected in get_status() and the state is reset."""
         mock_process = mock_ros2.bag_record.return_value.process
         recorder.start(topics=["/topic"])
@@ -397,9 +377,7 @@ class TestDetectCrash:
         status = recorder.get_status()
         assert status.is_recording is False
 
-    def test_crash_calls_cleanup(
-        self, recorder: ROS2BagRecorder, mock_ros2: MagicMock
-    ) -> None:
+    def test_crash_calls_cleanup(self, recorder: ROS2BagRecorder, mock_ros2: MagicMock) -> None:
         """The pty master is cleaned up when an abnormal exit is detected."""
         mock_record = mock_ros2.bag_record.return_value
         recorder.start(topics=["/topic"])
@@ -409,9 +387,7 @@ class TestDetectCrash:
         recorder.get_status()
         mock_record.cleanup.assert_called_once()
 
-    def test_crash_cleans_up_qos_file(
-        self, recorder: ROS2BagRecorder, mock_ros2: MagicMock
-    ) -> None:
+    def test_crash_cleans_up_qos_file(self, recorder: ROS2BagRecorder, mock_ros2: MagicMock) -> None:
         """The QoS file is also cleaned up when an abnormal exit is detected."""
         mock_record = mock_ros2.bag_record.return_value
         recorder.start(topics=["/topic"], qos_overrides={"/topic": "reliable"})
@@ -422,9 +398,7 @@ class TestDetectCrash:
         recorder.get_status()
         assert recorder._qos_file is None
 
-    def test_no_false_positive_while_running(
-        self, recorder: ROS2BagRecorder, mock_ros2: MagicMock
-    ) -> None:
+    def test_no_false_positive_while_running(self, recorder: ROS2BagRecorder, mock_ros2: MagicMock) -> None:
         """poll()=None (still running) is not treated as an abnormal exit."""
         recorder.start(topics=["/topic"])
 

--- a/backend/tests/features/validation/test_cache.py
+++ b/backend/tests/features/validation/test_cache.py
@@ -48,7 +48,5 @@ class TestSaveLoad:
 
     def test_load_invalid_schema_returns_none(self, tmp_path: Path) -> None:
         """Valid JSON but a schema mismatch yields None."""
-        (tmp_path / CACHE_FILENAME).write_text(
-            json.dumps({"unexpected": "field"}), encoding="utf-8"
-        )
+        (tmp_path / CACHE_FILENAME).write_text(json.dumps({"unexpected": "field"}), encoding="utf-8")
         assert load_report(tmp_path) is None

--- a/backend/tests/features/validation/test_registry.py
+++ b/backend/tests/features/validation/test_registry.py
@@ -51,9 +51,7 @@ class TestRegisterValidator:
         with pytest.raises(ValueError, match="'name'"):
             register_validator(_EmptyName)
 
-    def test_duplicate_name_logs_warning_but_keeps_both(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_duplicate_name_logs_warning_but_keeps_both(self, caplog: pytest.LogCaptureFixture) -> None:
         register_validator(_OkValidator)
 
         class _OkDup(RecordingValidator):
@@ -85,9 +83,7 @@ class TestLoadCustomValidators:
         assert len(validators) == 1
         assert validators[0].name == "sample_validator"
 
-    def test_load_mixed_plugin_isolates_failures(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_load_mixed_plugin_isolates_failures(self, caplog: pytest.LogCaptureFixture) -> None:
         """A failing module does not prevent others from loading."""
         with caplog.at_level(logging.WARNING):
             load_custom_validators("tests.features.validation.fixtures.mixed_plugin")
@@ -98,17 +94,13 @@ class TestLoadCustomValidators:
         assert "mixed_good_validator" in names
         assert "intentional" in " ".join(r.message for r in caplog.records)
 
-    def test_load_nonexistent_package_logs_warning(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_load_nonexistent_package_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level(logging.WARNING):
             load_custom_validators("nonexistent.package.does.not.exist")
         assert any("Failed to load" in r.message for r in caplog.records)
         assert get_custom_validators() == []
 
-    def test_load_module_without_path_logs_warning(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_load_module_without_path_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         """When the import target is a module (not a package) a warning is logged."""
         with caplog.at_level(logging.WARNING):
             # `sys` is a top-level module without __path__.

--- a/backend/tests/features/validation/test_service.py
+++ b/backend/tests/features/validation/test_service.py
@@ -69,29 +69,21 @@ class TestValidationServiceGet:
         assert response.report is not None
         assert response.report.overall_status == "pass"
 
-    async def test_returns_analyzing_when_job_running(
-        self, tmp_path: Path, mock_queue: MagicMock
-    ) -> None:
+    async def test_returns_analyzing_when_job_running(self, tmp_path: Path, mock_queue: MagicMock) -> None:
         mock_queue.get_active_validation_job.return_value = _make_job(tmp_path, JobStatus.RUNNING)
 
         response = await ValidationService().get(tmp_path)
         assert response.status == "analyzing"
         assert response.report is None
 
-    async def test_returns_analyzing_when_job_queued(
-        self, tmp_path: Path, mock_queue: MagicMock
-    ) -> None:
+    async def test_returns_analyzing_when_job_queued(self, tmp_path: Path, mock_queue: MagicMock) -> None:
         mock_queue.get_active_validation_job.return_value = _make_job(tmp_path, JobStatus.QUEUED)
 
         response = await ValidationService().get(tmp_path)
         assert response.status == "analyzing"
 
-    async def test_returns_error_when_job_failed(
-        self, tmp_path: Path, mock_queue: MagicMock
-    ) -> None:
-        mock_queue.get_active_validation_job.return_value = _make_job(
-            tmp_path, JobStatus.FAILED, error="boom"
-        )
+    async def test_returns_error_when_job_failed(self, tmp_path: Path, mock_queue: MagicMock) -> None:
+        mock_queue.get_active_validation_job.return_value = _make_job(tmp_path, JobStatus.FAILED, error="boom")
 
         response = await ValidationService().get(tmp_path)
         assert response.status == "error"
@@ -100,17 +92,13 @@ class TestValidationServiceGet:
     async def test_returns_error_with_default_message_when_no_detail(
         self, tmp_path: Path, mock_queue: MagicMock
     ) -> None:
-        mock_queue.get_active_validation_job.return_value = _make_job(
-            tmp_path, JobStatus.FAILED, error=None
-        )
+        mock_queue.get_active_validation_job.return_value = _make_job(tmp_path, JobStatus.FAILED, error=None)
 
         response = await ValidationService().get(tmp_path)
         assert response.status == "error"
         assert response.error == "Validation failed"
 
-    async def test_returns_not_found_when_nothing(
-        self, tmp_path: Path, mock_queue: MagicMock
-    ) -> None:
+    async def test_returns_not_found_when_nothing(self, tmp_path: Path, mock_queue: MagicMock) -> None:
         mock_queue.get_active_validation_job.return_value = None
 
         response = await ValidationService().get(tmp_path)
@@ -129,18 +117,14 @@ class TestValidationServiceStart:
         assert response.status == "ready"
         mock_queue.enqueue_validation.assert_not_called()
 
-    async def test_returns_analyzing_when_job_running(
-        self, tmp_path: Path, mock_queue: MagicMock
-    ) -> None:
+    async def test_returns_analyzing_when_job_running(self, tmp_path: Path, mock_queue: MagicMock) -> None:
         mock_queue.get_active_validation_job.return_value = _make_job(tmp_path, JobStatus.RUNNING)
 
         response = await ValidationService().start(tmp_path)
         assert response.status == "analyzing"
         mock_queue.enqueue_validation.assert_not_called()
 
-    async def test_returns_not_found_without_quality_report(
-        self, tmp_path: Path, mock_queue: MagicMock
-    ) -> None:
+    async def test_returns_not_found_without_quality_report(self, tmp_path: Path, mock_queue: MagicMock) -> None:
         """Validation requires the quality report to be already generated."""
         mock_queue.get_active_validation_job.return_value = None
 

--- a/config/simulator.yaml
+++ b/config/simulator.yaml
@@ -27,12 +27,14 @@ recording_start_delay_sec: 0
 
 # Default topics to record (pre-selected in the UI)
 default_topics:
-  - /right_arm_depth_cam/color/image_raw/compressed
-  - /right_arm_depth_cam_2/color/image_raw/compressed
+  - /chest_depth_cam/color/image_raw/compressed
+  - /head_depth_cam/color/image_raw/compressed
   - /left_arm_depth_cam/color/image_raw/compressed
-  - /left_arm_depth_cam_2/color/image_raw/compressed
-  - /robot_master/cmd
-  - /robot_slave/states
+  - /sim/slave_arm_left
+  - /sim/slave_arm_left/gripper
+  - /sim/slave_arm_left/pose
+  - /sim/master_arm_left
+  - /sim/master_arm_left/hand
 
 # Expected Hz for quality monitoring (pattern match, first match wins).
 # Omit `hz` to enable dynamic learning (auto-computed from message intervals
@@ -41,9 +43,7 @@ default_topics:
 expected_hz_patterns:
   - pattern: "**/compressed"
     hz: 30
-  - pattern: "/robot_master/*"
-    hz:
-  - pattern: "/robot_slave/*"
+  - pattern: "/sim/**"
     hz: 100
 
 # LeRobot dataset export mapping (used by the "Export to LeRobot" action on
@@ -75,111 +75,51 @@ lerobot_export:
   # Required. Maps camera names to image topics.
   # Each entry becomes observation.images.<camera_name> in the dataset.
   images:
-    right_arm: /right_arm_depth_cam/color/image_raw/compressed
-    left_arm:  /left_arm_depth_cam/color/image_raw/compressed
-    chest:     /chest_depth_cam/color/image_raw/compressed
-    head:      /head_depth_cam/color/image_raw/compressed
+    chest: /chest_depth_cam/color/image_raw/compressed
+    head:  /head_depth_cam/color/image_raw/compressed
+    left_arm: /left_arm_depth_cam/color/image_raw/compressed
 
   # Required. Maps LeRobot field names to one or more source topics.
   # Each field becomes observation.<field_name> in the dataset.
   # Multiple sources under one field are concatenated in declaration order.
   #
   # type must be one of: list | number | struct
-  #   list   → numeric sequence (float64[], float32[]); indices selects elements (required).
+  #   list   → numeric sequence; indices selects elements (required).
   #   number → scalar float/int; becomes a 1-element array automatically.
-  #   struct → named-field object (e.g. geometry_msgs/Point); keys lists attributes (required).
+  #   struct → named-field object; keys lists sub-field names to extract (required).
   observation:
     # --- type: list ---
-    # /mcap/slave_arm_{left,right}
-    # {
-    #   "joint_state": {
-    #     "position": [-0.8235510608460442, -1.2301953232682032, 1.5731874278701288]
-    #   }
-    # }
+    # sensor_msgs/JointState: {"name": ["joint1", ...], "position": [-0.858, -1.287, 1.582, ...]}
     state:
-      - topic: /mcap/slave_arm_left
-        field: joint_state.position
+      - topic: /sim/slave_arm_left
         type: list
-        indices: [0, 1, 2]
-        names: [left_j1, left_j2, left_j3]
-        interpolation: linear
-      - topic: /mcap/slave_arm_right
-        field: joint_state.position
-        type: list
-        indices: [0, 1, 2]
-        names: [right_j1, right_j2, right_j3]
-        interpolation: linear
+        field: position
+        indices: [0, 1, 2, 3, 4, 5, 6]
 
     # --- type: number ---
-    # /mcap/slave_arm_{left,right}
-    # {
-    #   "gripper_pos": 0.006583333481103182
-    # }
+    # std_msgs/Float64: {"data": 0.033}
     gripper:
-      - topic: /mcap/slave_arm_left
-        field: gripper_pos
+      - topic: /sim/slave_arm_left/gripper
         type: number
-        names: [left_gripper]
-        interpolation: nearest
-      - topic: /mcap/slave_arm_right
-        field: gripper_pos
-        type: number
-        names: [right_gripper]
-        interpolation: nearest
+        field: data
 
     # --- type: struct ---
-    # /mcap/slave_arm_{left,right}
-    # {
-    #   "pose": {
-    #     "position": { "x": -0.151332, "y": 0.435293, "z": 0.272669 }
-    #   }
-    # }
+    # geometry_msgs/Point: {"x": -0.183, "y": 0.481, "z": 0.274}
     ee_pos:
-      - topic: /mcap/slave_arm_left
-        field: pose.position
+      - topic: /sim/slave_arm_left/pose
         type: struct
         keys: [x, y, z]
-        names: [left_ee_x, left_ee_y, left_ee_z]
-        interpolation: linear
-      - topic: /mcap/slave_arm_right
-        field: pose.position
-        type: struct
-        keys: [x, y, z]
-        names: [right_ee_x, right_ee_y, right_ee_z]
-        interpolation: linear
 
   # Required. Same source format and concatenation rules as observation.
   # All sources are concatenated into one flat action vector.
   #
-  # /mcap/master_arm_{left,right}  (rm_robot_interfaces/ArmMasterData)
-  # {
-  #   "joint_state": {
-  #     "position": [-47109.0, -70488.0, 90087.0]
-  #   },
-  #   "hand_position": [0.07999999821186066]
-  # }
+  # sensor_msgs/JointState: {"position": [-49517.0, -74117.0, ...]}  (encoder counts)
+  # std_msgs/Float64: {"data": 0.51}
   action:
-    - topic: /mcap/master_arm_left
-      field: joint_state.position
+    - topic: /sim/master_arm_left
       type: list
-      indices: [0, 1, 2]
-      names: [left_j1, left_j2, left_j3]
-      interpolation: linear
-    - topic: /mcap/master_arm_right
-      field: joint_state.position
-      type: list
-      indices: [0, 1, 2]
-      names: [right_j1, right_j2, right_j3]
-      interpolation: linear
-    - topic: /mcap/master_arm_left
-      field: hand_position
-      type: list
-      indices: [0]
-      names: [left_hand]
-      interpolation: nearest
-    - topic: /mcap/master_arm_right
-      field: hand_position
-      type: list
-      indices: [0]
-      names: [right_hand]
-      interpolation: nearest
+      field: position
+      indices: [0, 1, 2, 3, 4, 5, 6]
+    - topic: /sim/master_arm_left/hand
+      type: number
+      field: data

--- a/config/simulator.yaml
+++ b/config/simulator.yaml
@@ -1,9 +1,9 @@
-# Recording configuration (default: simulator)
+# Robot configuration (default: simulator)
 #
-# Set RECORDING_CONFIG=config/simulator.yaml in .env to use this file.
+# Set ROBOT_CONFIG=config/simulator.yaml in .env to use this file.
 # Use it as a template for a physical robot: copy to e.g. config/myrobot.yaml,
 # adjust ros_domain_id / topic names / expected Hz / stamp_quality /
-# recording_start_delay_sec, then repoint RECORDING_CONFIG at the new file.
+# recording_start_delay_sec, then repoint ROBOT_CONFIG at the new file.
 
 robot_name: RobotSimulator
 ros_domain_id: 0
@@ -27,32 +27,12 @@ recording_start_delay_sec: 0
 
 # Default topics to record (pre-selected in the UI)
 default_topics:
-  - /chest_depth_cam/color/image_raw/compressed
-  - /head_depth_cam/color/image_raw/compressed
+  - /right_arm_depth_cam/color/image_raw/compressed
+  - /right_arm_depth_cam_2/color/image_raw/compressed
   - /left_arm_depth_cam/color/image_raw/compressed
-  - /sim/slave_arm_left
-  - /sim/slave_arm_left/gripper
-  - /sim/slave_arm_left/pose
-  - /sim/master_arm_left
-  - /sim/master_arm_left/hand
-
-# Builtin validators run after each recording completes.
-# Each entry must have a `name` matching a builtin validator; remaining fields
-# are passed as arguments to that validator's constructor.
-validators:
-  - name: required_topics_present
-    topics:
-      - /chest_depth_cam/color/image_raw/compressed
-      - /head_depth_cam/color/image_raw/compressed
-      - /left_arm_depth_cam/color/image_raw/compressed
-      - /sim/slave_arm_left
-      - /sim/slave_arm_left/gripper
-      - /sim/slave_arm_left/pose
-      - /sim/master_arm_left
-      - /sim/master_arm_left/hand
-  - name: total_duration_sec
-    min_sec: 5
-    max_sec: 30
+  - /left_arm_depth_cam_2/color/image_raw/compressed
+  - /robot_master/cmd
+  - /robot_slave/states
 
 # Expected Hz for quality monitoring (pattern match, first match wins).
 # Omit `hz` to enable dynamic learning (auto-computed from message intervals
@@ -61,42 +41,145 @@ validators:
 expected_hz_patterns:
   - pattern: "**/compressed"
     hz: 30
-  - pattern: "/sim/**"
+  - pattern: "/robot_master/*"
+    hz:
+  - pattern: "/robot_slave/*"
     hz: 100
 
 # LeRobot dataset export mapping (used by the "Export to LeRobot" action on
 # /recordings). Declares how this robot's MCAP topics map to LeRobot v3.0
 # features. Omit this whole section to disable export for the robot.
-#
-#   fps                output frame rate (0 = auto-detect from the first image topic)
-#   robot_type         free-form id stored in the dataset's meta/info.json
-#   sync_tolerance_ms  time-sync tolerance for state/action sources (default 50)
-#   image_tolerance_ms time-sync tolerance for image alignment (default 200)
-#   time_range         "intersection" (default) or "union"
-#   images             {camera_name: topic}   -> observation.images.<camera_name>
-#   observation        {field: [source, ...]} -> observation.<field> (concatenated)
-#   action             [source, ...]          -> action (concatenated)
-#
-# Each source: { topic, field?, indices?, names?, interpolation? }.
-#   field          optional; omitted = structural default (JointState -> position,
-#                  Float*MultiArray -> data). Override with velocity/effort/data/...
-#   interpolation  "linear" (default) or "nearest".
 lerobot_export:
+  # Output video frame rate. 0 = auto-detect from the first image topic's
+  # message interval. (optional, default: 0)
   fps: 30
+
+  # Free-form robot identifier written to the dataset's meta/info.json.
+  # (optional, default: "custom")
   robot_type: robot_simulator
+
+  # Maximum time gap (ms) allowed when aligning state/action samples across
+  # topics. Samples farther apart than this are not paired. (optional, default: 50)
+  sync_tolerance_ms: 50.0
+
+  # Maximum time gap (ms) allowed when aligning image frames to the sync grid.
+  # (optional, default: 200)
+  image_tolerance_ms: 200.0
+
+  # How to determine the episode time span when sources have different durations.
+  # "intersection": use only the period covered by all sources (safest).
+  # "union":        extend to the full span of any source (pads missing samples).
+  # (optional, default: "intersection")
+  time_range: intersection
+
+  # Required. Maps camera names to image topics.
+  # Each entry becomes observation.images.<camera_name> in the dataset.
   images:
-    chest: /chest_depth_cam/color/image_raw/compressed
-    head: /head_depth_cam/color/image_raw/compressed
-    left_arm: /left_arm_depth_cam/color/image_raw/compressed
+    right_arm: /right_arm_depth_cam/color/image_raw/compressed
+    left_arm:  /left_arm_depth_cam/color/image_raw/compressed
+    chest:     /chest_depth_cam/color/image_raw/compressed
+    head:      /head_depth_cam/color/image_raw/compressed
+
+  # Required. Maps LeRobot field names to one or more source topics.
+  # Each field becomes observation.<field_name> in the dataset.
+  # Multiple sources under one field are concatenated in declaration order.
+  #
+  # type must be one of: list | number | struct
+  #   list   → numeric sequence (float64[], float32[]); indices selects elements (required).
+  #   number → scalar float/int; becomes a 1-element array automatically.
+  #   struct → named-field object (e.g. geometry_msgs/Point); keys lists attributes (required).
   observation:
+    # --- type: list ---
+    # /mcap/slave_arm_{left,right}
+    # {
+    #   "joint_state": {
+    #     "position": [-0.8235510608460442, -1.2301953232682032, 1.5731874278701288]
+    #   }
+    # }
     state:
-      - topic: /sim/master_arm_left
-        field: position
-        names: ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "joint7"]
-    hand:
-      - topic: /sim/master_arm_left/hand
-        field: data
+      - topic: /mcap/slave_arm_left
+        field: joint_state.position
+        type: list
+        indices: [0, 1, 2]
+        names: [left_j1, left_j2, left_j3]
+        interpolation: linear
+      - topic: /mcap/slave_arm_right
+        field: joint_state.position
+        type: list
+        indices: [0, 1, 2]
+        names: [right_j1, right_j2, right_j3]
+        interpolation: linear
+
+    # --- type: number ---
+    # /mcap/slave_arm_{left,right}
+    # {
+    #   "gripper_pos": 0.006583333481103182
+    # }
+    gripper:
+      - topic: /mcap/slave_arm_left
+        field: gripper_pos
+        type: number
+        names: [left_gripper]
+        interpolation: nearest
+      - topic: /mcap/slave_arm_right
+        field: gripper_pos
+        type: number
+        names: [right_gripper]
+        interpolation: nearest
+
+    # --- type: struct ---
+    # /mcap/slave_arm_{left,right}
+    # {
+    #   "pose": {
+    #     "position": { "x": -0.151332, "y": 0.435293, "z": 0.272669 }
+    #   }
+    # }
+    ee_pos:
+      - topic: /mcap/slave_arm_left
+        field: pose.position
+        type: struct
+        keys: [x, y, z]
+        names: [left_ee_x, left_ee_y, left_ee_z]
+        interpolation: linear
+      - topic: /mcap/slave_arm_right
+        field: pose.position
+        type: struct
+        keys: [x, y, z]
+        names: [right_ee_x, right_ee_y, right_ee_z]
+        interpolation: linear
+
+  # Required. Same source format and concatenation rules as observation.
+  # All sources are concatenated into one flat action vector.
+  #
+  # /mcap/master_arm_{left,right}  (rm_robot_interfaces/ArmMasterData)
+  # {
+  #   "joint_state": {
+  #     "position": [-47109.0, -70488.0, 90087.0]
+  #   },
+  #   "hand_position": [0.07999999821186066]
+  # }
   action:
-    - topic: /sim/slave_arm_left
-      field: position
-      names: ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "joint7"]
+    - topic: /mcap/master_arm_left
+      field: joint_state.position
+      type: list
+      indices: [0, 1, 2]
+      names: [left_j1, left_j2, left_j3]
+      interpolation: linear
+    - topic: /mcap/master_arm_right
+      field: joint_state.position
+      type: list
+      indices: [0, 1, 2]
+      names: [right_j1, right_j2, right_j3]
+      interpolation: linear
+    - topic: /mcap/master_arm_left
+      field: hand_position
+      type: list
+      indices: [0]
+      names: [left_hand]
+      interpolation: nearest
+    - topic: /mcap/master_arm_right
+      field: hand_position
+      type: list
+      indices: [0]
+      names: [right_hand]
+      interpolation: nearest

--- a/config/simulator.yaml
+++ b/config/simulator.yaml
@@ -1,9 +1,9 @@
-# Robot configuration (default: simulator)
+# Recording configuration (default: simulator)
 #
-# Set ROBOT_CONFIG=config/simulator.yaml in .env to use this file.
+# Set RECORDING_CONFIG=config/simulator.yaml in .env to use this file.
 # Use it as a template for a physical robot: copy to e.g. config/myrobot.yaml,
 # adjust ros_domain_id / topic names / expected Hz / stamp_quality /
-# recording_start_delay_sec, then repoint ROBOT_CONFIG at the new file.
+# recording_start_delay_sec, then repoint RECORDING_CONFIG at the new file.
 
 robot_name: RobotSimulator
 ros_domain_id: 0


### PR DESCRIPTION
## 概要

LeRobotエクスポートのソース設定（`SourceConfig`）において、フィールド指定を明示的なドットパスと型宣言で行うよう変更。
変換ロジックがYAML設定に完全に可視化され、設定ファイルが「どんな変換を行ったか」の履歴になるようにした。
また、変換できるデータの幅が広がったため、対応するシミュレーション用のデータを変更し、simulator.yamlでの例を変換の書き方がわかるように修正

## 背景・動機

### 暗黙の自動抽出の問題

従来の実装では `field` を省略すると `extract_joint_positions` による暗黙の自動抽出が走る。
この関数は `decoded.joint_state.position` → `decoded.position` → `decoded.neck_joint_state.position` という固定パターンでフィールドを探索するもので、以下の課題があった。

**変換できるデータに構造的な制限**

- `joint_state.position`（JointState）か `data`（Float\*MultiArray）しか自動抽出できない
- `gripper_pos`（スカラー）や `pose.position`（geometry\_msgs/Point）などは取得不可
- フィールド指定が1段階の `getattr` のみで、`joint_state.position` のようなドットパスが未対応
- スカラー値に `list()` を呼ぶため `gripper_pos: float32` を指定すると即クラッシュ

**設定を見ても変換内容がわからない**

自動抽出の挙動は `extract_joint_positions` の実装を知っている必要がある。
設定ファイルに `topic: /mcap/slave_arm_left` とだけ書かれていても、実際に何次元の何のデータが抽出されているかは内部ロジックを追わないとわからない。
また、自動抽出のロジックが将来変更された場合、同じ設定ファイルを使っても異なる変換結果になる可能性がある

### YAML設定を変換ルールの記録として機能させる

ロボット学習データセットの品質管理において「このデータセットはどう作られたか」は重要な情報。
設定ファイルに `field`・`type`・`indices`/`keys` を必須で明記することで、

- 設定ファイルを見るだけで変換の全容が把握できる
- 同じ設定を使えば同じ変換が再現できることが保証される
- どのフィールドをどのインデックスで切り出したかがデータセットと一緒に残る

ようになる。
設定の書き方は冗長になるが、再現性・説明可能性のために有用。

## 変更内容

### `SourceConfig` の拡張（`models.py`）

`field`・`type` を必須フィールドとして追加。

| フィールド | 説明 |
|---|---|
| `field` | ドット区切りの属性パス（例: `joint_state.position`, `gripper_pos`, `pose.position`） |
| `type` | `list` / `number` / `struct` のいずれか（必須） |
| `indices` | `type: list` のとき必須。取得する要素のインデックス |
| `keys` | `type: struct` のときの取得する属性名のリスト |

### 抽出ロジックの変更（`extract.py`）

- `extract_field_data` をtype駆動に書き換え
- `list` → `indices` 必須、未指定はエラー
- `number` → スカラーを `[value]` に自動ラップ
- `struct` → jsonや辞書形式のデータをパース（keysで特定のキーを指定可能）
- 不明な `type` 値はパース時にエラー
- `extract_joint_positions` への依存を削除

### シミュレータ用データの更新

`config/simulator.yaml` を更新
type(numbler, list, struct)3種類すべての使用例を記載
そのため、使用するデータ自体を更新（画像ファイルは入れ替えを行い150枚増加）

## テスト

- test_extract.py: 自動検出テストを削除し、3種類の型・ドットパス・エラーケースのテストに置き換え
- test_config_loader.py: field・type 未指定および不正 type のバリデーションテストを追加
- 既存テスト全ファイル（test_converter, test_service, test_validation, test_router, test_models）を新しい SourceConfig シグネチャに合わせて更新