### PR TITLE
fix(test): restore caplog capture under the ROS 2 environment

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,31 @@
 """Shared test configuration."""
 
+import logging
+from collections.abc import Iterator
+
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_log_propagation() -> Iterator[None]:
+    """Keep `caplog` working under the ROS 2 environment.
+
+    Tests run inside the ROS-enabled image with `/opt/ros/humble/setup.bash`
+    sourced, which auto-loads ROS pytest plugins. Loading them imports
+    `launch.logging`, which calls `logging.setLoggerClass(LaunchLogger)`; every
+    `LaunchLogger` sets `propagate = False` in its constructor. With
+    propagation disabled, `app.*` log records never reach the root logger where
+    pytest's `caplog` handler lives, so log-assertion tests see no records.
+
+    Restore the standard logger class (so loggers created later propagate
+    normally) and re-enable propagation on the `app.*` loggers that already
+    exist from collection-time imports.
+    """
+    logging.setLoggerClass(logging.Logger)
+    for name, candidate in logging.Logger.manager.loggerDict.items():
+        if isinstance(candidate, logging.Logger) and (name == "app" or name.startswith("app.")):
+            candidate.propagate = True
+    yield
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:


### PR DESCRIPTION
## Summary

`make test` failed with 5 errors where the asserted log message clearly fired (it appeared in *Captured stderr*) but `caplog.text` was empty:

- `lerobot_export/test_writer.py::test_warn_if_oversized`
- `validation/test_registry.py` — 4 tests asserting on warning logs

## Root cause

Backend tests run inside the Docker image with `/opt/ros/humble/setup.bash` sourced, which auto-loads ROS pytest plugins (`launch-testing`, `launch-testing-ros`, …). Loading them imports `launch.logging`, which at import time runs:

```python
class LaunchLogger(logging.getLoggerClass()):
    def __init__(self, *args):
        super().__init__(*args)
        self.propagate = False        # launch/logging/__init__.py
def reset():
    logging.setLoggerClass(LaunchLogger)
reset()                               # runs on import
```

`setLoggerClass(LaunchLogger)` makes **every logger created afterward** default to `propagate = False`, process-wide. With propagation disabled, `app.*` records never reach the root logger where pytest's `caplog` handler is attached — so `caplog.records` stays empty and the message falls through to `logging.lastResort` (printed raw to stderr, no format prefix).

## Fix

An autouse fixture in the root test conftest that:
1. Restores the standard logger class (`logging.setLoggerClass(logging.Logger)`) so loggers created later propagate normally, and
2. Re-enables propagation on the `app.*` loggers already created at collection time (resetting the class does not retroactively fix existing `LaunchLogger` instances).

Chosen over disabling the ROS plugins via `addopts` because the plugin entry-point names are fragile and `launch.logging` is pulled in transitively — this targets the actual mechanism and documents the gotcha.

## Verification (in the Docker test env)

- Previously-failing tests + neighbors: **11 passed**
- Full backend suite: **657 passed** (was 652 passed / 5 failed)
- `ruff check`, `ruff format --check`, `mypy` on the conftest: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)