### PR TITLE
Propose a convention for .env.example and update it accordingly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,54 @@
+# All configurable variables are listed here.
+# - Required variables are uncommented.
+# - Variables with defaults are commented out with their default value.
+# - Optional features are enabled where possible (e.g. upload uses local MinIO by default).
+
 # Recording config (required; specify a YAML file under the config/ directory)
 # Topics, expected Hz, ROS_DOMAIN_ID, robot name, validators, etc. are managed in YAML
 RECORDING_CONFIG=config/simulator.yaml
+# RECORDING_CONFIG=config/myrobot.yaml   # for a physical robot (copy simulator.yaml as a template)
 
 # Recording settings (required; directory where MCAP recordings are stored)
 OUTPUT_DIR=./output
 
 # Server settings
-HOST=0.0.0.0
-PORT=8000
-DEBUG=false
+# HOST=0.0.0.0
+# PORT=8000
+# DEBUG=false
+
+# Topic monitor settings
+# GAP_THRESHOLD_SEC=3.0      # seconds without a message before a topic is flagged as a gap
+# MONITOR_BUFFER_SIZE=600    # number of recent messages kept per topic for live quality monitoring
+# MAX_LOG_ENTRIES=500        # maximum number of entries kept in the log panel
+
+# Upload destination (optional; omit to disable the upload feature)
+# Set UPLOAD_DESTINATION to one of: "s3" (S3 or S3-compatible), "local" (bind-mounted directory)
+# See docs/SETUP.md for details
+
+# --- Option 1: Local MinIO for development (requires: make minio-up) ---
+UPLOAD_DESTINATION=s3
+S3_BUCKET=lutra-recordings
+S3_KEY_TEMPLATE=lutra-recordings/operation-files/{yyyymmddhhmmss}/{recording_name}.zip
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
+AWS_ENDPOINT_URL=http://minio:9000
+
+# --- Option 2: AWS S3 (or S3-compatible without a custom endpoint) ---
+# UPLOAD_DESTINATION=s3
+# S3_BUCKET=lutra-recordings
+# S3_KEY_TEMPLATE=lutra-recordings/operation-files/{yyyymmddhhmmss}/{recording_name}.zip
+# AWS_REGION=ap-northeast-1
+# AWS_ACCESS_KEY_ID=AKIA...
+# AWS_SECRET_ACCESS_KEY=...
+# AWS_SESSION_TOKEN=...             # only for temporary STS credentials
+# AWS_PROFILE=...                   # alternative to access key / secret key pair
+# AWS_ENDPOINT_URL=...              # custom S3 endpoint (R2, LocalStack, etc.)
+# S3_MULTIPART_THRESHOLD_MB=8      # boto3 default: 8 MB
+# S3_MULTIPART_CHUNKSIZE_MB=8      # boto3 default: 8 MB
+# S3_MAX_CONCURRENCY=10            # boto3 default: 10
+
+# --- Option 3: Local-network upload (NFS / SMB bind-mounted directory) ---
+# UPLOAD_DESTINATION=local
+# LOCAL_UPLOAD_DIR=/mnt/recordings
+# LOCAL_UPLOAD_PATH_TEMPLATE=operation-files/{yyyymmddhhmmss}/{recording_name}.zip

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # All configurable variables are listed here.
 # - Required variables are uncommented.
 # - Variables with defaults are commented out with their default value.
-# - Optional features are enabled where possible (e.g. upload uses local MinIO by default).
+# - Optional features are disabled by default; uncomment a block to enable (e.g. upload).
 
 # Recording config (required; specify a YAML file under the config/ directory)
 # Topics, expected Hz, ROS_DOMAIN_ID, robot name, validators, etc. are managed in YAML
@@ -26,13 +26,13 @@ OUTPUT_DIR=./output
 # See docs/SETUP.md for details
 
 # --- Option 1: Local MinIO for development (requires: make minio-up) ---
-UPLOAD_DESTINATION=s3
-S3_BUCKET=lutra-recordings
-S3_KEY_TEMPLATE=lutra-recordings/operation-files/{yyyymmddhhmmss}/{recording_name}.zip
-AWS_REGION=us-east-1
-AWS_ACCESS_KEY_ID=minioadmin
-AWS_SECRET_ACCESS_KEY=minioadmin
-AWS_ENDPOINT_URL=http://minio:9000
+# UPLOAD_DESTINATION=s3
+# S3_BUCKET=lutra-recordings
+# S3_KEY_TEMPLATE=lutra-recordings/operation-files/{yyyymmddhhmmss}/{recording_name}.zip
+# AWS_REGION=us-east-1
+# AWS_ACCESS_KEY_ID=minioadmin
+# AWS_SECRET_ACCESS_KEY=minioadmin
+# AWS_ENDPOINT_URL=http://minio:9000
 
 # --- Option 2: AWS S3 (or S3-compatible without a custom endpoint) ---
 # UPLOAD_DESTINATION=s3


### PR DESCRIPTION
## Overview

To help new users better understand the features, I believe it's beneficial to have everything fully operational right from the first launch. Additionally, allowing them to easily review all available configurations in one place provides a great onboarding experience.

Therefore, I have refactored `.env.example` based on the following guidelines:

- **Required variables** are not commented out.
- **Variables with default values** are commented out but listed with their defaults visible.
- **Optional features** are enabled by default as much as possible.

## Discussion: MinIO default

The upload feature is enabled by default using local MinIO — but MinIO requires a separate `make minio-up` to actually run. This creates a small risk of confusion for users who copy `.env.example` as-is without taking that step.

Personally, I think it would be ideal to automatically start and stop MinIO as part of `make up` / `make down`. If this PR looks good as-is, I think it makes more sense to handle that in a separate PR.