### PR TITLE
perf(recordings): speed up the recordings list for 1000+ folders

### DIFF
--- a/backend/app/features/recordings/scanner.py
+++ b/backend/app/features/recordings/scanner.py
@@ -23,7 +23,9 @@ from app.features.validation.cache import load_report as load_validation_report
 
 logger = logging.getLogger(__name__)
 
-METADATA_FILENAME = "metadata.yaml"
+# The bag metadata sidecar that `ros2 bag record` writes next to the .mcap segments
+# (distinct from META_FILENAME / recording_meta.json, this app's own metadata file).
+MCAP_METADATA_FILENAME = "metadata.yaml"
 QUALITY_REPORT_FILENAME = "quality_report.json"
 
 
@@ -48,18 +50,22 @@ class _ParsedBundle:
 
 
 # Source files whose parsed contents are memoized per folder. A change to any of
-# them (mtime or size) flips the signature and invalidates that folder's entry.
+# them (mtime or size) flips the fingerprint and invalidates that folder's entry.
 _SOURCE_FILENAMES: tuple[str, ...] = (
-    METADATA_FILENAME,
+    MCAP_METADATA_FILENAME,
     META_FILENAME,
     VALIDATION_RESULT_FILENAME,
     UPLOAD_STATE_FILENAME,
 )
 
+# A per-folder cache-validity token: the (st_mtime_ns, st_size) of each source
+# file, or None when the file is absent. The cached parse is reused only while
+# this fingerprint is unchanged.
+_SourceFingerprint = tuple[tuple[int, int] | None, ...]
+
 # Per-folder cache of parse results, keyed by absolute folder path and guarded by
 # _cache_lock. Rebuilt and pruned to the folders present on every scan.
-_Signature = tuple[tuple[int, int] | None, ...]
-_parse_cache: dict[str, tuple[_Signature, _ParsedBundle]] = {}
+_parse_cache: dict[str, tuple[_SourceFingerprint, _ParsedBundle]] = {}
 _cache_lock = threading.Lock()
 
 
@@ -101,10 +107,10 @@ def scan_output_dir(output_dir: Path) -> list[FileEntry]:
     with _cache_lock:
         snapshot = dict(_parse_cache)
 
-    fresh_cache: dict[str, tuple[_Signature, _ParsedBundle]] = {}
+    fresh_cache: dict[str, tuple[_SourceFingerprint, _ParsedBundle]] = {}
     entries: list[FileEntry] = []
-    for key, signature, bundle, entry in _scan_folders(folders, output_dir, snapshot):
-        fresh_cache[key] = (signature, bundle)
+    for key, fingerprint, bundle, entry in _scan_folders(folders, output_dir, snapshot):
+        fresh_cache[key] = (fingerprint, bundle)
         entries.append(entry)
 
     # Replace the cache wholesale so deleted / renamed folders are pruned.
@@ -120,8 +126,8 @@ def scan_output_dir(output_dir: Path) -> list[FileEntry]:
 def _scan_folders(
     folders: list[Path],
     rel_root: Path,
-    snapshot: dict[str, tuple[_Signature, _ParsedBundle]],
-) -> list[tuple[str, _Signature, _ParsedBundle, FileEntry]]:
+    snapshot: dict[str, tuple[_SourceFingerprint, _ParsedBundle]],
+) -> list[tuple[str, _SourceFingerprint, _ParsedBundle, FileEntry]]:
     """Build entries for every folder concurrently (I/O-bound). None results are dropped.
 
     Each worker reads the shared `snapshot` read-only and never mutates the cache,
@@ -138,14 +144,14 @@ def _scan_folders(
 def _build_recording_entry(
     folder: Path,
     rel_root: Path,
-    cache_snapshot: dict[str, tuple[_Signature, _ParsedBundle]],
-) -> tuple[str, _Signature, _ParsedBundle, FileEntry] | None:
+    cache_snapshot: dict[str, tuple[_SourceFingerprint, _ParsedBundle]],
+) -> tuple[str, _SourceFingerprint, _ParsedBundle, FileEntry] | None:
     """Build a FileEntry (plus its cache payload) for a single recording folder.
 
     Returns None if no `.mcap` is present or the folder cannot be read. Size,
     mtime, and artifact flags are recomputed from a single `os.scandir` pass
     every call; only the parsed source-file contents are reused from the cache
-    when their (mtime, size) signature is unchanged.
+    when their (mtime, size) fingerprint is unchanged.
     """
     total_size = 0
     has_mcap = False
@@ -177,10 +183,10 @@ def _build_recording_entry(
     if not has_mcap:
         return None
 
-    signature: _Signature = tuple(source_stats.get(name) for name in _SOURCE_FILENAMES)
+    fingerprint: _SourceFingerprint = tuple(source_stats.get(name) for name in _SOURCE_FILENAMES)
     key = str(folder)
     cached = cache_snapshot.get(key)
-    bundle = cached[1] if cached is not None and cached[0] == signature else _parse_sources(folder)
+    bundle = cached[1] if cached is not None and cached[0] == fingerprint else _parse_sources(folder)
 
     entry = FileEntry(
         name=folder.name,
@@ -198,7 +204,7 @@ def _build_recording_entry(
         recording_config_name=bundle.recording_config_name,
         tags=list(bundle.tags),
     )
-    return key, signature, bundle, entry
+    return key, fingerprint, bundle, entry
 
 
 def _parse_sources(folder: Path) -> _ParsedBundle:

--- a/backend/app/features/recordings/scanner.py
+++ b/backend/app/features/recordings/scanner.py
@@ -4,18 +4,63 @@ Pure filesystem logic, split out of router.py.
 """
 
 import logging
+import os
 import re
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from pathlib import Path
 
 # Import the constant directly (not via the package __init__) to avoid eagerly
 # importing the export writer's pandas/numpy stack at recordings-scan time.
 from app.features.lerobot_export.exports import EXPORTS_DIRNAME
-from app.features.recordings.meta import read_recording_meta
+from app.features.recordings.meta import META_FILENAME, read_recording_meta
 from app.features.recordings.schemas import FileEntry
+from app.features.upload.cache import CACHE_FILENAME as UPLOAD_STATE_FILENAME
 from app.features.upload.cache import load_state as load_upload_state
+from app.features.validation.cache import CACHE_FILENAME as VALIDATION_RESULT_FILENAME
 from app.features.validation.cache import load_report as load_validation_report
 
 logger = logging.getLogger(__name__)
+
+METADATA_FILENAME = "metadata.yaml"
+QUALITY_REPORT_FILENAME = "quality_report.json"
+
+
+@dataclass(frozen=True)
+class _ParsedBundle:
+    """Memoized parse result of a recording folder's source files.
+
+    Holds everything that requires reading/parsing a file (the expensive part).
+    Size, mtime, and artifact flags are intentionally NOT stored here — they are
+    recomputed from disk on every scan so file-size freshness is never lost.
+    """
+
+    topic_count: int | None
+    recording_start_ns: int | None
+    duration_ns: int | None
+    message_count: int | None
+    validation_overall_status: str | None
+    upload_status: str | None
+    task_name: str | None
+    recording_config_name: str | None
+    tags: tuple[str, ...]
+
+
+# Source files whose parsed contents are memoized per folder. A change to any of
+# them (mtime or size) flips the signature and invalidates that folder's entry.
+_SOURCE_FILENAMES: tuple[str, ...] = (
+    METADATA_FILENAME,
+    META_FILENAME,
+    VALIDATION_RESULT_FILENAME,
+    UPLOAD_STATE_FILENAME,
+)
+
+# Per-folder cache of parse results, keyed by absolute folder path and guarded by
+# _cache_lock. Rebuilt and pruned to the folders present on every scan.
+_Signature = tuple[tuple[int, int] | None, ...]
+_parse_cache: dict[str, tuple[_Signature, _ParsedBundle]] = {}
+_cache_lock = threading.Lock()
 
 
 def scan_output_dir(output_dir: Path) -> list[FileEntry]:
@@ -44,71 +89,141 @@ def scan_output_dir(output_dir: Path) -> list[FileEntry]:
     except PermissionError:
         return []
 
+    # Skip the reserved exports directory (generated datasets, not recordings).
+    # Note: only this exact name is excluded — recording folders may legitimately
+    # start with `_`/`.` (task names are unsanitized), and must stay visible.
+    folders = [
+        item
+        for item in items
+        if item.is_dir() and item.name != ".DS_Store" and item.name != EXPORTS_DIRNAME
+    ]
+
+    with _cache_lock:
+        snapshot = dict(_parse_cache)
+
+    fresh_cache: dict[str, tuple[_Signature, _ParsedBundle]] = {}
     entries: list[FileEntry] = []
-    for item in items:
-        # Skip the reserved exports directory (generated datasets, not recordings).
-        # Note: only this exact name is excluded — recording folders may legitimately
-        # start with `_`/`.` (task names are unsanitized), and must stay visible.
-        if not item.is_dir() or item.name == ".DS_Store" or item.name == EXPORTS_DIRNAME:
-            continue
-        entry = _build_recording_entry(item, output_dir)
-        if entry is not None:
-            entries.append(entry)
+    for key, signature, bundle, entry in _scan_folders(folders, output_dir, snapshot):
+        fresh_cache[key] = (signature, bundle)
+        entries.append(entry)
+
+    # Replace the cache wholesale so deleted / renamed folders are pruned.
+    with _cache_lock:
+        _parse_cache.clear()
+        _parse_cache.update(fresh_cache)
 
     # Sort by recording_start_ns primarily, mtime as fallback. Descending (newest first).
     entries.sort(key=_sort_key_recording_desc, reverse=True)
     return entries
 
 
-def _build_recording_entry(folder: Path, rel_root: Path) -> FileEntry | None:
-    """Build a FileEntry for a single recording folder. Returns None if no `.mcap` is present."""
+def _scan_folders(
+    folders: list[Path],
+    rel_root: Path,
+    snapshot: dict[str, tuple[_Signature, _ParsedBundle]],
+) -> list[tuple[str, _Signature, _ParsedBundle, FileEntry]]:
+    """Build entries for every folder concurrently (I/O-bound). None results are dropped.
+
+    Each worker reads the shared `snapshot` read-only and never mutates the cache,
+    so no locking is needed inside the workers.
+    """
+    if not folders:
+        return []
+    workers = min(32, (os.cpu_count() or 4) * 4)
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        built = executor.map(lambda folder: _build_recording_entry(folder, rel_root, snapshot), folders)
+        return [result for result in built if result is not None]
+
+
+def _build_recording_entry(
+    folder: Path,
+    rel_root: Path,
+    cache_snapshot: dict[str, tuple[_Signature, _ParsedBundle]],
+) -> tuple[str, _Signature, _ParsedBundle, FileEntry] | None:
+    """Build a FileEntry (plus its cache payload) for a single recording folder.
+
+    Returns None if no `.mcap` is present or the folder cannot be read. Size,
+    mtime, and artifact flags are recomputed from a single `os.scandir` pass
+    every call; only the parsed source-file contents are reused from the cache
+    when their (mtime, size) signature is unchanged.
+    """
     total_size = 0
     has_mcap = False
     has_quality_report = False
+    source_stats: dict[str, tuple[int, int]] = {}
 
     try:
-        children = list(folder.iterdir())
-    except PermissionError:
+        with os.scandir(folder) as children:
+            for child in children:
+                if not child.is_file():
+                    continue
+                try:
+                    info = child.stat()
+                except OSError as e:
+                    logger.debug("Failed to read file size: %s - %s", child.path, e)
+                    continue
+                total_size += info.st_size
+                name = child.name
+                if name.endswith(".mcap"):
+                    has_mcap = True
+                elif name == QUALITY_REPORT_FILENAME:
+                    has_quality_report = True
+                if name in _SOURCE_FILENAMES:
+                    source_stats[name] = (info.st_mtime_ns, info.st_size)
+    except OSError:
         return None
-
-    for child in children:
-        if not child.is_file():
-            continue
-        try:
-            total_size += child.stat().st_size
-        except OSError as e:
-            logger.debug("Failed to read file size: %s - %s", child, e)
-
-        name = child.name
-        if name.endswith(".mcap"):
-            has_mcap = True
-        elif name == "quality_report.json":
-            has_quality_report = True
 
     # Folders without any .mcap are not treated as recordings.
     if not has_mcap:
         return None
 
-    topic_count, start_ns, dur_ns, msg_count = read_metadata_summary(folder)
-    meta = read_recording_meta(folder)
-    validation_report = load_validation_report(folder)
-    upload_state = load_upload_state(folder)
-    return FileEntry(
+    signature: _Signature = tuple(source_stats.get(name) for name in _SOURCE_FILENAMES)
+    key = str(folder)
+    cached = cache_snapshot.get(key)
+    bundle = cached[1] if cached is not None and cached[0] == signature else _parse_sources(folder)
+
+    entry = FileEntry(
         name=folder.name,
         path=str(folder.relative_to(rel_root)),
         size=total_size,
         modified_at=folder.stat().st_mtime,
+        topic_count=bundle.topic_count,
+        recording_start_ns=bundle.recording_start_ns,
+        duration_ns=bundle.duration_ns,
+        message_count=bundle.message_count,
+        has_quality_report=has_quality_report,
+        validation_overall_status=bundle.validation_overall_status,
+        upload_status=bundle.upload_status,
+        task_name=bundle.task_name,
+        recording_config_name=bundle.recording_config_name,
+        tags=list(bundle.tags),
+    )
+    return key, signature, bundle, entry
+
+
+def _parse_sources(folder: Path) -> _ParsedBundle:
+    """Read and parse the four per-folder source files (the expensive, cached part)."""
+    topic_count, start_ns, dur_ns, msg_count = read_metadata_summary(folder)
+    meta = read_recording_meta(folder)
+    validation_report = load_validation_report(folder)
+    upload_state = load_upload_state(folder)
+    return _ParsedBundle(
         topic_count=topic_count,
         recording_start_ns=start_ns,
         duration_ns=dur_ns,
         message_count=msg_count,
-        has_quality_report=has_quality_report,
-        validation_overall_status=(validation_report.overall_status if validation_report else None),
+        validation_overall_status=validation_report.overall_status if validation_report else None,
         upload_status=upload_state.status if upload_state else None,
         task_name=meta.task_name if meta else None,
         recording_config_name=meta.recording_config_name if meta else None,
-        tags=meta.tags if meta else [],
+        tags=tuple(meta.tags) if meta else (),
     )
+
+
+def _reset_cache() -> None:
+    """Empty the parse cache. Used by tests to keep runs deterministic."""
+    with _cache_lock:
+        _parse_cache.clear()
 
 
 def _sort_key_recording_desc(entry: FileEntry) -> tuple[int, float]:

--- a/backend/tests/features/recordings/test_scanner.py
+++ b/backend/tests/features/recordings/test_scanner.py
@@ -5,15 +5,30 @@ Verifies the pure filesystem logic of scan_output_dir / read_metadata_summary.
 
 import json
 import os
+import shutil
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
+from app.features.recordings import scanner
 from app.features.recordings.scanner import (
     collect_recent_task_names,
     read_metadata_summary,
     scan_output_dir,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_scanner_cache() -> Iterator[None]:
+    """Reset the module-level parse cache around every test for determinism."""
+    scanner._reset_cache()
+    yield
+    scanner._reset_cache()
 
 # ---------------------------------------------------------------------------
 # read_metadata_summary
@@ -468,3 +483,148 @@ class TestCollectRecentTaskNames:
         names = collect_recent_task_names(tmp_path)
 
         assert names == ["pick", "place"]
+
+
+# ---------------------------------------------------------------------------
+# Parse cache + scandir edge cases
+# ---------------------------------------------------------------------------
+
+
+class _FakeDirEntry:
+    """Minimal os.DirEntry stand-in exposing only name / path / is_file / stat."""
+
+    def __init__(self, name: str, *, is_file: bool = True, stat_error: bool = False, size: int = 0) -> None:
+        self.name = name
+        self.path = name
+        self._is_file = is_file
+        self._stat_error = stat_error
+        self._size = size
+
+    def is_file(self) -> bool:
+        return self._is_file
+
+    def stat(self) -> object:
+        if self._stat_error:
+            raise OSError("stat failed")
+        return SimpleNamespace(st_size=self._size, st_mtime_ns=0)
+
+
+@contextmanager
+def _fake_scandir(entries: list[_FakeDirEntry]) -> Iterator[Iterator[_FakeDirEntry]]:
+    """Context manager that mimics os.scandir, yielding the given fake entries."""
+    yield iter(entries)
+
+
+class TestScanCaching:
+    """Tests for the per-folder parse cache and os.scandir edge cases."""
+
+    def test_second_scan_reuses_cached_parse(self, tmp_path: Path) -> None:
+        """A second scan with no file changes does not re-read/parse the source files."""
+        _make_recording(tmp_path / "rec", metadata=METADATA_YAML)
+        scan_output_dir(tmp_path)  # populate cache
+
+        with (
+            patch("app.features.recordings.scanner.read_metadata_summary") as m_meta,
+            patch("app.features.recordings.scanner.read_recording_meta") as m_rec,
+            patch("app.features.recordings.scanner.load_validation_report") as m_val,
+            patch("app.features.recordings.scanner.load_upload_state") as m_up,
+        ):
+            entries = scan_output_dir(tmp_path)
+
+        m_meta.assert_not_called()
+        m_rec.assert_not_called()
+        m_val.assert_not_called()
+        m_up.assert_not_called()
+        # Values still come through from the cached bundle.
+        assert entries[0].topic_count == 2
+        assert entries[0].recording_start_ns == 1700000000000000000
+
+    def test_cache_invalidated_when_source_file_changes(self, tmp_path: Path) -> None:
+        """Editing a source file flips its signature and triggers a re-parse."""
+        rec = _make_recording(
+            tmp_path / "rec",
+            files={
+                "validation_result.json": json.dumps(
+                    {"overall_status": "warn", "results": [], "task_name": "t", "executed_at": "2026-05-25T00:00:00"}
+                ).encode("utf-8")
+            },
+        )
+        assert scan_output_dir(tmp_path)[0].validation_overall_status == "warn"
+
+        (rec / "validation_result.json").write_text(
+            json.dumps(
+                {"overall_status": "fail", "results": [], "task_name": "t", "executed_at": "2026-05-25T00:00:00"}
+            ),
+            encoding="utf-8",
+        )
+        # Force a distinct mtime so the signature changes regardless of fs resolution.
+        os.utime(rec / "validation_result.json", (time.time() + 10, time.time() + 10))
+
+        assert scan_output_dir(tmp_path)[0].validation_overall_status == "fail"
+
+    def test_size_recomputed_on_cache_hit(self, tmp_path: Path) -> None:
+        """Adding an mcap segment (which leaves the source files untouched) still updates size."""
+        rec = _make_recording(tmp_path / "rec", metadata=METADATA_YAML)
+        first_size = scan_output_dir(tmp_path)[0].size
+
+        (rec / "recording_1.mcap").write_bytes(b"y" * 500)
+        # The four source files are unchanged, so this is a cache hit, yet size must grow.
+        assert scan_output_dir(tmp_path)[0].size == first_size + 500
+
+    def test_deleted_folder_pruned_from_cache(self, tmp_path: Path) -> None:
+        """A folder removed between scans is dropped from the cache."""
+        _make_recording(tmp_path / "rec_a")
+        _make_recording(tmp_path / "rec_b")
+        scan_output_dir(tmp_path)
+        assert str(tmp_path / "rec_a") in scanner._parse_cache
+
+        shutil.rmtree(tmp_path / "rec_a")
+        scan_output_dir(tmp_path)
+
+        assert str(tmp_path / "rec_a") not in scanner._parse_cache
+        assert str(tmp_path / "rec_b") in scanner._parse_cache
+
+    def test_subdirectory_inside_recording_ignored(self, tmp_path: Path) -> None:
+        """Non-file children (e.g. a nested directory) are skipped, not summed."""
+        rec = _make_recording(tmp_path / "rec")
+        (rec / "nested").mkdir()
+
+        entries = scan_output_dir(tmp_path)
+
+        assert len(entries) == 1
+        assert entries[0].name == "rec"
+
+    def test_child_stat_failure_is_skipped(self, tmp_path: Path) -> None:
+        """A file whose stat() fails is skipped; the rest of the folder still loads."""
+        rec = _make_recording(tmp_path / "rec")
+        entries = [
+            _FakeDirEntry("recording_0.mcap", size=100),
+            _FakeDirEntry("broken.bin", stat_error=True),
+        ]
+        # Fake scandir only for the recording folder; the top-level listing
+        # (Path.iterdir uses os.scandir on some Python versions) stays real.
+        real_scandir = os.scandir
+
+        def fake(path: object, *args: object, **kwargs: object) -> object:
+            if Path(os.fspath(path)) == rec:
+                return _fake_scandir(entries)
+            return real_scandir(path, *args, **kwargs)
+
+        with patch("os.scandir", side_effect=fake):
+            result = scan_output_dir(tmp_path)
+
+        assert len(result) == 1
+        assert result[0].size == 100  # broken file omitted, only the mcap counted
+
+    def test_folder_scandir_failure_skips_folder(self, tmp_path: Path) -> None:
+        """An os.scandir failure on a folder drops just that folder."""
+        rec = _make_recording(tmp_path / "rec")
+        real_scandir = os.scandir
+
+        def fake(path: object, *args: object, **kwargs: object) -> object:
+            if Path(os.fspath(path)) == rec:
+                raise PermissionError("denied")
+            return real_scandir(path, *args, **kwargs)
+
+        with patch("os.scandir", side_effect=fake):
+            assert scan_output_dir(tmp_path) == []

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@tanstack/react-query": "5.100.14",
     "@tanstack/react-router": "1.170.10",
+    "@tanstack/react-virtual": "3.14.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.17.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tanstack/react-router':
         specifier: 1.170.10
         version: 1.170.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-virtual':
+        specifier: 3.14.4
+        version: 3.14.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1745,6 +1748,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.14.4':
+    resolution: {integrity: sha512-dZzAQP2uCDAd+9sAehqmx/DcU+B91Q4Gb0aDSM7t9bJvWDyGF9sapFNW5r1gNLsHs4wTb6ScZENJeYaHxJLiOw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.171.8':
     resolution: {integrity: sha512-PbrTBbofFcacrH3RLgHYILRqTFnAGq+gXrXoA/vo7qUSkJpSO4GWfLtrtCahD4VayzRm19IPwcjPPLEugag6pw==}
     engines: {node: '>=20.19'}
@@ -1784,6 +1793,9 @@ packages:
 
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tanstack/virtual-core@3.17.2':
+    resolution: {integrity: sha512-w43MvWvmShpb6kIC9MOoLyUkLmRTLPjt61bHWs+X29hACSpX+n8DvgZ3qM7cUfflKlRRcHR9KVJE6TmcqnQvcA==}
 
   '@tanstack/virtual-file-routes@1.162.0':
     resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
@@ -5496,6 +5508,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  '@tanstack/react-virtual@3.14.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/router-core@1.171.8':
     dependencies:
       '@tanstack/history': 1.162.0
@@ -5563,6 +5581,8 @@ snapshots:
       - webpack
 
   '@tanstack/store@0.9.3': {}
+
+  '@tanstack/virtual-core@3.17.2': {}
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 

--- a/frontend/src/features/recordings-table/recordings-table.tsx
+++ b/frontend/src/features/recordings-table/recordings-table.tsx
@@ -40,7 +40,10 @@ export function RecordingsTable({ entries }: { entries: FileEntry[] }) {
   const virtualizer = useVirtualizer({
     count: filteredEntries.length,
     getScrollElement: () => scrollRef.current,
+    // Initial guess for a two-line row (py-2 padding + title + meta line + 1px border).
+    // Only affects scrollbar sizing before each row is measured; measureElement corrects it.
     estimateSize: () => 57,
+    // Render 8 extra rows above/below the viewport so fast scrolling does not flash blanks.
     overscan: 8,
   });
 

--- a/frontend/src/features/recordings-table/recordings-table.tsx
+++ b/frontend/src/features/recordings-table/recordings-table.tsx
@@ -4,9 +4,14 @@
  * returns recording_start_ns desc + mtime fallback).
  * Filters: single-select dropdown by task_name.
  * Application order: search → taskFilter (AND-combined).
+ *
+ * The list body is virtualized (@tanstack/react-virtual): only the visible rows are
+ * mounted, so a 1000+ recording list stays responsive.
  */
 
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Search } from "lucide-react";
+import { useMemo, useRef } from "react";
 import type { FileEntry } from "@/api/generated/schemas";
 import { Checkbox } from "@/components/ui/checkbox";
 import { BulkExportButton } from "@/features/lerobot-export";
@@ -17,21 +22,34 @@ import { TaskFilter } from "./ui/task-filter";
 import { applySearchAndFilter } from "./utils";
 
 export function RecordingsTable({ entries }: { entries: FileEntry[] }) {
+  // --- Filter state + derived lists ---
+  const searchText = useRecordingsTableStore((s) => s.searchText);
+  const taskFilter = useRecordingsTableStore((s) => s.taskFilter);
+
+  // List with only the search applied. Used as the population for TaskFilter options/counts.
+  const searchedEntries = useMemo(() => applySearchAndFilter(entries, searchText), [entries, searchText]);
+  // Final list with all filters applied.
+  const filteredEntries = useMemo(
+    () => applySearchAndFilter(entries, searchText, taskFilter),
+    [entries, searchText, taskFilter],
+  );
+  const allFolders = useMemo(() => filteredEntries.map((e) => e.name), [filteredEntries]);
+
+  // --- Virtualization ---
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: filteredEntries.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 57,
+    overscan: 8,
+  });
+
+  // --- Render-only state ---
+  const setSearchText = useRecordingsTableStore((s) => s.setSearchText);
+  const setTaskFilter = useRecordingsTableStore((s) => s.setTaskFilter);
   const checkedFolders = useRecordingsStore((s) => s.checkedFolders);
   const toggleCheckAll = useRecordingsStore((s) => s.toggleCheckAll);
   const setCheckedFolders = useRecordingsStore((s) => s.setCheckedFolders);
-  const searchText = useRecordingsTableStore((s) => s.searchText);
-  const setSearchText = useRecordingsTableStore((s) => s.setSearchText);
-  const taskFilter = useRecordingsTableStore((s) => s.taskFilter);
-  const setTaskFilter = useRecordingsTableStore((s) => s.setTaskFilter);
-
-  // List with only the search applied. Used as the population for TaskFilter options/counts.
-  const searchedEntries = applySearchAndFilter(entries, searchText);
-
-  // Final list with all filters applied
-  const filteredEntries = applySearchAndFilter(entries, searchText, taskFilter);
-
-  const allFolders = filteredEntries.map((e) => e.name);
 
   return (
     <div className="flex h-full flex-col">
@@ -83,14 +101,29 @@ export function RecordingsTable({ entries }: { entries: FileEntry[] }) {
         </div>
       </div>
 
-      {/* List body */}
-      <div className="flex-1 overflow-auto">
+      {/* List body (virtualized) */}
+      <div ref={scrollRef} className="flex-1 overflow-auto">
         {filteredEntries.length === 0 ? (
           <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
             {searchText ? "No matching files" : "No recordings yet"}
           </div>
         ) : (
-          filteredEntries.map((entry) => <RecordingListItem key={entry.name} entry={entry} />)
+          <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
+            {virtualizer.getVirtualItems().map((virtualRow) => {
+              const entry = filteredEntries[virtualRow.index];
+              return (
+                <div
+                  key={entry.name}
+                  data-index={virtualRow.index}
+                  ref={virtualizer.measureElement}
+                  className="absolute top-0 left-0 w-full"
+                  style={{ transform: `translateY(${virtualRow.start}px)` }}
+                >
+                  <RecordingListItem entry={entry} />
+                </div>
+              );
+            })}
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/features/recordings/ui/recording-list-item.tsx
+++ b/frontend/src/features/recordings/ui/recording-list-item.tsx
@@ -5,7 +5,7 @@
 
 import { useNavigate } from "@tanstack/react-router";
 import { Check, Loader2, Pencil, Trash2, X } from "lucide-react";
-import { useState } from "react";
+import { memo, useState } from "react";
 import type { FileEntry } from "@/api/generated/schemas";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -29,7 +29,9 @@ import {
 import { FileMetaLine } from "./file-meta-line";
 import { MetaEditDialog } from "./meta-edit-dialog";
 
-export function RecordingListItem({
+// Memoized: the list renders many rows, and only the row whose `entry` (or its
+// own checked state, read via a store selector inside) changes should re-render.
+export const RecordingListItem = memo(function RecordingListItem({
   entry,
   checkDisabled,
   canRename,
@@ -240,4 +242,4 @@ export function RecordingListItem({
       </div>
     </div>
   );
-}
+});

--- a/frontend/src/features/upload/__tests__/upload-badge.test.tsx
+++ b/frontend/src/features/upload/__tests__/upload-badge.test.tsx
@@ -3,13 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConfigResponse, FileEntry, JobSchema } from "@/api/generated/schemas";
 import { UploadBadge } from "../upload-badge";
 
-const { useConfigMock, useJobsMock } = vi.hoisted(() => ({
+const { useConfigMock, useUploadJobMock } = vi.hoisted(() => ({
   useConfigMock: vi.fn<() => { data: ConfigResponse | undefined }>(() => ({ data: undefined })),
-  useJobsMock: vi.fn<() => JobSchema[]>(() => []),
+  useUploadJobMock: vi.fn<(folder: string) => JobSchema | undefined>(() => undefined),
 }));
 
 vi.mock("@/hooks/use-api", () => ({ useConfig: () => useConfigMock() }));
-vi.mock("@/hooks/use-jobs-stream", () => ({ useJobs: () => useJobsMock() }));
+vi.mock("@/hooks/use-jobs-stream", () => ({ useUploadJob: (folder: string) => useUploadJobMock(folder) }));
 
 function makeConfig(overrides: Partial<ConfigResponse> = {}): ConfigResponse {
   return {
@@ -62,12 +62,12 @@ function makeJob(overrides: JobOverrides = {}): JobSchema {
 
 beforeEach(() => {
   useConfigMock.mockReturnValue({ data: makeConfig() });
-  useJobsMock.mockReturnValue([]);
+  useUploadJobMock.mockReturnValue(undefined);
 });
 
 afterEach(() => {
   useConfigMock.mockReset();
-  useJobsMock.mockReset();
+  useUploadJobMock.mockReset();
 });
 
 describe("UploadBadge", () => {
@@ -99,9 +99,9 @@ describe("UploadBadge", () => {
   });
 
   it("shows live progress when an active upload job matches this folder", () => {
-    useJobsMock.mockReturnValue([
+    useUploadJobMock.mockReturnValue(
       makeJob({ folder: "rec_001", status: "running", progress: { current: 50, total: 100 } }),
-    ]);
+    );
     const { container, getByText } = render(<UploadBadge entry={makeEntry({ upload_status: "uploaded" })} />);
     // Live job wins over the persisted status.
     expect(container.querySelector('[data-status="uploading"]')).not.toBeNull();
@@ -109,23 +109,24 @@ describe("UploadBadge", () => {
   });
 
   it("clamps progress to 100% when current exceeds total", () => {
-    useJobsMock.mockReturnValue([
+    useUploadJobMock.mockReturnValue(
       makeJob({ folder: "rec_001", status: "running", progress: { current: 200, total: 100 } }),
-    ]);
+    );
     const { getByText } = render(<UploadBadge entry={makeEntry()} />);
     expect(getByText("100%")).toBeInTheDocument();
   });
 
   it("falls back to 0% when total is zero", () => {
-    useJobsMock.mockReturnValue([
+    useUploadJobMock.mockReturnValue(
       makeJob({ folder: "rec_001", status: "running", progress: { current: 0, total: 0 } }),
-    ]);
+    );
     const { getByText } = render(<UploadBadge entry={makeEntry()} />);
     expect(getByText("0%")).toBeInTheDocument();
   });
 
-  it("ignores jobs for other folders", () => {
-    useJobsMock.mockReturnValue([makeJob({ folder: "other_folder", status: "running" })]);
+  it("shows the persisted status when there is no active job for this folder", () => {
+    // useUploadJob already scopes to this folder, so no match -> undefined.
+    useUploadJobMock.mockReturnValue(undefined);
     const { container } = render(<UploadBadge entry={makeEntry({ upload_status: "uploaded", name: "rec_001" })} />);
     expect(container.querySelector('[data-status="uploaded"]')).not.toBeNull();
     expect(container.querySelector('[data-status="uploading"]')).toBeNull();

--- a/frontend/src/features/upload/upload-badge.tsx
+++ b/frontend/src/features/upload/upload-badge.tsx
@@ -14,18 +14,14 @@
 import { CloudCheck, CloudOff, Loader2 } from "lucide-react";
 import type { FileEntry } from "@/api/generated/schemas";
 import { useConfig } from "@/hooks/use-api";
-import { useJobs } from "@/hooks/use-jobs-stream";
+import { useUploadJob } from "@/hooks/use-jobs-stream";
 
 export function UploadBadge({ entry }: { entry: FileEntry }) {
   // --- Server state ---
   const { data: config } = useConfig();
-  const jobs = useJobs();
+  const activeJob = useUploadJob(entry.name);
 
   if (!config?.upload_enabled) return null;
-
-  const activeJob = jobs.find(
-    (j) => j.type === "upload" && j.folder === entry.name && (j.status === "queued" || j.status === "running"),
-  );
 
   if (activeJob) {
     const { current, total } = activeJob.progress;

--- a/frontend/src/hooks/__tests__/use-jobs-stream.test.tsx
+++ b/frontend/src/hooks/__tests__/use-jobs-stream.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getGetRecordingsQueryKey } from "@/api/generated/recordings/recordings";
 import type { JobSchema } from "@/api/generated/schemas";
 import { getGetValidationQueryKey } from "@/api/generated/validation/validation";
-import { useJobsStream } from "../use-jobs-stream";
+import { useJobsStream, useUploadJob } from "../use-jobs-stream";
 
 // A minimal EventSource stand-in: capture listeners and let tests dispatch
 // fake job events synchronously.
@@ -106,5 +106,33 @@ describe("useJobsStream", () => {
     expect(calls).toContainEqual(getGetRecordingsQueryKey());
     const cached = client.getQueryData<JobSchema[]>(["sse", "jobs"]);
     expect(cached?.[0]?.status).toBe("completed");
+  });
+});
+
+function renderUploadJob(folder: string, jobs: JobSchema[]) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  // Seed the cache before rendering so the first render already reflects it.
+  client.setQueryData<JobSchema[]>(["sse", "jobs"], jobs);
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return renderHook(() => useUploadJob(folder), { wrapper });
+}
+
+describe("useUploadJob", () => {
+  it("returns the active upload job scoped to the given folder", () => {
+    const { result } = renderUploadJob("rec_001", [
+      makeJob({ job_id: "u1", type: "upload", folder: "rec_001", status: "running" }),
+      makeJob({ job_id: "u2", type: "upload", folder: "other", status: "running" }),
+      makeJob({ job_id: "v1", type: "validation", folder: "rec_001", status: "running" }),
+    ]);
+    expect(result.current?.job_id).toBe("u1");
+  });
+
+  it("returns undefined when the folder has no queued/running upload job", () => {
+    const { result } = renderUploadJob("rec_001", [
+      makeJob({ job_id: "u1", type: "upload", folder: "rec_001", status: "completed" }),
+    ]);
+    expect(result.current).toBeUndefined();
   });
 });

--- a/frontend/src/hooks/use-jobs-stream.ts
+++ b/frontend/src/hooks/use-jobs-stream.ts
@@ -123,3 +123,20 @@ export function useJob(jobId: string | null | undefined): JobSchema | undefined 
   if (!jobId) return undefined;
   return jobs.find((j) => j.job_id === jobId);
 }
+
+/** Reactively read the active (queued/running) upload job for a single folder.
+ *
+ * Uses TanStack Query `select` so a subscriber re-renders only when its own
+ * folder's upload job changes, not on every job-stream tick. This keeps a long
+ * recordings list cheap to render while an upload is in flight.
+ */
+export function useUploadJob(folderName: string): JobSchema | undefined {
+  return useQuery<JobSchema[], Error, JobSchema | undefined>({
+    queryKey: sseKeys.jobs(),
+    queryFn: skipToken,
+    select: (jobs) =>
+      jobs.find(
+        (j) => j.type === "upload" && j.folder === folderName && (j.status === "queued" || j.status === "running"),
+      ),
+  }).data;
+}

--- a/frontend/src/routes/recordings.tsx
+++ b/frontend/src/routes/recordings.tsx
@@ -30,8 +30,8 @@ function RecordingsPage() {
         </div>
       </div>
 
-      {/* Main content: the table */}
-      <div className="flex-1 overflow-auto">
+      {/* Main content: the table (it owns its own scroll container for virtualization) */}
+      <div className="min-h-0 flex-1 overflow-hidden">
         <RecordingsTable entries={entries} />
       </div>
     </div>


### PR DESCRIPTION
## Summary

Opening `/recordings` took several seconds with 1000+ recording folders. This PR removes the latency on both ends. Investigation and plan: #51.

## Backend — `features/recordings/scanner.py`

- **Signature-based parse cache.** `scan_output_dir` now memoizes the expensive per-folder parse (the four source files: `metadata.yaml`, `recording_meta.json`, `validation_result.json`, `upload_state.json`), keyed by a `(mtime_ns, size)` signature of those files. A change to any of them busts that folder's entry.
- **Freshness preserved.** `size`, `modified_at`, and the mcap/quality flags are recomputed from a single `os.scandir` pass on every request, so file-size freshness is never sacrificed (only the read+parse is cached).
- **Parallel cold scan.** Folders are built concurrently via a `ThreadPoolExecutor` (the work is I/O-bound); workers read a read-only cache snapshot, and the cache is rebuilt + pruned to the folders present on each scan.
- API response contract (`FilesResponse` / `FileEntry`) and sort order (`recording_start_ns` desc) are unchanged.

## Frontend

- **Virtualization** (`recordings-table.tsx`): the list body uses `@tanstack/react-virtual`, so only visible rows mount. The table body is the single scroll container (`routes/recordings.tsx` switched to `overflow-hidden`).
- **Memoization**: `RecordingListItem` is wrapped in `React.memo`; the derived `searchedEntries` / `filteredEntries` / `allFolders` are `useMemo`-ized.
- **Scoped job subscription**: a new `useUploadJob(folder)` hook uses TanStack Query `select` so each `UploadBadge` re-renders only when its own folder's upload job changes, instead of on every job-progress tick.

## Out of scope

Server-side pagination — larger API change and the task-name filter needs the full set as its population. The cache + virtualization remove the perceived latency without it; kept as a future option.

## Testing

- Backend: `scanner.py` is 100% covered in isolation (new tests for cache hit/invalidation/prune, size-freshness on cache hit, and the `os.scandir` edge cases); full backend suite green; `ruff` + `mypy` clean.
- Frontend: `tsc` clean, `vitest` green (existing `UploadBadge`/jobs-stream tests updated for the new hook, plus new `useUploadJob` coverage), `biome` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
