### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the major version is `0`, minor releases may include breaking changes.
 
+## [0.2.0] - 2026-06-19
+
+This release adds two major capabilities — uploading recordings to an external
+storage destination and exporting them to the LeRobot dataset format — alongside
+validation and configuration improvements.
+
+> **Beta release.** APIs, data formats, configuration, and the web UI may
+> change without notice until v1.0.0. Docker images are not published at this
+> stage; the project is distributed as source.
+
+### Added
+
+- Upload a recording's archive to a storage destination — Amazon S3 (or any
+  S3-compatible endpoint such as MinIO / Cloudflare R2) or a local-network
+  filesystem directory — one at a time or in bulk from the recordings list. The
+  destination is pluggable and selected per machine via `UPLOAD_DESTINATION`;
+  the feature stays disabled until configured. See
+  [docs/domain/upload.md](docs/domain/upload.md) and the
+  [S3](docs/SETUP.md#s3-upload-optional) and
+  [local-network](docs/SETUP.md#local-network-upload-optional) setup guides.
+- Export selected recordings to the
+  [LeRobot v3.0](https://huggingface.co/docs/lerobot/en/lerobot-dataset-v3)
+  dataset format (parquet + per-camera H.264 MP4) and download the result as a
+  zip from the browser. Topic mapping is declared in the active recording
+  config; see the `lerobot_export` section in
+  [config/simulator.yaml](config/simulator.yaml).
+- Built-in validator parameters can be configured from the robot YAML config.
+  See [docs/domain/custom_validators.md](docs/domain/custom_validators.md).
+- Validation result details are shown as a formatted, collapsible JSON
+  accordion on the recording detail page.
+
+### Changed
+
+- `ROBOT_CONFIG` and `OUTPUT_DIR` are now required in `.env`; the backend fails
+  fast when they are unset. See [docs/SETUP.md](docs/SETUP.md).
+- Task-name validation errors are surfaced inline in the recording header editor.
+- Polished the recording page layout (relocated the Stop toggle, made the
+  monitor pane minimizable, surfaced Hz in the narrow sidebar).
+- Bumped backend and frontend dependencies.
+
+### Fixed
+
+- Removed an unreadable hover tooltip from the monitor LOSS RATE chart.
+
 ## [0.1.0] - 2026-05-28
 
 Initial public release of OpenLUTRA — a ROS2 data-recording system for robot
@@ -52,4 +96,5 @@ and development guides.
 - During the `0.y.z` phase, only the latest `main` is eligible for security
   fixes.
 
+[0.2.0]: https://github.com/fastlabel/open-lutra/releases/tag/v0.2.0
 [0.1.0]: https://github.com/fastlabel/open-lutra/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 # OpenLUTRA
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-0.1.0-orange.svg)](#release-status)
+[![Version](https://img.shields.io/badge/version-0.2.0-orange.svg)](#release-status)
 [![Status: Beta](https://img.shields.io/badge/status-beta-yellow.svg)](#release-status)
 [![CI](https://github.com/fastlabel/open-lutra/actions/workflows/ci.yml/badge.svg)](https://github.com/fastlabel/open-lutra/actions/workflows/ci.yml)
 
 **A ROS2 data-recording system for robot teaching — record topics from ROS2-compatible robots and persist them as MCAP, all driven from a web UI.**
 
-> **Release status — pre-1.0 (v0.1.0, beta).** APIs, data formats, and the CLI/UI may change without notice. Pin a specific version for any production use.
+> **Release status — pre-1.0 (v0.2.0, beta).** APIs, data formats, and the CLI/UI may change without notice. Pin a specific version for any production use.
 
 [Quickstart](#quickstart) · [Documentation](#documentation) · [Issues](https://github.com/fastlabel/open-lutra/issues) · [Security](./SECURITY.md)
 
@@ -120,7 +120,7 @@ Set the task name (for example `pick-and-place`) from the inline editor in the h
 
 ## Release status
 
-OpenLUTRA is currently **v0.1.0 (beta)** and follows the [SemVer](https://semver.org/) `0.y.z` convention: minor versions may include breaking changes until v1.0.0. Only the latest `main` is eligible for security fixes (see [SECURITY.md](./SECURITY.md)).
+OpenLUTRA is currently **v0.2.0 (beta)** and follows the [SemVer](https://semver.org/) `0.y.z` convention: minor versions may include breaking changes until v1.0.0. Only the latest `main` is eligible for security fixes (see [SECURITY.md](./SECURITY.md)).
 
 Docker images are **not** published at this stage; the project is distributed as source.
 
@@ -128,7 +128,6 @@ Docker images are **not** published at this stage; the project is distributed as
 
 Nothing on this list is committed — these are directions we are currently exploring.
 
-- **LeRobot-format export** — conversion and output of recordings to the [LeRobot](https://github.com/huggingface/lerobot) dataset format.
 - **Richer validation and quality analysis** — expand the set of built-in validators and quality metrics, and surface more actionable diagnostics in the UI.
 - **Recording labeling** — attach labels, tags, and review status to recordings to organize datasets for downstream training.
 - **Seamless storage integrations** — first-class support for shipping recorded files to various storage backends (object stores, dataset platforms, etc.).

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,7 +71,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app = FastAPI(
         title="OpenLUTRA",
         description="ROS2 topic recorder for teleoperation robots (ROS2-standard topics)",
-        version="0.1.0",
+        version="0.2.0",
         lifespan=lifespan,
     )
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-lutra"
-version = "0.1.0"
+version = "0.2.0"
 description = "ROS2 topic recorder for teleoperation robots (ROS2-standard topics)"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -806,7 +806,7 @@ wheels = [
 
 [[package]]
 name = "open-lutra"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-lutra-frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Release preparation for **v0.2.0**. Bumps the version across backend, frontend, and docs, and adds the `0.2.0` CHANGELOG entry.

The two headline features since v0.1.0 are **uploading recordings to an external storage destination** (S3-compatible or local-network) and **exporting recordings to the LeRobot v3.0 dataset format**.

## Changes

- Bump version `0.1.0` → `0.2.0` in `frontend/package.json`, `backend/pyproject.toml`, `backend/uv.lock`, and `backend/app/main.py`.
- Update the version badge and release-status notices in `README.md`, and drop the now-shipped **LeRobot-format export** item from the Roadmap.
- Add the `## [0.2.0]` section to `CHANGELOG.md` (Added / Changed / Fixed), dated 2026-06-19.

See [CHANGELOG.md](https://github.com/fastlabel/open-lutra/blob/release/v0.2.0/CHANGELOG.md) for the full v0.2.0 entry.

## Release steps after merge

After this merges to `main`, cut the release from GitHub's **Create a new release** button: create tag `v0.2.0` targeting `main`, check **Set as a pre-release** (still `0.y.z` beta, as with v0.1.0), and link the CHANGELOG in the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)