### PR TITLE
fix(docker): enable OUTPUT_DIR from .env for the backend volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - ./backend/tests:/app/tests
       - ./config:/app/config:ro
       - ./backend/pyproject.toml:/app/pyproject.toml:ro
-      - ./output:/data/output
+      - ${OUTPUT_DIR:-./output}:/data/output
     ports:
       - "8000:8000"
     restart: unless-stopped


### PR DESCRIPTION
The backend volume mount was hardcoded to `./output`, which meant the `OUTPUT_DIR` setting in `.env` had no effect. This change makes the host-side path configurable by using `${OUTPUT_DIR:-./output}`, allowing users to customize where recordings are stored on the host machine.