### PR TITLE
docs: note recordings-list virtualization and scan caching

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -353,6 +353,8 @@ Clicking the details panel header navigates to the MCAP detail page (`/recording
 
 **Where bulk actions live**: bulk-action buttons are individual components under `frontend/src/features/recordings/ui/bulk-*.tsx` (today: `bulk-delete-button.tsx`) and mounted inside `features/recordings-table/recordings-table.tsx`. They read the selected set from `useRecordingsStore.checkedFolders` (a Zustand store inside the `recordings` feature). Add new bulk actions by mirroring this pattern.
 
+**Rendering & scan (large lists)**: the table is virtualized with `@tanstack/react-virtual`, so only the rows in view are mounted (each row is absolutely positioned and measured) and the list stays responsive with thousands of recordings. On the backend, `scan_output_dir` caches each folder's parsed metadata keyed by a source-file fingerprint and scans folders in parallel, so repeated list fetches are cheap; file size and mtime are always recomputed fresh so they never go stale.
+
 #### MCAP detail page (`/recordings/:folder`) — integrated timeline view
 
 ```

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -32,6 +32,7 @@
 | Valibot | 1.x | Schema validation |
 | shadcn/ui | - | UI component primitives (Radix UI based) |
 | react-resizable-panels | 4.x | Resizable panel layout |
+| TanStack Virtual | 3.x | List virtualization (recordings table) |
 | lucide-react | latest | Icons |
 | uPlot | 1.6+ | Time-series charts |
 


### PR DESCRIPTION
## Summary

Follow-up docs for the recordings-list performance work merged in #52. No code changes — documentation only.

- **`docs/TECH_STACK.md`**: add `TanStack Virtual` (3.x) to the frontend library table — a new runtime dependency, listed at the same granularity as `react-resizable-panels` / `uPlot`.
- **`docs/ARCHITECTURE.md`** (Recordings list page section): add a short "Rendering & scan (large lists)" note explaining that the table is virtualized with `@tanstack/react-virtual` (only visible rows mount) and that the backend `scan_output_dir` caches each folder's parsed metadata by a source-file fingerprint and scans folders in parallel, while size/mtime stay fresh.

## Notes

Intentionally left out: a `CHANGELOG.md` entry (the changelog is maintained per release with no Unreleased section), and `CLAUDE.md` / `STRUCTURE.md` (the change is a perf optimization, not a contributor-facing rule, and the existing one-line descriptions remain accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
