### PR TITLE
refactor(recordings): rename META_FILENAME to RECORDING_META_FILENAME

### DIFF
--- a/backend/app/features/recordings/meta.py
+++ b/backend/app/features/recordings/meta.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
-META_FILENAME = "recording_meta.json"
+RECORDING_META_FILENAME = "recording_meta.json"
 
 
 class RecordingMeta(BaseModel):
@@ -29,7 +29,7 @@ class RecordingMeta(BaseModel):
 
 def read_recording_meta(directory: Path) -> RecordingMeta | None:
     """Load recording_meta.json. Returns None if the file is missing or corrupt."""
-    meta_path = directory / META_FILENAME
+    meta_path = directory / RECORDING_META_FILENAME
     if not meta_path.exists():
         return None
     try:
@@ -42,7 +42,7 @@ def read_recording_meta(directory: Path) -> RecordingMeta | None:
 
 def write_recording_meta(directory: Path, meta: RecordingMeta) -> None:
     """Write recording_meta.json (plain overwrite, not an atomic replace)."""
-    meta_path = directory / META_FILENAME
+    meta_path = directory / RECORDING_META_FILENAME
     meta_path.write_text(
         json.dumps(meta.model_dump(), indent=2, ensure_ascii=False),
         encoding="utf-8",

--- a/backend/app/features/recordings/scanner.py
+++ b/backend/app/features/recordings/scanner.py
@@ -14,7 +14,7 @@ from pathlib import Path
 # Import the constant directly (not via the package __init__) to avoid eagerly
 # importing the export writer's pandas/numpy stack at recordings-scan time.
 from app.features.lerobot_export.exports import EXPORTS_DIRNAME
-from app.features.recordings.meta import META_FILENAME, read_recording_meta
+from app.features.recordings.meta import RECORDING_META_FILENAME, read_recording_meta
 from app.features.recordings.schemas import FileEntry
 from app.features.upload.cache import CACHE_FILENAME as UPLOAD_STATE_FILENAME
 from app.features.upload.cache import load_state as load_upload_state
@@ -24,7 +24,7 @@ from app.features.validation.cache import load_report as load_validation_report
 logger = logging.getLogger(__name__)
 
 # The bag metadata sidecar that `ros2 bag record` writes next to the .mcap segments
-# (distinct from META_FILENAME / recording_meta.json, this app's own metadata file).
+# (distinct from RECORDING_META_FILENAME / recording_meta.json, this app's own metadata file).
 MCAP_METADATA_FILENAME = "metadata.yaml"
 QUALITY_REPORT_FILENAME = "quality_report.json"
 
@@ -53,7 +53,7 @@ class _ParsedBundle:
 # them (mtime or size) flips the fingerprint and invalidates that folder's entry.
 _SOURCE_FILENAMES: tuple[str, ...] = (
     MCAP_METADATA_FILENAME,
-    META_FILENAME,
+    RECORDING_META_FILENAME,
     VALIDATION_RESULT_FILENAME,
     UPLOAD_STATE_FILENAME,
 )


### PR DESCRIPTION
## Summary

`backend/app/features/recordings/meta.py` の定数 `META_FILENAME` が汎用的すぎて、ROS2 が自動生成する `metadata.yaml`（同じ `scanner.py` 内の `MCAP_METADATA_FILENAME`）と混同しやすかったため、レコーディング固有のメタデータ（`recording_meta.json` / `RecordingMeta`）を指すことが明確になるよう `RECORDING_META_FILENAME` にリネームしました。

## Changes

- `backend/app/features/recordings/meta.py` — 定数定義 + 読み書き2箇所
- `backend/app/features/recordings/scanner.py` — import / `_SOURCE_FILENAMES` での使用 / コメント内の参照

## Notes

- 純粋なリネームで、ファイル名や挙動の変更はありません。
- `MCAP_METADATA_FILENAME`（ROS2 生成の bag サイドカー）は別物のため据え置き。
- テストは文字列リテラル `"recording_meta.json"` を直接使っており定数をインポートしていないため影響なし。
- `docs/` / `README.md` / `CLAUDE.md` を含むリポジトリ全体に `META_FILENAME` の残存参照がないことを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)