### PR TITLE
feat(recording): add Space shortcut to toggle recording start/stop (#34)

### DIFF
--- a/frontend/src/features/recording/__tests__/store.test.ts
+++ b/frontend/src/features/recording/__tests__/store.test.ts
@@ -2,15 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- Mock setup (initialized via vi.hoisted before vi.mock) ---
 
-const { mockMutateStart, mockMutateStop, mockShowMessage, mockClearMessageTimer, mockGetQueryData } = vi.hoisted(
-  () => ({
-    mockMutateStart: vi.fn(),
-    mockMutateStop: vi.fn(),
-    mockShowMessage: vi.fn(),
-    mockClearMessageTimer: vi.fn(),
-    mockGetQueryData: vi.fn((): unknown => undefined),
-  }),
-);
+const {
+  mockMutateStart,
+  mockMutateStop,
+  mockShowMessage,
+  mockClearMessageTimer,
+  mockGetQueryData,
+  mockSelectedTopics,
+} = vi.hoisted(() => ({
+  mockMutateStart: vi.fn(),
+  mockMutateStop: vi.fn(),
+  mockShowMessage: vi.fn(),
+  mockClearMessageTimer: vi.fn(),
+  mockGetQueryData: vi.fn((_key?: unknown): unknown => undefined),
+  mockSelectedTopics: { current: new Set<string>(["/topic_a", "/topic_b"]) },
+}));
 
 vi.mock("zustand/middleware", () => ({
   persist: (fn: unknown) => fn,
@@ -37,7 +43,7 @@ vi.mock("@/api/generated/recording/recording", () => ({
 vi.mock("@/features/live-topics", () => ({
   useLiveTopicsStore: {
     getState: vi.fn(() => ({
-      selectedTopics: new Set(["/topic_a", "/topic_b"]),
+      selectedTopics: mockSelectedTopics.current,
     })),
   },
 }));
@@ -66,6 +72,8 @@ describe("useRecordingStore", () => {
       message: null,
       finishedRecording: null,
     });
+    mockSelectedTopics.current = new Set(["/topic_a", "/topic_b"]);
+    mockGetQueryData.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -247,23 +255,43 @@ describe("useRecordingStore", () => {
       expect(mockShowMessage).toHaveBeenCalledWith("Countdown canceled", "error");
     });
 
-    it("calls startRecording when not recording or counting down", () => {
-      mockGetQueryData.mockReturnValue({
-        data: { is_recording: false },
-        status: 200,
-      });
+    it("starts recording when idle, connected, and a topic is selected", () => {
+      // getIsRecording reads the recording-status key; getConnectionStatus reads the SSE key.
+      mockGetQueryData.mockImplementation((key?: unknown) =>
+        Array.isArray(key) && key[0] === "recording-status"
+          ? { data: { is_recording: false }, status: 200 }
+          : "connected",
+      );
 
       useRecordingStore.getState().toggle();
 
       expect(mockMutateStart).toHaveBeenCalled();
     });
 
-    it("calls startRecording when queryData is undefined", () => {
-      mockGetQueryData.mockReturnValue(undefined);
+    it("does not start when disconnected, and shows a message", () => {
+      // recording-status undefined -> not recording; connection status -> disconnected.
+      mockGetQueryData.mockImplementation((key?: unknown) =>
+        Array.isArray(key) && key[0] === "recording-status" ? undefined : "disconnected",
+      );
 
       useRecordingStore.getState().toggle();
 
-      expect(mockMutateStart).toHaveBeenCalled();
+      expect(mockMutateStart).not.toHaveBeenCalled();
+      expect(mockShowMessage).toHaveBeenCalledWith("Cannot start recording while disconnected", "error");
+    });
+
+    it("does not start when no topic is selected, and shows a message", () => {
+      mockSelectedTopics.current = new Set();
+      mockGetQueryData.mockImplementation((key?: unknown) =>
+        Array.isArray(key) && key[0] === "recording-status"
+          ? { data: { is_recording: false }, status: 200 }
+          : "connected",
+      );
+
+      useRecordingStore.getState().toggle();
+
+      expect(mockMutateStart).not.toHaveBeenCalled();
+      expect(mockShowMessage).toHaveBeenCalledWith("Select at least one topic to record", "error");
     });
   });
 

--- a/frontend/src/features/recording/__tests__/use-record-shortcut.test.ts
+++ b/frontend/src/features/recording/__tests__/use-record-shortcut.test.ts
@@ -1,0 +1,89 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { mockToggle } = vi.hoisted(() => ({ mockToggle: vi.fn() }));
+
+vi.mock("../store", () => ({
+  useRecordingStore: {
+    getState: () => ({ toggle: mockToggle }),
+  },
+}));
+
+import { useRecordShortcut } from "../use-record-shortcut";
+
+function dispatchSpace(init: KeyboardEventInit = {}): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", { code: "Space", cancelable: true, ...init });
+  document.dispatchEvent(event);
+  return event;
+}
+
+describe("useRecordShortcut", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("toggles recording on a plain Space and prevents the default scroll", () => {
+    renderHook(() => useRecordShortcut());
+
+    const event = dispatchSpace();
+
+    expect(mockToggle).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("ignores Space combined with a modifier key", () => {
+    renderHook(() => useRecordShortcut());
+
+    dispatchSpace({ ctrlKey: true });
+
+    expect(mockToggle).not.toHaveBeenCalled();
+  });
+
+  it("ignores auto-repeat (held key)", () => {
+    renderHook(() => useRecordShortcut());
+
+    dispatchSpace({ repeat: true });
+
+    expect(mockToggle).not.toHaveBeenCalled();
+  });
+
+  it("ignores keys other than Space", () => {
+    renderHook(() => useRecordShortcut());
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { code: "Enter", cancelable: true }));
+
+    expect(mockToggle).not.toHaveBeenCalled();
+  });
+
+  it("does not fire while a text input is focused", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    renderHook(() => useRecordShortcut());
+
+    dispatchSpace();
+
+    expect(mockToggle).not.toHaveBeenCalled();
+  });
+
+  it("does not fire while a button is focused (its native Space click handles it)", () => {
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+    button.focus();
+    renderHook(() => useRecordShortcut());
+
+    dispatchSpace();
+
+    expect(mockToggle).not.toHaveBeenCalled();
+  });
+
+  it("removes the listener on unmount", () => {
+    const { unmount } = renderHook(() => useRecordShortcut());
+
+    unmount();
+    dispatchSpace();
+
+    expect(mockToggle).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/recording/record-button.tsx
+++ b/frontend/src/features/recording/record-button.tsx
@@ -4,6 +4,7 @@ import { useLiveTopicsStore } from "@/features/live-topics";
 import { useIsRecording } from "@/hooks/use-api";
 import { useConnectionStatus } from "@/hooks/use-topics-stream";
 import { useRecordingStore } from "./store";
+import { useRecordShortcut } from "./use-record-shortcut";
 
 export function RecordButton() {
   const isRecording = useIsRecording();
@@ -20,6 +21,10 @@ export function RecordButton() {
   const cannotStart = !active && (connectionStatus !== "connected" || !hasSelectedTopics);
   const disabled = loading || cannotStart;
 
+  // --- Side effects ---
+  // Space toggles recording (keyboard / foot-pedal), mirroring this button. See use-record-shortcut.
+  useRecordShortcut();
+
   return (
     // Show and pulse the outer gray border only while recording. pulse-border animates border-color only,
     // not the children's opacity (so the inner STOP icon and text do not pulse).
@@ -32,6 +37,7 @@ export function RecordButton() {
         type="button"
         disabled={disabled}
         onClick={active ? stopRecording : startRecording}
+        title={active ? "Stop recording (Space)" : "Start recording (Space)"}
         aria-label={label}
         aria-pressed={active}
         className={`flex h-20 w-[200px] cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-white text-[14px] font-bold tracking-wider text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${

--- a/frontend/src/features/recording/store.ts
+++ b/frontend/src/features/recording/store.ts
@@ -8,7 +8,9 @@ import { devtools, persist } from "zustand/middleware";
 import { getGetRecordingStatusQueryKey } from "@/api/generated/recording/recording";
 import type { RecordingStatus } from "@/api/generated/schemas";
 import { useLiveTopicsStore } from "@/features/live-topics";
+import type { SseConnectionStatus } from "@/hooks/use-topics-stream";
 import { queryClient } from "@/lib/query-client";
+import { sseKeys } from "@/lib/query-keys";
 import { createTimer } from "./create-timer";
 import { clearMessageTimer, showMessage, startRecordingMutation, stopRecordingMutation } from "./mutations";
 
@@ -78,6 +80,11 @@ function getIsRecording(): boolean {
   return resp?.status === 200 ? resp.data.is_recording : false;
 }
 
+/** Read the SSE connection status synchronously from the TanStack Query cache. */
+function getConnectionStatus(): SseConnectionStatus | undefined {
+  return queryClient.getQueryData<SseConnectionStatus>(sseKeys.connectionStatus());
+}
+
 /** Countdown one-second tick (recursive setTimeout). */
 function tick() {
   const { countdownSec } = useRecordingStore.getState();
@@ -132,12 +139,21 @@ export const useRecordingStore = create<RecordingStore>()(
         toggle: () => {
           const { isStarting, isStopping, countdownSec, stopRecording, startRecording } = get();
           if (isStarting || isStopping) return;
-          const isRecording = getIsRecording();
-          if (isRecording || countdownSec !== null) {
+          if (getIsRecording() || countdownSec !== null) {
             stopRecording();
-          } else {
-            startRecording();
+            return;
           }
+          // Mirror the record button's start preconditions (record-button.tsx): require a live
+          // connection and at least one selected topic, with feedback when a start is refused.
+          if (getConnectionStatus() !== "connected") {
+            showMessage("Cannot start recording while disconnected", "error");
+            return;
+          }
+          if (useLiveTopicsStore.getState().selectedTopics.size === 0) {
+            showMessage("Select at least one topic to record", "error");
+            return;
+          }
+          startRecording();
         },
 
         clearMessage: () => {

--- a/frontend/src/features/recording/use-record-shortcut.ts
+++ b/frontend/src/features/recording/use-record-shortcut.ts
@@ -1,0 +1,40 @@
+/** Keyboard shortcut: Space toggles recording start/stop, mirroring the Record button.
+ *
+ * Mounted by RecordButton, which renders only on the recorder page, so the shortcut is
+ * scoped to that page and torn down on navigation. Targets hands-free operation (e.g. a
+ * foot pedal that emits Space) per issue #34.
+ */
+import { useEffect } from "react";
+import { useRecordingStore } from "./store";
+
+/** True when focus is on an element that natively consumes Space or text input. */
+function isInteractiveTarget(el: Element | null): boolean {
+  if (!el) return false;
+  if (
+    el instanceof HTMLInputElement ||
+    el instanceof HTMLTextAreaElement ||
+    el instanceof HTMLSelectElement ||
+    el instanceof HTMLButtonElement
+  ) {
+    return true;
+  }
+  if (el instanceof HTMLElement && el.isContentEditable) return true;
+  return el.closest('[role="button"], [role="textbox"]') !== null;
+}
+
+export function useRecordShortcut(): void {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code !== "Space" || e.repeat) return;
+      if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+      // Skip while typing or when an element already handles Space (also avoids a double-toggle
+      // when the Record button itself is focused — its native Space click handles that case).
+      if (isInteractiveTarget(document.activeElement)) return;
+      // Space owns the recorder page; suppress the default page scroll.
+      e.preventDefault();
+      useRecordingStore.getState().toggle();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+}


### PR DESCRIPTION
## Summary

Adds a **Space** keyboard shortcut on the recorder page that toggles recording **Start/Stop**, the first step of #34.

Robot operators usually have both hands occupied (leader arm, VR controller), so hands-free control via foot pedals is common. Space is a natural, widely-recognized toggle key and a common default key for USB foot pedals.

## What changed

- **New hook `features/recording/use-record-shortcut.ts`** — a single `document` keydown listener. Acts only on a plain `Space` (no modifiers, no key-repeat) and **skips while focus is on a natively-Space / text-input element** (`input` / `textarea` / `select` / `button` / `contenteditable`, `role=button|textbox`). This protects the inline task-name editor and avoids a double-toggle when the Record button itself is focused.
- **`store.ts` — reuse the pre-built `useRecordingStore.toggle()`** (it already existed for this purpose). Closes its one gap vs. the button: the start path is now gated on an active SSE connection **and** at least one selected topic, with a transient message when refused — so the shortcut reaches full Record-button parity.
- **`record-button.tsx`** — calls `useRecordShortcut()` (so the shortcut is mounted only on the recorder page `/` and torn down on navigation) and adds a `title` tooltip for discoverability.

## Tests

- New `use-record-shortcut.test.ts` (7 cases): plain Space toggles + prevents default scroll; modifier / key-repeat / non-Space ignored; input- and button-focus guarded; listener removed on unmount.
- `store.test.ts` updated for the new start guards (connected + topic-selected) and the two refusal branches.

## Verification

- ✅ `make test-frontend` — 219 passing
- ✅ `make lint-frontend` — tsc + biome clean
- `store.ts` new branches fully covered.

> Note: `make test-cov-frontend` fails on a **pre-existing** `src/lib/**` 100% threshold breach (`chart-theme.ts` / `dev-mode.ts` report 0% under the v8 coverage `all` mode — they look like they should join `utils.ts` / `query-client.ts` in the coverage `exclude`). Unrelated to this change; overall coverage actually rose 98.13% → 98.21%. Happy to fix the config separately.

## Scope

Part of #34 — **Start/Stop only**. The remaining shortcuts are deferred to follow-up PRs: delete latest episode (#33), go to Recordings page, and delete-from-detail-page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)