### PR TITLE
test: restore 100% test coverage for backend and frontend

### DIFF
--- a/backend/app/features/media/models.py
+++ b/backend/app/features/media/models.py
@@ -177,7 +177,7 @@ def build_joint_state_mapping(topic_roles: dict[str, str]) -> JointStateMapping 
     elif not act_entries:
         act_entries = list(unclassified_entries) if unclassified_entries else list(obs_entries)
 
-    if not obs_entries:
+    if not obs_entries:  # pragma: no cover - defensive; unreachable once topic_roles is non-empty
         return None
 
     # Stable sort: right(0) -> left(1) -> body(2) -> other(3)

--- a/backend/app/infra/mcap/reader.py
+++ b/backend/app/infra/mcap/reader.py
@@ -56,12 +56,12 @@ class MCAPReader:
     so that features only need to worry about iterating MCAPMessage values.
     """
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path) -> None:  # pragma: no cover - MCAP I/O boundary
         self._path = path
         self._file: IO[bytes] | None = None
         self._reader: Any = None  # mcap.reader.McapReader (typed as Any since it lives in the mcap library)
 
-    def __enter__(self) -> "MCAPReader":
+    def __enter__(self) -> "MCAPReader":  # pragma: no cover - MCAP I/O boundary
         self._file = self._path.open("rb")
         self._reader = make_reader(self._file, decoder_factories=[DecoderFactory()])
         return self
@@ -71,13 +71,13 @@ class MCAPReader:
         exc_type: type[BaseException] | None,
         exc: BaseException | None,
         tb: TracebackType | None,
-    ) -> None:
+    ) -> None:  # pragma: no cover - MCAP I/O boundary
         if self._file is not None:
             self._file.close()
             self._file = None
             self._reader = None
 
-    def get_channels(self) -> dict[str, MCAPChannel]:
+    def get_channels(self) -> dict[str, MCAPChannel]:  # pragma: no cover - MCAP I/O boundary
         """Return a topic → MCAPChannel dict (from the MCAP summary).
 
         Returns an empty dict if no summary exists (old or truncated MCAP).
@@ -95,7 +95,7 @@ class MCAPReader:
             )
         return channels
 
-    def get_time_range_ns(self) -> tuple[int, int]:
+    def get_time_range_ns(self) -> tuple[int, int]:  # pragma: no cover - MCAP I/O boundary
         """Return the overall log_time range of the MCAP as (start_ns, end_ns).
 
         Returns (0, 0) if no summary exists.
@@ -113,7 +113,7 @@ class MCAPReader:
         topics: list[str] | None = None,
         start_time_ns: int | None = None,
         end_time_ns: int | None = None,
-    ) -> Iterator[MCAPMessage]:
+    ) -> Iterator[MCAPMessage]:  # pragma: no cover - MCAP I/O boundary
         """Iterate messages and yield decoded MCAPMessage values.
 
         The topic and time-range filters are applied at the chunk index level,

--- a/backend/tests/features/analysis/test_quality_analyzer.py
+++ b/backend/tests/features/analysis/test_quality_analyzer.py
@@ -1,0 +1,121 @@
+"""Tests for the QualityAnalyzer lifecycle facade.
+
+The actual MCAP analysis runs on the JobQueue; this covers the facade's state
+transitions. A cached report is materialized as a real ``quality_report.json``
+(so ``load_report`` returns a valid model), and the queue is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.features.analysis.quality_analyzer import QualityAnalyzer, get_quality_analyzer
+from app.features.jobs.models import JobStatus
+
+_QUEUE_PATH = "app.features.analysis.quality_analyzer.get_job_queue"
+
+
+def _write_quality_report(directory: Path) -> None:
+    payload = {
+        "duration_sec": 60.0,
+        "total_messages": 0,
+        "total_topics": 0,
+        "file_size_bytes": 0,
+        "topics": [],
+    }
+    (directory / "quality_report.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _queue(active: object | None = None) -> MagicMock:
+    queue = MagicMock()
+    queue.get_active_quality_job.return_value = active
+    queue.enqueue_quality = AsyncMock()
+    return queue
+
+
+class TestQualityAnalyzerGet:
+    async def test_returns_ready_when_cached(self, tmp_path: Path) -> None:
+        _write_quality_report(tmp_path)
+        result = await QualityAnalyzer().get(tmp_path)
+        assert result.status == "ready"
+        assert result.report is not None
+
+    async def test_returns_analyzing_when_job_running(self, tmp_path: Path) -> None:
+        active = MagicMock(status=JobStatus.RUNNING)
+        with patch(_QUEUE_PATH, return_value=_queue(active)):
+            result = await QualityAnalyzer().get(tmp_path)
+        assert result.status == "analyzing"
+
+    async def test_returns_error_when_job_failed(self, tmp_path: Path) -> None:
+        active = MagicMock(status=JobStatus.FAILED, error="boom")
+        with patch(_QUEUE_PATH, return_value=_queue(active)):
+            result = await QualityAnalyzer().get(tmp_path)
+        assert result.status == "error"
+        assert result.error == "boom"
+
+    async def test_returns_error_with_default_message(self, tmp_path: Path) -> None:
+        active = MagicMock(status=JobStatus.FAILED, error=None)
+        with patch(_QUEUE_PATH, return_value=_queue(active)):
+            result = await QualityAnalyzer().get(tmp_path)
+        assert result.status == "error"
+        assert result.error is not None and "failed" in result.error.lower()
+
+    async def test_returns_not_found_when_nothing(self, tmp_path: Path) -> None:
+        with patch(_QUEUE_PATH, return_value=_queue(None)):
+            result = await QualityAnalyzer().get(tmp_path)
+        assert result.status == "not_found"
+
+
+class TestQualityAnalyzerStart:
+    async def test_returns_ready_when_cached(self, tmp_path: Path) -> None:
+        _write_quality_report(tmp_path)
+        result = await QualityAnalyzer().start(tmp_path)
+        assert result.status == "ready"
+
+    async def test_returns_analyzing_when_job_running(self, tmp_path: Path) -> None:
+        active = MagicMock(status=JobStatus.RUNNING)
+        with patch(_QUEUE_PATH, return_value=_queue(active)):
+            result = await QualityAnalyzer().start(tmp_path)
+        assert result.status == "analyzing"
+
+    async def test_returns_not_found_when_no_mcap(self, tmp_path: Path) -> None:
+        with patch(_QUEUE_PATH, return_value=_queue(None)):
+            result = await QualityAnalyzer().start(tmp_path)
+        assert result.status == "not_found"
+        assert result.error == "MCAP file not found"
+
+    async def test_enqueues_when_mcap_present(self, tmp_path: Path) -> None:
+        (tmp_path / "rec.mcap").write_bytes(b"")
+        queue = _queue(None)
+        with patch(_QUEUE_PATH, return_value=queue):
+            result = await QualityAnalyzer().start(tmp_path)
+        assert result.status == "analyzing"
+        queue.enqueue_quality.assert_awaited_once_with(tmp_path)
+
+
+class TestQualityAnalyzerSchedule:
+    async def test_noop_when_cached(self, tmp_path: Path) -> None:
+        _write_quality_report(tmp_path)
+        queue = _queue(None)
+        with patch(_QUEUE_PATH, return_value=queue):
+            await QualityAnalyzer().schedule(tmp_path)
+        queue.enqueue_quality.assert_not_awaited()
+
+    async def test_noop_when_no_mcap(self, tmp_path: Path) -> None:
+        queue = _queue(None)
+        with patch(_QUEUE_PATH, return_value=queue):
+            await QualityAnalyzer().schedule(tmp_path)
+        queue.enqueue_quality.assert_not_awaited()
+
+    async def test_enqueues_when_mcap_present(self, tmp_path: Path) -> None:
+        (tmp_path / "rec.mcap").write_bytes(b"")
+        queue = _queue(None)
+        with patch(_QUEUE_PATH, return_value=queue):
+            await QualityAnalyzer().schedule(tmp_path)
+        queue.enqueue_quality.assert_awaited_once_with(tmp_path)
+
+
+def test_get_quality_analyzer_returns_singleton() -> None:
+    assert get_quality_analyzer() is get_quality_analyzer()

--- a/backend/tests/features/analysis/test_timeline_analyzer.py
+++ b/backend/tests/features/analysis/test_timeline_analyzer.py
@@ -522,3 +522,55 @@ class TestTimelineAnalyzer:
             result = await analyzer.start(tmp_path)
         assert result["status"] == "analyzing"
         mock_queue.enqueue_timeline.assert_awaited_once_with(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_start_returns_cached_data(self, tmp_path: Path) -> None:
+        """start() returns ready immediately when cached data is present."""
+        cache = {
+            "duration_sec": 10.0,
+            "bin_width_sec": 0.05,
+            "recording_start_ns": 1700000000000000000,
+            "log_time_offset_ns": 0,
+            "topics": [],
+        }
+        (tmp_path / "timeline_data.json").write_text(json.dumps(cache))
+        result = await TimelineAnalyzer().start(tmp_path)
+        assert result["status"] == "ready"
+        assert "data" in result
+
+    @pytest.mark.asyncio
+    async def test_start_active_failed_job_returns_error(self, tmp_path: Path) -> None:
+        """start() surfaces a failed job's error."""
+        from app.features.jobs.models import JobStatus
+
+        (tmp_path / "data.mcap").write_bytes(b"")
+        with patch("app.features.jobs.service.get_job_queue") as mock_queue_fn:
+            mock_queue = MagicMock()
+            mock_queue.get_active_timeline_job.return_value = MagicMock(status=JobStatus.FAILED, error="bad")
+            mock_queue_fn.return_value = mock_queue
+            result = await TimelineAnalyzer().start(tmp_path)
+        assert result["status"] == "error"
+        assert result["error"] == "bad"
+
+    @pytest.mark.asyncio
+    async def test_start_active_running_job_returns_analyzing(self, tmp_path: Path) -> None:
+        """start() returns analyzing when a job is already running."""
+        from app.features.jobs.models import JobStatus
+
+        (tmp_path / "data.mcap").write_bytes(b"")
+        with patch("app.features.jobs.service.get_job_queue") as mock_queue_fn:
+            mock_queue = MagicMock()
+            mock_queue.get_active_timeline_job.return_value = MagicMock(status=JobStatus.RUNNING)
+            mock_queue_fn.return_value = mock_queue
+            result = await TimelineAnalyzer().start(tmp_path)
+        assert result["status"] == "analyzing"
+
+    @pytest.mark.asyncio
+    async def test_start_no_mcap_returns_not_found(self, tmp_path: Path) -> None:
+        """start() returns not_found when there is no MCAP and no active job."""
+        with patch("app.features.jobs.service.get_job_queue") as mock_queue_fn:
+            mock_queue = MagicMock()
+            mock_queue.get_active_timeline_job.return_value = None
+            mock_queue_fn.return_value = mock_queue
+            result = await TimelineAnalyzer().start(tmp_path)
+        assert result["status"] == "not_found"

--- a/backend/tests/features/jobs/test_queue.py
+++ b/backend/tests/features/jobs/test_queue.py
@@ -1,0 +1,293 @@
+"""Tests for the generic JobQueue infrastructure and the media/quality/timeline runs.
+
+Validation / upload / LeRobot-export specifics live in their own job test modules.
+This covers enqueue dedup, lookups, the SSE subscription, the worker loop (dispatch,
+failure handling, cancellation, history trimming) and the run methods whose underlying
+MCAP work is mocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.features.jobs import service as jobs_service
+from app.features.jobs.models import GenerateMediaJob, Job, JobStatus, JobType, QualityJob, TimelineJob
+from app.features.jobs.service import EVENT_JOB_ADDED, JobQueue
+
+
+class TestEnqueue:
+    async def test_enqueue_generate_media(self, tmp_path: Path) -> None:
+        queue = JobQueue()
+        job = await queue.enqueue_generate_media(tmp_path)
+        assert isinstance(job, GenerateMediaJob)
+        assert job.type == JobType.MEDIA
+        assert job.status == JobStatus.QUEUED
+        active = queue.get_active_media_job(tmp_path)
+        assert active is not None and active.job_id == job.job_id
+        # Re-enqueue returns the existing job.
+        assert (await queue.enqueue_generate_media(tmp_path)).job_id == job.job_id
+
+    async def test_enqueue_quality(self, tmp_path: Path) -> None:
+        queue = JobQueue()
+        job = await queue.enqueue_quality(tmp_path)
+        assert isinstance(job, QualityJob)
+        active = queue.get_active_quality_job(tmp_path)
+        assert active is not None and active.job_id == job.job_id
+        assert (await queue.enqueue_quality(tmp_path)).job_id == job.job_id
+
+    async def test_enqueue_timeline(self, tmp_path: Path) -> None:
+        queue = JobQueue()
+        job = await queue.enqueue_timeline(tmp_path)
+        assert isinstance(job, TimelineJob)
+        active = queue.get_active_timeline_job(tmp_path)
+        assert active is not None and active.job_id == job.job_id
+        assert (await queue.enqueue_timeline(tmp_path)).job_id == job.job_id
+
+
+class TestLookups:
+    async def test_get_job(self, tmp_path: Path) -> None:
+        queue = JobQueue()
+        job = await queue.enqueue_quality(tmp_path)
+        assert queue.get_job(job.job_id) is job
+        assert queue.get_job("missing") is None
+
+    async def test_wait_for_completion_unknown_job(self) -> None:
+        queue = JobQueue()
+        assert await queue.wait_for_completion("missing") is None
+
+    async def test_wait_for_completion_already_finished(self, tmp_path: Path) -> None:
+        queue = JobQueue()
+        job = await queue.enqueue_quality(tmp_path)
+        job.status = JobStatus.COMPLETED
+        assert await queue.wait_for_completion(job.job_id) is job
+
+    async def test_list_jobs_combines_active_and_history(self, tmp_path: Path) -> None:
+        queue = JobQueue()
+        active = await queue.enqueue_quality(tmp_path)
+        done = await queue.enqueue_timeline(tmp_path / "other")
+        done.status = JobStatus.COMPLETED
+        queue._history.append(done)
+        jobs = queue.list_jobs()
+        assert active in jobs and done in jobs
+
+
+class TestSubscribe:
+    async def test_yields_snapshot_then_events(self, tmp_path: Path) -> None:
+        queue = JobQueue()
+        await queue.enqueue_quality(tmp_path)
+        agen = queue.subscribe()
+        snapshot = await agen.__anext__()
+        assert snapshot.event == "queue_snapshot"
+
+        job = await queue.enqueue_timeline(tmp_path / "x")
+        await queue._broadcast(EVENT_JOB_ADDED, job)
+        event = await agen.__anext__()
+        assert event.event == EVENT_JOB_ADDED
+
+        await agen.aclose()
+        assert not queue._subscribers
+
+
+class TestWorker:
+    async def test_dispatches_each_job_type(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        queue = JobQueue()
+        for name in (
+            "_run_generate_media",
+            "_run_quality",
+            "_run_timeline",
+            "_run_validation",
+            "_run_upload",
+            "_run_lerobot_export",
+        ):
+            monkeypatch.setattr(queue, name, AsyncMock())
+
+        await queue.start()
+        try:
+            jobs = [
+                await queue.enqueue_generate_media(tmp_path / "m"),
+                await queue.enqueue_quality(tmp_path / "q"),
+                await queue.enqueue_timeline(tmp_path / "t"),
+                await queue.enqueue_validation(tmp_path / "v"),
+                await queue.enqueue_upload(tmp_path / "u"),
+                await queue.enqueue_lerobot_export(source_dirs=[tmp_path / "s"], output_dir=tmp_path / "ds"),
+            ]
+            for job in jobs:
+                finished = await queue.wait_for_completion(job.job_id)
+                assert finished is not None and finished.status == JobStatus.COMPLETED
+        finally:
+            await queue.shutdown()
+
+    async def test_marks_failed_on_exception(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        queue = JobQueue()
+        monkeypatch.setattr(queue, "_run_quality", AsyncMock(side_effect=RuntimeError("kaboom")))
+        await queue.start()
+        try:
+            job = await queue.enqueue_quality(tmp_path)
+            finished = await queue.wait_for_completion(job.job_id)
+            assert finished is not None
+            assert finished.status == JobStatus.FAILED
+            assert finished.error == "kaboom"
+        finally:
+            await queue.shutdown()
+
+    async def test_worker_survives_unhandled_execute_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        queue = JobQueue()
+        real_execute = queue._execute
+        seen: list[str] = []
+
+        async def flaky_execute(job: Job) -> None:
+            seen.append(job.job_id)
+            if len(seen) == 1:
+                raise RuntimeError("boom")  # leaks to the worker loop
+            await real_execute(job)
+
+        monkeypatch.setattr(queue, "_execute", flaky_execute)
+        monkeypatch.setattr(queue, "_run_quality", AsyncMock())
+
+        await queue.start()
+        try:
+            await queue.enqueue_quality(tmp_path / "first")
+            second = await queue.enqueue_quality(tmp_path / "second")
+            finished = await queue.wait_for_completion(second.job_id)
+            assert finished is not None and finished.status == JobStatus.COMPLETED
+        finally:
+            await queue.shutdown()
+
+    async def test_worker_propagates_cancellation_during_execute(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        queue = JobQueue()
+        entered = asyncio.Event()
+
+        async def hang(_job: Job) -> None:
+            entered.set()
+            await asyncio.sleep(3600)
+
+        monkeypatch.setattr(queue, "_execute", hang)
+        await queue.start()
+        await queue.enqueue_quality(tmp_path)
+        await asyncio.wait_for(entered.wait(), timeout=5)
+
+        await queue.shutdown()
+        task = queue._worker_task
+        assert task is not None and task.done()
+
+    async def test_history_trimmed_to_max(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(jobs_service, "_MAX_HISTORY", 2)
+        queue = JobQueue()
+        monkeypatch.setattr(queue, "_run_quality", AsyncMock())
+
+        await queue.start()
+        try:
+            last: QualityJob | None = None
+            for i in range(4):
+                last = await queue.enqueue_quality(tmp_path / f"rec{i}")
+            assert last is not None
+            await queue.wait_for_completion(last.job_id)
+            assert len(queue._history) == 2
+        finally:
+            await queue.shutdown()
+
+
+class TestRunGenerateMedia:
+    async def test_skips_when_mp4_exists(self, tmp_path: Path) -> None:
+        (tmp_path / "observation.images.cam.mp4").write_bytes(b"")
+        queue = JobQueue()
+        job = await queue.enqueue_generate_media(tmp_path)
+        await queue._run_generate_media(job)
+        assert job.progress.step == "ready"
+
+    async def test_raises_when_no_mcap(self, tmp_path: Path) -> None:
+        queue = JobQueue()
+        job = await queue.enqueue_generate_media(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            await queue._run_generate_media(job)
+
+    async def test_runs_conversion_and_reports_progress(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "rec.mcap").write_bytes(b"")
+        seen: list[Path] = []
+
+        def fake_convert(target: Path, on_progress: Callable[[str, int, int], None]) -> None:
+            on_progress("mp4", 1, 2)  # exercise the progress callback hop
+            seen.append(target)
+
+        monkeypatch.setattr(jobs_service, "_run_convert_mcap", fake_convert)
+        queue = JobQueue()
+        job = await queue.enqueue_generate_media(tmp_path)
+        await queue._run_generate_media(job)
+        assert seen == [tmp_path]
+        assert job.progress.step == "mp4"
+
+
+class TestRunQuality:
+    async def test_skips_when_cached(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("app.features.analysis.mcap_analyzer.load_report", lambda _t: MagicMock())
+        queue = JobQueue()
+        job = await queue.enqueue_quality(tmp_path)
+        await queue._run_quality(job)
+        assert job.progress.step == "ready"
+
+    async def test_raises_when_no_mcap(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("app.features.analysis.mcap_analyzer.load_report", lambda _t: None)
+        queue = JobQueue()
+        job = await queue.enqueue_quality(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            await queue._run_quality(job)
+
+    async def test_runs_analysis(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "rec.mcap").write_bytes(b"")
+        called: list[Path] = []
+        monkeypatch.setattr("app.features.analysis.mcap_analyzer.load_report", lambda _t: None)
+        monkeypatch.setattr("app.features.analysis.mcap_analyzer.analyze_and_save", called.append)
+        queue = JobQueue()
+        job = await queue.enqueue_quality(tmp_path)
+        await queue._run_quality(job)
+        assert called == [tmp_path]
+        assert job.progress.step == "analyze"
+
+
+class TestRunTimeline:
+    async def test_skips_when_cached(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("app.features.analysis.timeline_analyzer.load_timeline", lambda _t: MagicMock())
+        queue = JobQueue()
+        job = await queue.enqueue_timeline(tmp_path)
+        await queue._run_timeline(job)
+        assert job.progress.step == "ready"
+
+    async def test_raises_when_no_mcap(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("app.features.analysis.timeline_analyzer.load_timeline", lambda _t: None)
+        queue = JobQueue()
+        job = await queue.enqueue_timeline(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            await queue._run_timeline(job)
+
+    async def test_runs_build(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "rec.mcap").write_bytes(b"")
+        called: list[Path] = []
+        monkeypatch.setattr("app.features.analysis.timeline_analyzer.load_timeline", lambda _t: None)
+        monkeypatch.setattr("app.features.analysis.timeline_analyzer.build_and_save_timeline", called.append)
+        queue = JobQueue()
+        job = await queue.enqueue_timeline(tmp_path)
+        await queue._run_timeline(job)
+        assert called == [tmp_path]
+
+
+def test_get_job_queue_raises_when_uninitialized() -> None:
+    previous = jobs_service._job_queue
+    jobs_service._job_queue = None
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            jobs_service.get_job_queue()
+        assert exc_info.value.status_code == 503
+    finally:
+        jobs_service._job_queue = previous

--- a/backend/tests/features/jobs/test_router.py
+++ b/backend/tests/features/jobs/test_router.py
@@ -1,0 +1,15 @@
+"""Tests for the jobs router glue (list endpoint)."""
+
+from app.features.jobs import service as jobs_service
+from app.features.jobs.router import list_jobs
+from app.features.jobs.service import JobQueue
+
+
+async def test_list_jobs_returns_snapshot() -> None:
+    previous = jobs_service._job_queue
+    jobs_service.set_job_queue(JobQueue())
+    try:
+        response = await list_jobs()
+        assert response.jobs == []
+    finally:
+        jobs_service._job_queue = previous

--- a/backend/tests/features/lerobot_export/test_config_loader.py
+++ b/backend/tests/features/lerobot_export/test_config_loader.py
@@ -83,3 +83,14 @@ def test_parse_source_keys_stored() -> None:
     config = parse_config(data)
     assert config.action[0].keys == ["x", "y", "z"]
     assert config.action[0].type == "struct"
+
+
+def test_parse_config_invalid_time_range_raises() -> None:
+    with pytest.raises(ValueError, match="time_range"):
+        parse_config({**_VALID, "time_range": "average"})
+
+
+def test_parse_config_malformed_structure_raises() -> None:
+    """A structural error (observation not a mapping) is normalized to ValueError."""
+    with pytest.raises(ValueError, match="Malformed"):
+        parse_config({**_VALID, "observation": "not-a-mapping"})

--- a/backend/tests/features/media/test_joint_reader.py
+++ b/backend/tests/features/media/test_joint_reader.py
@@ -1,0 +1,55 @@
+"""Tests for joint_reader cache helpers.
+
+The MCAP-reading path (``read_joint_data`` / ``_read_from_mcap``) is marked
+``pragma: no cover``; this covers the cache file naming and load/save helpers.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from app.features.media.joint_reader import (
+    JointData,
+    JointTopicsResponse,
+    _cache_filename,
+    _load_cache,
+    _save_cache,
+)
+
+
+class TestCacheFilename:
+    def test_no_decimation(self) -> None:
+        assert _cache_filename(1) == "joint_data.json"
+        assert _cache_filename(0) == "joint_data.json"
+
+    def test_with_decimation(self) -> None:
+        assert _cache_filename(20) == "joint_data_d20.json"
+
+
+def _sample_response() -> JointTopicsResponse:
+    return JointTopicsResponse(
+        topics=[JointData(topic="/j", joint_names=["a"], timestamps=[0.0], positions=[[1.0]])]
+    )
+
+
+class TestSaveLoadCache:
+    def test_roundtrip(self, tmp_path: Path) -> None:
+        _save_cache(tmp_path, _sample_response(), decimation=1)
+        loaded = _load_cache(tmp_path, decimation=1)
+        assert loaded is not None
+        assert loaded.topics[0].topic == "/j"
+
+    def test_load_missing_returns_none(self, tmp_path: Path) -> None:
+        assert _load_cache(tmp_path, decimation=1) is None
+
+    def test_load_corrupted_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "joint_data.json").write_text("not json {{{", encoding="utf-8")
+        assert _load_cache(tmp_path, decimation=1) is None
+
+    def test_load_invalid_schema_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "joint_data.json").write_text(json.dumps({"unexpected": 1}), encoding="utf-8")
+        assert _load_cache(tmp_path, decimation=1) is None
+
+    def test_save_failure_is_swallowed(self, tmp_path: Path) -> None:
+        with patch("app.features.media.joint_reader.Path.write_text", side_effect=OSError("disk full")):
+            _save_cache(tmp_path, _sample_response(), decimation=1)  # no exception raised

--- a/backend/tests/features/media/test_mcap_converter.py
+++ b/backend/tests/features/media/test_mcap_converter.py
@@ -1,0 +1,20 @@
+"""Tests for the pure helpers in mcap_converter.
+
+The MCAP-reading / ffmpeg-piping functions are marked ``pragma: no cover``; this
+covers the pure timestamp-sorting helper (and forces the module to import so its
+module-level definitions are measured).
+"""
+
+from app.features.media.mcap_converter import _JointTopicData, _sort_topic_data
+
+
+def test_sort_topic_data_empty() -> None:
+    data = _JointTopicData(timestamps=[], positions=[], joint_count=0)
+    assert _sort_topic_data(data) == ([], [])
+
+
+def test_sort_topic_data_orders_by_timestamp() -> None:
+    data = _JointTopicData(timestamps=[30, 10, 20], positions=[[3.0], [1.0], [2.0]], joint_count=1)
+    timestamps, positions = _sort_topic_data(data)
+    assert timestamps == [10, 20, 30]
+    assert positions == [[1.0], [2.0], [3.0]]

--- a/backend/tests/features/media/test_video_generator.py
+++ b/backend/tests/features/media/test_video_generator.py
@@ -1,0 +1,16 @@
+"""Tests for the media video_generator helpers."""
+
+from pathlib import Path
+
+from app.features.media.video_generator import list_videos
+
+
+def test_list_videos_returns_sorted_mp4_names(tmp_path: Path) -> None:
+    (tmp_path / "b.mp4").write_bytes(b"")
+    (tmp_path / "a.mp4").write_bytes(b"")
+    (tmp_path / "notes.txt").write_bytes(b"")
+    assert list_videos(tmp_path) == ["a.mp4", "b.mp4"]
+
+
+def test_list_videos_empty_directory(tmp_path: Path) -> None:
+    assert list_videos(tmp_path) == []

--- a/backend/tests/features/topics/test_models.py
+++ b/backend/tests/features/topics/test_models.py
@@ -263,3 +263,121 @@ class TestToApi:
         assert info.is_subscribed is True
         assert info.qos_reliability == "RELIABLE"
         assert info.message_count == 50
+
+
+# ---------------------------------------------------------------------------
+# counter-based actual_hz (fixed baseline)
+# ---------------------------------------------------------------------------
+
+
+class TestCounterBasedHz:
+    """Tests for the counter-based Hz path used when baseline_fixed is True."""
+
+    def _fixed(self) -> TopicStats:
+        return TopicStats(name="/t", msg_type="x", baseline_hz=10.0, baseline_fixed=True)
+
+    def test_no_data_returns_zero(self) -> None:
+        """No messages yet (counter never started) -> 0 Hz."""
+        stats = self._fixed()
+        stats.refresh_cache(100.0)
+        assert stats.actual_hz == 0.0
+
+    def test_too_short_window_returns_zero(self) -> None:
+        """Less than 0.5 s of data -> 0 Hz."""
+        stats = self._fixed()
+        stats.on_stamp(100.0, None)
+        stats.refresh_cache(100.2)
+        assert stats.actual_hz == 0.0
+
+    def test_computes_rate(self) -> None:
+        """20 messages over 2 s -> ~10 Hz."""
+        stats = self._fixed()
+        for i in range(20):
+            stats.on_stamp(100.0 + i * 0.1, None)
+        stats.refresh_cache(102.0)
+        assert stats.actual_hz == pytest.approx(10.0, abs=0.5)
+
+    def test_resets_after_window(self) -> None:
+        """The counter resets once the window length is exceeded."""
+        stats = self._fixed()
+        for i in range(40):
+            stats.on_stamp(100.0 + i * 0.1, None)
+        stats.refresh_cache(104.0)
+        assert stats.actual_hz == pytest.approx(10.0, abs=0.5)
+        assert stats._hz_count == 0
+        assert stats._hz_count_start == 104.0
+
+
+# ---------------------------------------------------------------------------
+# timestamp-based actual_hz windowing
+# ---------------------------------------------------------------------------
+
+
+class TestTimestampWindow:
+    """Tests for the sliding-window bounds in _compute_hz_from_timestamps."""
+
+    def test_old_timestamps_excluded_by_window(self) -> None:
+        """Timestamps older than the 3 s window are excluded."""
+        ts = deque(float(i) for i in range(11))  # 0..10 s, 1 s apart
+        stats = _make_stats_with_cache(now=10.0, name="/t", msg_type="x", timestamps=ts)
+        assert stats.actual_hz == pytest.approx(1.0, abs=0.01)
+
+    def test_single_recent_timestamp_returns_zero(self) -> None:
+        """Only one timestamp inside the window -> 0 Hz."""
+        ts = deque([0.0, 10.0])
+        stats = _make_stats_with_cache(now=10.0, name="/t", msg_type="x", timestamps=ts)
+        assert stats.actual_hz == 0.0
+
+
+# ---------------------------------------------------------------------------
+# stamp-based quality (stamp_quality=True)
+# ---------------------------------------------------------------------------
+
+
+class TestStampBasedQuality:
+    """Tests for stamp-interval loss counting and the stamp-based loss rate."""
+
+    def test_on_stamp_counts_losses_from_intervals(self) -> None:
+        stats = TopicStats(name="/t", msg_type="x", baseline_hz=10.0, baseline_fixed=True, stamp_quality=True)
+        stats.on_stamp(100.0, 1000.0)  # first stamp
+        stats.on_stamp(100.1, 1000.5)  # 0.5 s gap at 10 Hz -> ~4 lost
+        assert stats._stamp_loss_count == 4
+        stats.on_stamp(100.2, 1000.6)  # 0.1 s gap -> jitter, no extra loss
+        assert stats._stamp_loss_count == 4
+        assert stats._stamp_msg_count == 3
+
+    def test_stamp_based_loss_rate(self) -> None:
+        stats = TopicStats(
+            name="/t",
+            msg_type="x",
+            baseline_hz=10.0,
+            baseline_fixed=True,
+            stamp_quality=True,
+            message_count=10,
+            _last_msg_time=100.0,
+            _gap_threshold_sec=3.0,
+        )
+        stats._stamp_window_start = 100.0
+        stats._stamp_msg_count = 8
+        stats._stamp_loss_count = 2
+        stats.refresh_cache(101.5)  # stamp_elapsed 1.5 s
+        assert stats.loss_rate == pytest.approx(0.2, abs=0.001)  # 2 / (8 + 2)
+
+    def test_stamp_based_loss_rate_resets_window(self) -> None:
+        stats = TopicStats(
+            name="/t",
+            msg_type="x",
+            baseline_hz=10.0,
+            baseline_fixed=True,
+            stamp_quality=True,
+            message_count=10,
+            _last_msg_time=100.0,
+            _gap_threshold_sec=100.0,
+        )
+        stats._stamp_window_start = 100.0
+        stats._stamp_msg_count = 50
+        stats._stamp_loss_count = 5
+        stats.refresh_cache(106.0)  # stamp_elapsed 6 s >= 5 s window -> reset
+        assert stats._stamp_window_start == 106.0
+        assert stats._stamp_loss_count == 0
+        assert stats._stamp_msg_count == 0

--- a/backend/tests/features/topics/test_service.py
+++ b/backend/tests/features/topics/test_service.py
@@ -5,6 +5,8 @@ can be tested without depending on rclpy.
 """
 
 import time
+from types import SimpleNamespace
+from typing import ClassVar
 from unittest.mock import MagicMock
 
 from app.features.topics.service import TopicMonitorService
@@ -475,3 +477,159 @@ class TestPauseResume:
         monitor.resume()
         logs, _ = log_manager.get_logs()
         assert any("resumed" in log.message.lower() for log in logs)
+
+
+# ---------------------------------------------------------------------------
+# Live mode
+# ---------------------------------------------------------------------------
+
+
+class TestLiveMode:
+    """Live-mode accessors (used by image/sensor SSE streaming)."""
+
+    def _subscribe_joint(self, monitor: TopicMonitorService, mock_subscriber: MagicMock) -> None:
+        mock_subscriber.discover_topics.return_value = [("/joint_states", ["sensor_msgs/msg/JointState"])]
+        monitor.on_discover_tick()
+
+    def test_is_live_defaults_false(self, monitor: TopicMonitorService, mock_subscriber: MagicMock) -> None:
+        self._subscribe_joint(monitor, mock_subscriber)
+        assert monitor.is_live("/joint_states") is False
+        assert monitor.is_live("/unknown") is False
+
+    def test_start_live_sets_live(self, monitor: TopicMonitorService, mock_subscriber: MagicMock) -> None:
+        self._subscribe_joint(monitor, mock_subscriber)
+        assert monitor.start_live("/joint_states") is True
+        assert monitor.is_live("/joint_states") is True
+
+    def test_start_live_unknown_returns_false(self, monitor: TopicMonitorService, mock_subscriber: MagicMock) -> None:
+        self._subscribe_joint(monitor, mock_subscriber)
+        assert monitor.start_live("/missing") is False
+
+    def test_start_live_stops_other_sessions(
+        self, monitor: TopicMonitorService, mock_subscriber: MagicMock
+    ) -> None:
+        mock_subscriber.discover_topics.return_value = [
+            ("/joint_states", ["sensor_msgs/msg/JointState"]),
+            ("/arm_states", ["sensor_msgs/msg/JointState"]),
+        ]
+        monitor.on_discover_tick()
+        monitor.update_subscriptions(["/joint_states", "/arm_states"])
+        monitor.start_live("/joint_states")
+        monitor.start_live("/arm_states")
+        assert monitor.is_live("/joint_states") is False
+        assert monitor.is_live("/arm_states") is True
+
+    def test_stop_live(self, monitor: TopicMonitorService, mock_subscriber: MagicMock) -> None:
+        self._subscribe_joint(monitor, mock_subscriber)
+        monitor.start_live("/joint_states")
+        monitor.stop_live("/joint_states")
+        assert monitor.is_live("/joint_states") is False
+
+    def test_stop_live_unknown_is_noop(self, monitor: TopicMonitorService, mock_subscriber: MagicMock) -> None:
+        self._subscribe_joint(monitor, mock_subscriber)
+        monitor.stop_live("/missing")  # no exception
+
+    def test_get_live_raw_image(self, monitor: TopicMonitorService, mock_subscriber: MagicMock) -> None:
+        self._subscribe_joint(monitor, mock_subscriber)
+        assert monitor.get_live_raw_image("/missing") == b""
+        monitor._topic_stats["/joint_states"]._live_raw_image = b"frame"
+        assert monitor.get_live_raw_image("/joint_states") == b"frame"
+
+    def test_get_live_positions_none_when_not_live(
+        self, monitor: TopicMonitorService, mock_subscriber: MagicMock
+    ) -> None:
+        self._subscribe_joint(monitor, mock_subscriber)
+        assert monitor.get_live_positions("/missing") is None
+        assert monitor.get_live_positions("/joint_states") is None  # not in live mode
+
+    def test_get_live_positions_none_when_empty(
+        self, monitor: TopicMonitorService, mock_subscriber: MagicMock
+    ) -> None:
+        self._subscribe_joint(monitor, mock_subscriber)
+        monitor.start_live("/joint_states")
+        assert monitor.get_live_positions("/joint_states") is None  # nothing captured yet
+
+    def test_get_live_positions_returns_data(
+        self, monitor: TopicMonitorService, mock_subscriber: MagicMock
+    ) -> None:
+        self._subscribe_joint(monitor, mock_subscriber)
+        monitor.start_live("/joint_states")
+        stats = monitor._topic_stats["/joint_states"]
+        stats._live_positions = [1.0, 2.0]
+        stats._live_joint_names = ["a", "b"]
+        assert monitor.get_live_positions("/joint_states") == {"positions": [1.0, 2.0], "names": ["a", "b"]}
+
+
+class TestOnMessageLiveCapture:
+    """on_message branches for live capture and image raw-byte swapping."""
+
+    def _subscribe_joint(self, monitor: TopicMonitorService, mock_subscriber: MagicMock) -> None:
+        mock_subscriber.discover_topics.return_value = [("/joint_states", ["sensor_msgs/msg/JointState"])]
+        monitor.on_discover_tick()
+
+    def test_live_joint_capture(self, monitor: TopicMonitorService, mock_subscriber: MagicMock) -> None:
+        self._subscribe_joint(monitor, mock_subscriber)
+        monitor.start_live("/joint_states")
+        monitor.on_message("/joint_states", SimpleNamespace(position=[1.0, 2.0], name=["a", "b"]))
+        assert monitor.get_live_positions("/joint_states") == {"positions": [1.0, 2.0], "names": ["a", "b"]}
+
+    def test_live_wrapped_joint_capture(self, monitor: TopicMonitorService, mock_subscriber: MagicMock) -> None:
+        self._subscribe_joint(monitor, mock_subscriber)
+        monitor.start_live("/joint_states")
+        msg = SimpleNamespace(joint_state=SimpleNamespace(position=[3.0], name=["j1"]))
+        monitor.on_message("/joint_states", msg)
+        assert monitor.get_live_positions("/joint_states") == {"positions": [3.0], "names": ["j1"]}
+
+    def test_live_capture_handles_extraction_error(
+        self, monitor: TopicMonitorService, mock_subscriber: MagicMock
+    ) -> None:
+        self._subscribe_joint(monitor, mock_subscriber)
+        monitor.start_live("/joint_states")
+
+        class _Bad:
+            name: ClassVar[list[str]] = ["x"]
+
+            @property
+            def position(self) -> list[float]:
+                raise RuntimeError("boom")
+
+        monitor.on_message("/joint_states", _Bad())  # exception is swallowed
+        assert monitor.get_live_positions("/joint_states") is None
+
+    def test_image_topic_captures_raw_bytes(
+        self, monitor: TopicMonitorService, mock_subscriber: MagicMock
+    ) -> None:
+        mock_subscriber.discover_topics.return_value = [("/cam/image", ["sensor_msgs/msg/Image"])]
+        monitor.on_discover_tick()
+        monitor.update_subscriptions(["/cam/image"])
+        monitor.on_message("/cam/image", SimpleNamespace(data=b"\xff\xd8jpeg"))
+        assert monitor.get_live_raw_image("/cam/image") == b"\xff\xd8jpeg"
+
+
+class TestSubscribeExpectedHz:
+    """_subscribe_to_topic resolves a fixed baseline from the Hz resolver."""
+
+    def test_fixed_baseline_from_resolver(self, log_manager: LogManager, mock_subscriber: MagicMock) -> None:
+        service = TopicMonitorService(
+            subscribed_topics=["/joint_states"],
+            log_manager=log_manager,
+            resolve_expected_hz=lambda _name: 100.0,
+        )
+        service.set_subscriber(mock_subscriber)
+        mock_subscriber.discover_topics.return_value = [("/joint_states", ["sensor_msgs/msg/JointState"])]
+        service.on_discover_tick()
+        stats = service.get_topic_stats()[0]
+        assert stats.baseline_hz == 100.0
+        assert stats.baseline_fixed is True
+
+    def test_resolver_returns_none(self, log_manager: LogManager, mock_subscriber: MagicMock) -> None:
+        service = TopicMonitorService(
+            subscribed_topics=["/joint_states"],
+            log_manager=log_manager,
+            resolve_expected_hz=lambda _name: None,
+        )
+        service.set_subscriber(mock_subscriber)
+        mock_subscriber.discover_topics.return_value = [("/joint_states", ["sensor_msgs/msg/JointState"])]
+        service.on_discover_tick()
+        stats = service.get_topic_stats()[0]
+        assert stats.baseline_fixed is False

--- a/backend/tests/infra/mcap/test_messages.py
+++ b/backend/tests/infra/mcap/test_messages.py
@@ -1,0 +1,57 @@
+"""Tests for structure-based MCAP message detection / extraction."""
+
+from types import SimpleNamespace
+
+from app.infra.mcap.messages import extract_joint_names, extract_joint_positions, is_image_message
+
+
+class TestIsImageMessage:
+    def test_compressed_image_like(self) -> None:
+        assert is_image_message(SimpleNamespace(format="jpeg", data=b"\xff\xd8")) is True
+
+    def test_bytearray_data(self) -> None:
+        assert is_image_message(SimpleNamespace(format="raw", data=bytearray(b"x"))) is True
+
+    def test_data_not_bytes(self) -> None:
+        assert is_image_message(SimpleNamespace(format="jpeg", data=[1, 2, 3])) is False
+
+    def test_missing_format(self) -> None:
+        assert is_image_message(SimpleNamespace(data=b"x")) is False
+
+
+class TestExtractJointPositions:
+    def test_standard_joint_state(self) -> None:
+        assert extract_joint_positions(SimpleNamespace(position=[1.0, 2.0])) == [1.0, 2.0]
+
+    def test_wrapped_joint_state(self) -> None:
+        msg = SimpleNamespace(joint_state=SimpleNamespace(position=[3.0]))
+        assert extract_joint_positions(msg) == [3.0]
+
+    def test_composite_with_neck(self) -> None:
+        msg = SimpleNamespace(
+            joint_state=SimpleNamespace(position=[1.0]),
+            neck_joint_state=SimpleNamespace(position=[9.0]),
+        )
+        assert extract_joint_positions(msg) == [1.0, 9.0]
+
+    def test_no_position_returns_empty(self) -> None:
+        assert extract_joint_positions(SimpleNamespace(foo=1)) == []
+
+
+class TestExtractJointNames:
+    def test_standard_joint_state(self) -> None:
+        assert extract_joint_names(SimpleNamespace(name=["a", "b"])) == ["a", "b"]
+
+    def test_wrapped_joint_state(self) -> None:
+        msg = SimpleNamespace(joint_state=SimpleNamespace(name=["j1"]))
+        assert extract_joint_names(msg) == ["j1"]
+
+    def test_composite_with_neck(self) -> None:
+        msg = SimpleNamespace(
+            joint_state=SimpleNamespace(name=["a"]),
+            neck_joint_state=SimpleNamespace(name=["neck"]),
+        )
+        assert extract_joint_names(msg) == ["a", "neck"]
+
+    def test_no_name_returns_empty(self) -> None:
+        assert extract_joint_names(SimpleNamespace(position=[1.0])) == []

--- a/backend/tests/infra/mcap/test_timestamp.py
+++ b/backend/tests/infra/mcap/test_timestamp.py
@@ -1,0 +1,34 @@
+"""Tests for header.stamp-preferred timestamp normalization."""
+
+from types import SimpleNamespace
+
+from app.infra.mcap.timestamp import resolve_timestamp_ns, resolve_timestamp_sec
+
+
+def _msg_with_stamp(sec: int, nanosec: int) -> SimpleNamespace:
+    return SimpleNamespace(header=SimpleNamespace(stamp=SimpleNamespace(sec=sec, nanosec=nanosec)))
+
+
+_NO_HEADER = SimpleNamespace(data=b"x")
+
+
+class TestResolveTimestampSec:
+    def test_prefers_header_stamp(self) -> None:
+        assert resolve_timestamp_sec(_msg_with_stamp(100, 500_000_000), log_time_ns=1) == 100.5
+
+    def test_falls_back_to_log_time_without_header(self) -> None:
+        assert resolve_timestamp_sec(_NO_HEADER, log_time_ns=2_000_000_000) == 2.0
+
+    def test_falls_back_when_stamp_is_zero(self) -> None:
+        assert resolve_timestamp_sec(_msg_with_stamp(0, 0), log_time_ns=3_000_000_000) == 3.0
+
+
+class TestResolveTimestampNs:
+    def test_prefers_header_stamp(self) -> None:
+        assert resolve_timestamp_ns(_msg_with_stamp(100, 500_000_000), log_time_ns=1) == 100_500_000_000
+
+    def test_falls_back_to_log_time_without_header(self) -> None:
+        assert resolve_timestamp_ns(_NO_HEADER, log_time_ns=42) == 42
+
+    def test_falls_back_when_stamp_is_zero(self) -> None:
+        assert resolve_timestamp_ns(_msg_with_stamp(0, 0), log_time_ns=7) == 7

--- a/backend/tests/shared/test_stamp.py
+++ b/backend/tests/shared/test_stamp.py
@@ -35,6 +35,11 @@ class TestExtractStampSec:
         assert result is not None
         assert abs(result - 1.123456789) < 1e-9
 
+    def test_missing_sec_or_nanosec_returns_none(self) -> None:
+        """Returns None when sec or nanosec is absent from the stamp."""
+        msg = SimpleNamespace(header=SimpleNamespace(stamp=SimpleNamespace(sec=1)))
+        assert extract_stamp_sec(msg) is None
+
 
 class TestExtractStampNs:
     """Tests for extract_stamp_ns."""
@@ -53,3 +58,12 @@ class TestExtractStampNs:
         """Returns 0 when sec=0 and nanosec=0."""
         msg = SimpleNamespace(header=SimpleNamespace(stamp=SimpleNamespace(sec=0, nanosec=0)))
         assert extract_stamp_ns(msg) == 0
+
+    def test_without_stamp(self) -> None:
+        """Returns None when header is present but stamp is missing."""
+        assert extract_stamp_ns(SimpleNamespace(header=SimpleNamespace())) is None
+
+    def test_missing_sec_or_nanosec_returns_none(self) -> None:
+        """Returns None when sec or nanosec is absent from the stamp."""
+        msg = SimpleNamespace(header=SimpleNamespace(stamp=SimpleNamespace(nanosec=5)))
+        assert extract_stamp_ns(msg) is None

--- a/frontend/src/lib/__tests__/chart-theme.test.ts
+++ b/frontend/src/lib/__tests__/chart-theme.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getChartAxisColors } from "../chart-theme";
+
+describe("getChartAxisColors", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to default colors when the theme variables are unset", () => {
+    // jsdom returns empty strings for unset custom properties.
+    expect(getChartAxisColors()).toEqual({ axis: "#999", grid: "#333" });
+  });
+
+  it("reads and trims the theme variables when present", () => {
+    vi.stubGlobal("getComputedStyle", () => ({
+      getPropertyValue: (name: string) => (name === "--muted-foreground" ? "  #111  " : "  #222  "),
+    }));
+    expect(getChartAxisColors()).toEqual({ axis: "#111", grid: "#222" });
+  });
+});

--- a/frontend/src/lib/__tests__/dev-mode.test.ts
+++ b/frontend/src/lib/__tests__/dev-mode.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isDevMode } from "../dev-mode";
+
+describe("isDevMode", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns false when VITE_DEV_MODE is unset", () => {
+    expect(isDevMode()).toBe(false);
+  });
+
+  it("returns true only when VITE_DEV_MODE is exactly 'true'", () => {
+    vi.stubEnv("VITE_DEV_MODE", "true");
+    expect(isDevMode()).toBe(true);
+  });
+
+  it("returns false for any other value", () => {
+    vi.stubEnv("VITE_DEV_MODE", "1");
+    expect(isDevMode()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Backend coverage had drifted to **90.75%** and frontend to **98.21%** statements / **94.59%** branches. This PR brings both back to **100%**, the level CLAUDE.md mandates — with no production code behavior changes.

| | Before | After |
|---|---|---|
| Backend | 90.75% (672 tests) | **100%** (772 tests) |
| Frontend | 98.21% stmts / 94.59% branch (221 tests) | **100%** all metrics (226 tests) |

## Approach

Following the existing convention — **MCAP I/O and rclpy runtime are `pragma: no cover`; pure logic is unit-tested** — each uncovered region was resolved by *adding a real test* where the code is testable, and a *documented `pragma: no cover`* only where the code is a genuine I/O boundary or is unreachable. No gaps were papered over.

### Tests added / extended
- **infra/mcap**: timestamp normalization, structure-based image/Joint detection
- **media**: `video_generator`, `mcap_converter` sort helper, `joint_reader` cache load/save
- **analysis**: `QualityAnalyzer` lifecycle (mirrors the existing `TimelineAnalyzer` tests), `TimelineAnalyzer.start()` branches
- **jobs**: `JobQueue` infrastructure (worker loop, dispatch, failure/cancellation, history trimming, SSE subscription, media/quality/timeline runs) + `list_jobs` router
- **topics**: live-mode accessors, counter-based and stamp-based quality metrics
- **shared/stamp** and **lerobot_export/config_loader** edge cases
- **frontend lib**: `chart-theme`, `dev-mode`

### `pragma: no cover` (untestable / unreachable only)
- `infra/mcap/reader.py`: `MCAPReader` I/O methods (same MCAP-boundary precedent as `converter.py`'s `read_topic_messages`)
- `media/models.py`: a defensive `return None` that is unreachable once `topic_roles` is non-empty (reason noted inline)

## Verification
- `make test-cov-backend` → 772 passed, **100%**
- `make test-cov-frontend` → 226 passed, **100%** (statements / branches / functions / lines)
- `ruff`, `mypy`, `tsc`, `biome` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)