### PR TITLE
docs(config): restore validators sample in simulator.yaml

### DIFF
--- a/config/simulator.yaml
+++ b/config/simulator.yaml
@@ -36,6 +36,24 @@ default_topics:
   - /sim/master_arm_left
   - /sim/master_arm_left/hand
 
+# Builtin validators run after each recording completes.
+# Each entry must have a `name` matching a builtin validator; remaining fields
+# are passed as arguments to that validator's constructor.
+validators:
+  - name: required_topics_present
+    topics:
+      - /chest_depth_cam/color/image_raw/compressed
+      - /head_depth_cam/color/image_raw/compressed
+      - /left_arm_depth_cam/color/image_raw/compressed
+      - /sim/slave_arm_left
+      - /sim/slave_arm_left/gripper
+      - /sim/slave_arm_left/pose
+      - /sim/master_arm_left
+      - /sim/master_arm_left/hand
+  - name: total_duration_sec
+    min_sec: 5
+    max_sec: 30
+
 # Expected Hz for quality monitoring (pattern match, first match wins).
 # Omit `hz` to enable dynamic learning (auto-computed from message intervals
 # after subscribe). Example:


### PR DESCRIPTION
## Summary

PR #35 accidentally dropped the `validators:` sample from `config/simulator.yaml` while rewriting the file for the new `/sim/*` topic layout. This restores the sample so the config keeps documenting how to configure the builtin post-recording validators.

The sample is placed back in its original location (right after `default_topics`) and uses the same values as before #35.

## Verification

Confirmed the restored sample values are still valid against the current codebase before restoring:

- **Topics** — all 8 topics in `required_topics_present` are still published by the simulator (`simulator/robot_simulator.py`) and match the current `default_topics` exactly.
- **Validators** — both builtins still exist with the same names and constructor params: `required_topics_present(topics)` and `total_duration_sec(min_sec, max_sec)` (`backend/app/features/validation/builtins/`, registered in `active_set.py`).
- **YAML format** — `validators:` is still parsed by `active_set.py` as `name` + remaining fields → constructor kwargs; `RecordingConfig.validators` is unchanged in `settings.py`.

Also verified locally that validation runs against a recording with this config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)