### PR TITLE
feat(ui): add toast notifications and use them for recording feedback

### DIFF
--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -1,0 +1,78 @@
+/** shadcn/ui Toast component (Radix UI based). Renders transient notifications in the corner viewport. */
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+import { Toast as ToastPrimitive } from "radix-ui";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+const ToastProvider = ToastPrimitive.Provider;
+
+function ToastViewport({ className, ...props }: React.ComponentProps<typeof ToastPrimitive.Viewport>) {
+  return (
+    <ToastPrimitive.Viewport
+      data-slot="toast-viewport"
+      className={cn(
+        "fixed top-2 left-1/2 z-[100] flex max-h-screen w-full max-w-sm -translate-x-1/2 flex-col items-center gap-2 px-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-start gap-3 overflow-hidden rounded-md border p-4 pr-9 shadow-lg data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-full data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[swipe=move]:translate-y-[var(--radix-toast-swipe-move-y)] data-[swipe=cancel]:translate-y-0 data-[swipe=cancel]:transition-transform data-[swipe=end]:translate-y-[var(--radix-toast-swipe-end-y)]",
+  {
+    variants: {
+      variant: {
+        info: "border-border bg-popover text-popover-foreground",
+        success: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200",
+        error: "border-destructive/40 bg-destructive/15 text-foreground",
+      },
+    },
+    defaultVariants: { variant: "info" },
+  },
+);
+
+function Toast({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<typeof ToastPrimitive.Root> & VariantProps<typeof toastVariants>) {
+  return <ToastPrimitive.Root data-slot="toast" className={cn(toastVariants({ variant }), className)} {...props} />;
+}
+
+function ToastTitle({ className, ...props }: React.ComponentProps<typeof ToastPrimitive.Title>) {
+  return (
+    <ToastPrimitive.Title data-slot="toast-title" className={cn("text-[13px] font-semibold", className)} {...props} />
+  );
+}
+
+function ToastDescription({ className, ...props }: React.ComponentProps<typeof ToastPrimitive.Description>) {
+  return (
+    <ToastPrimitive.Description
+      data-slot="toast-description"
+      className={cn("text-[13px] opacity-90", className)}
+      {...props}
+    />
+  );
+}
+
+function ToastClose({ className, ...props }: React.ComponentProps<typeof ToastPrimitive.Close>) {
+  return (
+    <ToastPrimitive.Close
+      data-slot="toast-close"
+      aria-label="Close"
+      className={cn(
+        "absolute right-2 top-2 rounded-md p-0.5 opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring",
+        className,
+      )}
+      {...props}
+    >
+      <X size={14} />
+    </ToastPrimitive.Close>
+  );
+}
+
+export { Toast, ToastClose, ToastDescription, ToastProvider, ToastTitle, ToastViewport };

--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -1,0 +1,35 @@
+/** Toaster: renders the global toast stack (from the toast store) using Radix Toast. Mounted once at the app root. */
+
+import { CheckCircle2, Info, XCircle } from "lucide-react";
+import { type ToastVariant, useToastStore } from "@/stores/toast-store";
+import { Toast, ToastClose, ToastDescription, ToastProvider, ToastTitle, ToastViewport } from "./toast";
+
+const VARIANT_ICON: Record<ToastVariant, typeof Info> = {
+  success: CheckCircle2,
+  error: XCircle,
+  info: Info,
+};
+
+export function Toaster() {
+  const toasts = useToastStore((s) => s.toasts);
+  const remove = useToastStore((s) => s.remove);
+
+  return (
+    <ToastProvider swipeDirection="up">
+      {toasts.map((t) => {
+        const Icon = VARIANT_ICON[t.variant];
+        return (
+          <Toast key={t.id} variant={t.variant} duration={t.duration} onOpenChange={(open) => !open && remove(t.id)}>
+            <Icon size={15} className="mt-px flex-none" />
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <ToastTitle>{t.title}</ToastTitle>
+              {t.description && <ToastDescription>{t.description}</ToastDescription>}
+            </div>
+            <ToastClose />
+          </Toast>
+        );
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}

--- a/frontend/src/features/recording/__tests__/mutations.test.ts
+++ b/frontend/src/features/recording/__tests__/mutations.test.ts
@@ -2,18 +2,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- Mock setup ---
 
-const { mockSetState, mockAddMarker, mockStartRecordingApi, mockStopRecordingApi, mockGetFiles } = vi.hoisted(() => {
-  const mockAddMarker = vi.fn();
-  return {
-    mockSetState: vi.fn(),
-    mockAddMarker,
-    mockStartRecordingApi: vi.fn(() => Promise.resolve({ status: 200, data: {} })),
-    mockStopRecordingApi: vi.fn(() =>
-      Promise.resolve({ status: 200, data: { duration_sec: 10.5, output_path: "/data/test.mcap" } }),
-    ),
-    mockGetFiles: vi.fn(),
-  };
-});
+const { mockSetState, mockAddMarker, mockStartRecordingApi, mockStopRecordingApi, mockGetFiles, mockToast } =
+  vi.hoisted(() => {
+    const mockAddMarker = vi.fn();
+    return {
+      mockSetState: vi.fn(),
+      mockAddMarker,
+      mockStartRecordingApi: vi.fn(() => Promise.resolve({ status: 200, data: {} })),
+      mockStopRecordingApi: vi.fn(() =>
+        Promise.resolve({ status: 200, data: { duration_sec: 10.5, output_path: "/data/test.mcap" } }),
+      ),
+      mockGetFiles: vi.fn(),
+      mockToast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+    };
+  });
 
 vi.mock("@/lib/query-client", async () => {
   const { QueryClient: QC } = await import("@tanstack/react-query");
@@ -65,9 +67,13 @@ vi.mock("@/lib/query-keys", () => ({
   },
 }));
 
+vi.mock("@/stores/toast-store", () => ({
+  toast: mockToast,
+}));
+
 import { useSettingsStore } from "@/features/settings";
 import { queryClient } from "@/lib/query-client";
-import { clearMessageTimer, showMessage, startRecordingMutation, stopRecordingMutation } from "../mutations";
+import { startRecordingMutation, stopRecordingMutation } from "../mutations";
 
 /** Helper that flushes all pending Promises after mutate. */
 async function flushMutation() {
@@ -92,68 +98,6 @@ function suppressUnhandledRejection() {
     process.removeListener("unhandledRejection", processHandler);
   };
 }
-
-// --- showMessage / clearMessageTimer ---
-
-describe("showMessage", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("sets the message on the store", () => {
-    showMessage("Test success", "success");
-
-    expect(mockSetState).toHaveBeenCalledWith({
-      message: { text: "Test success", type: "success" },
-    });
-  });
-
-  it("auto-clears the message after 5 seconds", () => {
-    showMessage("Transient message", "error");
-
-    vi.advanceTimersByTime(5000);
-
-    expect(mockSetState).toHaveBeenLastCalledWith({ message: null });
-  });
-
-  it("cancels the previous timer on consecutive calls", () => {
-    showMessage("first", "success");
-    showMessage("last", "error");
-
-    // The auto-clear after 5 seconds runs only once.
-    vi.advanceTimersByTime(5000);
-
-    const nullCalls = mockSetState.mock.calls.filter((call) => (call[0] as { message: unknown }).message === null);
-    expect(nullCalls).toHaveLength(1);
-  });
-});
-
-describe("clearMessageTimer", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("cancels the showMessage auto-clear timer", () => {
-    showMessage("Test", "success");
-    clearMessageTimer();
-
-    vi.advanceTimersByTime(5000);
-
-    // setState is called only once (during showMessage; no auto-clear).
-    const nullCalls = mockSetState.mock.calls.filter((call) => (call[0] as { message: unknown }).message === null);
-    expect(nullCalls).toHaveLength(0);
-  });
-});
 
 // --- startRecordingMutation ---
 
@@ -205,13 +149,11 @@ describe("startRecordingMutation", () => {
     expect(mockAddMarker).toHaveBeenCalledWith("start");
   });
 
-  it("shows the start notification message on success", async () => {
+  it("shows the start notification toast on success", async () => {
     startRecordingMutation.mutate(["/topic_a"]);
     await flushMutation();
 
-    expect(mockSetState).toHaveBeenCalledWith({
-      message: { text: "Recording started", type: "success" },
-    });
+    expect(mockToast.success).toHaveBeenCalledWith("Recording started");
   });
 
   it("onSuccess: invalidates the file list 500ms later", async () => {
@@ -231,16 +173,14 @@ describe("startRecordingMutation", () => {
     expect(mockSetState).toHaveBeenCalledWith({ isStarting: false });
   });
 
-  it("shows an error message on error", async () => {
+  it("shows an error toast on error", async () => {
     const cleanup = suppressUnhandledRejection();
     mockStartRecordingApi.mockRejectedValueOnce(new Error("Connection error"));
 
     startRecordingMutation.mutate(["/topic_a"]);
     await flushMutation();
 
-    expect(mockSetState).toHaveBeenCalledWith({
-      message: { text: "Connection error", type: "error" },
-    });
+    expect(mockToast.error).toHaveBeenCalledWith("Connection error");
     cleanup();
   });
 
@@ -251,9 +191,7 @@ describe("startRecordingMutation", () => {
     startRecordingMutation.mutate(["/topic_a"]);
     await flushMutation();
 
-    expect(mockSetState).toHaveBeenCalledWith({
-      message: { text: "Failed to start recording", type: "error" },
-    });
+    expect(mockToast.error).toHaveBeenCalledWith("Failed to start recording");
     cleanup();
   });
 });
@@ -389,16 +327,14 @@ describe("stopRecordingMutation", () => {
     expect(mockSetState).toHaveBeenCalledWith({ isStopping: false });
   });
 
-  it("shows an error message on error", async () => {
+  it("shows an error toast on error", async () => {
     const cleanup = suppressUnhandledRejection();
     mockStopRecordingApi.mockRejectedValueOnce(new Error("Stop failed"));
 
     stopRecordingMutation.mutate(undefined);
     await flushMutation();
 
-    expect(mockSetState).toHaveBeenCalledWith({
-      message: { text: "Stop failed", type: "error" },
-    });
+    expect(mockToast.error).toHaveBeenCalledWith("Stop failed");
     cleanup();
   });
 
@@ -409,9 +345,7 @@ describe("stopRecordingMutation", () => {
     stopRecordingMutation.mutate(undefined);
     await flushMutation();
 
-    expect(mockSetState).toHaveBeenCalledWith({
-      message: { text: "Failed to stop recording", type: "error" },
-    });
+    expect(mockToast.error).toHaveBeenCalledWith("Failed to stop recording");
     cleanup();
   });
 });

--- a/frontend/src/features/recording/__tests__/store.test.ts
+++ b/frontend/src/features/recording/__tests__/store.test.ts
@@ -2,18 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- Mock setup (initialized via vi.hoisted before vi.mock) ---
 
-const {
-  mockMutateStart,
-  mockMutateStop,
-  mockShowMessage,
-  mockClearMessageTimer,
-  mockGetQueryData,
-  mockSelectedTopics,
-} = vi.hoisted(() => ({
+const { mockMutateStart, mockMutateStop, mockToast, mockGetQueryData, mockSelectedTopics } = vi.hoisted(() => ({
   mockMutateStart: vi.fn(),
   mockMutateStop: vi.fn(),
-  mockShowMessage: vi.fn(),
-  mockClearMessageTimer: vi.fn(),
+  mockToast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
   mockGetQueryData: vi.fn((_key?: unknown): unknown => undefined),
   mockSelectedTopics: { current: new Set<string>(["/topic_a", "/topic_b"]) },
 }));
@@ -26,8 +18,10 @@ vi.mock("zustand/middleware", () => ({
 vi.mock("../mutations", () => ({
   startRecordingMutation: { mutate: mockMutateStart },
   stopRecordingMutation: { mutate: mockMutateStop },
-  showMessage: mockShowMessage,
-  clearMessageTimer: mockClearMessageTimer,
+}));
+
+vi.mock("@/stores/toast-store", () => ({
+  toast: mockToast,
 }));
 
 vi.mock("@/lib/query-client", () => ({
@@ -69,7 +63,6 @@ describe("useRecordingStore", () => {
       countdownSec: null,
       isStarting: false,
       isStopping: false,
-      message: null,
       finishedRecording: null,
     });
     mockSelectedTopics.current = new Set(["/topic_a", "/topic_b"]);
@@ -90,7 +83,6 @@ describe("useRecordingStore", () => {
       expect(state.countdownSec).toBeNull();
       expect(state.isStarting).toBe(false);
       expect(state.isStopping).toBe(false);
-      expect(state.message).toBeNull();
       expect(state.finishedRecording).toBeNull();
     });
   });
@@ -206,7 +198,7 @@ describe("useRecordingStore", () => {
       useRecordingStore.getState().stopRecording();
 
       expect(useRecordingStore.getState().countdownSec).toBeNull();
-      expect(mockShowMessage).toHaveBeenCalledWith("Countdown canceled", "error");
+      expect(mockToast.error).toHaveBeenCalledWith("Countdown canceled");
       expect(mockMutateStop).not.toHaveBeenCalled();
     });
 
@@ -252,7 +244,7 @@ describe("useRecordingStore", () => {
       useRecordingStore.getState().toggle();
 
       expect(useRecordingStore.getState().countdownSec).toBeNull();
-      expect(mockShowMessage).toHaveBeenCalledWith("Countdown canceled", "error");
+      expect(mockToast.error).toHaveBeenCalledWith("Countdown canceled");
     });
 
     it("starts recording when idle, connected, and a topic is selected", () => {
@@ -277,7 +269,7 @@ describe("useRecordingStore", () => {
       useRecordingStore.getState().toggle();
 
       expect(mockMutateStart).not.toHaveBeenCalled();
-      expect(mockShowMessage).toHaveBeenCalledWith("Cannot start recording while disconnected", "error");
+      expect(mockToast.error).toHaveBeenCalledWith("Cannot start recording while disconnected");
     });
 
     it("does not start when no topic is selected, and shows a message", () => {
@@ -291,24 +283,7 @@ describe("useRecordingStore", () => {
       useRecordingStore.getState().toggle();
 
       expect(mockMutateStart).not.toHaveBeenCalled();
-      expect(mockShowMessage).toHaveBeenCalledWith("Select at least one topic to record", "error");
-    });
-  });
-
-  // --- clearMessage ---
-
-  describe("clearMessage", () => {
-    it("sets the message to null", () => {
-      useRecordingStore.setState({ message: { text: "Test", type: "success" } });
-      useRecordingStore.getState().clearMessage();
-
-      expect(useRecordingStore.getState().message).toBeNull();
-    });
-
-    it("calls clearMessageTimer", () => {
-      useRecordingStore.getState().clearMessage();
-
-      expect(mockClearMessageTimer).toHaveBeenCalled();
+      expect(mockToast.error).toHaveBeenCalledWith("Select at least one topic to record");
     });
   });
 

--- a/frontend/src/features/recording/completion-banner.tsx
+++ b/frontend/src/features/recording/completion-banner.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { useDeleteRecordings } from "@/hooks/use-api";
 import { useAddLog } from "@/hooks/use-topics-stream";
 import { formatDuration, formatSize } from "@/lib/format";
+import { toast } from "@/stores/toast-store";
 import { useRecordingStore } from "./store";
 
 export function RecordingCompletionBanner() {
@@ -40,10 +41,13 @@ export function RecordingCompletionBanner() {
       {
         onSuccess: () => {
           addLog("info", `Deleted recording: ${finished.name}`);
+          toast.success("Recording deleted", finished.name);
           dismiss();
         },
         onError: (err: unknown) => {
-          addLog("danger", `Delete failed: ${err instanceof Error ? err.message : "Delete failed"}`);
+          const msg = err instanceof Error ? err.message : "Delete failed";
+          addLog("danger", `Delete failed: ${msg}`);
+          toast.error("Delete failed", msg);
         },
       },
     );

--- a/frontend/src/features/recording/index.ts
+++ b/frontend/src/features/recording/index.ts
@@ -1,4 +1,4 @@
 export { RecordingCompletionBanner } from "./completion-banner";
 export { RecordingControl } from "./recording-control";
-export type { FinishedRecording, RecordingMessage } from "./store";
+export type { FinishedRecording } from "./store";
 export { DELAY_OPTIONS, useRecordingStore } from "./store";

--- a/frontend/src/features/recording/mutations.ts
+++ b/frontend/src/features/recording/mutations.ts
@@ -17,12 +17,10 @@ import type { LogEntry } from "@/hooks/use-topics-stream";
 import { queryClient } from "@/lib/query-client";
 import { sseKeys } from "@/lib/query-keys";
 import { useQualityHistoryStore } from "@/stores/quality-history-store";
-import { createTimer } from "./create-timer";
+import { toast } from "@/stores/toast-store";
 import { useRecordingStore } from "./store";
 
 // --- Helpers ---
-
-const messageTimer = createTimer();
 
 /** Append a UI log entry to the TanStack Query cache. */
 function addLog(severity: "info" | "warning" | "danger", message: string) {
@@ -35,17 +33,6 @@ function addLog(severity: "info" | "warning" | "danger", message: string) {
     source: "ui",
   };
   queryClient.setQueryData<LogEntry[]>(sseKeys.logs(), (old) => [...(old ?? []), entry].slice(-500));
-}
-
-/** Set the message and auto-clear it after 5 seconds. */
-export function showMessage(text: string, type: "success" | "error") {
-  useRecordingStore.setState({ message: { text, type } });
-  messageTimer.set(() => useRecordingStore.setState({ message: null }), 5000);
-}
-
-/** Cancel the message auto-clear timer. */
-export function clearMessageTimer() {
-  messageTimer.clear();
 }
 
 // --- MutationObserver ---
@@ -61,14 +48,14 @@ export const startRecordingMutation = new MutationObserver(queryClient, {
   },
   onSuccess: (_data, topics) => {
     useQualityHistoryStore.getState().addMarker("start");
-    showMessage("Recording started", "success");
+    toast.success("Recording started");
     addLog("info", `Recording started (${topics.length} topics)`);
     queryClient.invalidateQueries({ queryKey: getGetRecordingStatusQueryKey() });
     setTimeout(() => queryClient.invalidateQueries({ queryKey: getGetRecordingsQueryKey() }), 500);
   },
   onError: (error) => {
     const msg = error.message || "Failed to start recording";
-    showMessage(msg, "error");
+    toast.error(msg);
     addLog("danger", `Recording start failed: ${msg}`);
   },
   onSettled: () => {
@@ -87,7 +74,7 @@ export const stopRecordingMutation = new MutationObserver(queryClient, {
     queryClient.invalidateQueries({ queryKey: getGetRecordingStatusQueryKey() });
     if (resp.status !== 200) return;
     const d = resp.data;
-    showMessage("Recording completed", "success");
+    toast.success("Recording completed");
     addLog("info", `Recording stopped (${d.duration_sec.toFixed(1)}s) → ${d.output_path}`);
     // Force-refresh the file list to fetch the latest mcap.
     // invalidateQueries notifies every observer to refetch, ensuring the UI updates.
@@ -138,7 +125,7 @@ export const stopRecordingMutation = new MutationObserver(queryClient, {
   },
   onError: (error) => {
     const msg = error.message || "Failed to stop recording";
-    showMessage(msg, "error");
+    toast.error(msg);
     addLog("danger", `Recording stop failed: ${msg}`);
   },
   onSettled: () => {

--- a/frontend/src/features/recording/recording-control.tsx
+++ b/frontend/src/features/recording/recording-control.tsx
@@ -19,7 +19,6 @@ export function RecordingControl() {
 
   const isCountingDown = useRecordingStore((s) => s.countdownSec !== null);
   const loading = useRecordingStore((s) => s.isStarting || s.isStopping);
-  const message = useRecordingStore((s) => s.message);
   const delaySec = useRecordingStore((s) => s.delaySec);
   const setDelay = useRecordingStore((s) => s.setDelay);
   const [copied, setCopied] = useState(false);
@@ -106,16 +105,6 @@ export function RecordingControl() {
             <ClipboardCopy size={13} />
             <span>{copied ? "Copied" : "Copy command"}</span>
           </button>
-        )}
-
-        {/* Transient message (set via showMessage; auto-clears after 5 seconds) */}
-        {message && (
-          <span
-            className={`text-[13px] ${message.type === "success" ? "text-emerald-400" : "text-red-400"}`}
-            role="status"
-          >
-            {message.text}
-          </span>
         )}
 
         {/* Warn when YAML default topics have not yet been received via SSE.

--- a/frontend/src/features/recording/store.ts
+++ b/frontend/src/features/recording/store.ts
@@ -11,17 +11,12 @@ import { useLiveTopicsStore } from "@/features/live-topics";
 import type { SseConnectionStatus } from "@/hooks/use-topics-stream";
 import { queryClient } from "@/lib/query-client";
 import { sseKeys } from "@/lib/query-keys";
+import { toast } from "@/stores/toast-store";
 import { createTimer } from "./create-timer";
-import { clearMessageTimer, showMessage, startRecordingMutation, stopRecordingMutation } from "./mutations";
+import { startRecordingMutation, stopRecordingMutation } from "./mutations";
 
 /** Available delay options. */
 export const DELAY_OPTIONS = [0, 3, 5, 10] as const;
-
-/** Feedback message. */
-export interface RecordingMessage {
-  text: string;
-  type: "success" | "error";
-}
 
 /** Info about the just-finished recording (used to render the completion banner). */
 export interface FinishedRecording {
@@ -50,8 +45,6 @@ interface RecordingStore {
   isStarting: boolean;
   /** A stop request is in flight. */
   isStopping: boolean;
-  /** Feedback message. */
-  message: RecordingMessage | null;
   /** Info about the most recently finished recording (rendered as a banner; dismissed with × or cleared when a new recording starts). */
   finishedRecording: FinishedRecording | null;
 
@@ -65,8 +58,6 @@ interface RecordingStore {
   stopRecording: () => void;
   /** Dispatch start/stop based on loading/isRecording/isCountingDown. */
   toggle: () => void;
-  /** Clear the message. */
-  clearMessage: () => void;
   /** Close the completion banner. */
   dismissFinishedRecording: () => void;
 }
@@ -107,7 +98,6 @@ export const useRecordingStore = create<RecordingStore>()(
         countdownSec: null,
         isStarting: false,
         isStopping: false,
-        message: null,
         finishedRecording: null,
 
         setDelay: (sec) => set({ delaySec: sec }, false, "setDelay"),
@@ -130,7 +120,7 @@ export const useRecordingStore = create<RecordingStore>()(
           if (countdownSec !== null) {
             countdownTimer.clear();
             set({ countdownSec: null }, false, "cancelCountdown");
-            showMessage("Countdown canceled", "error");
+            toast.error("Countdown canceled");
             return;
           }
           stopRecordingMutation.mutate(undefined);
@@ -146,19 +136,14 @@ export const useRecordingStore = create<RecordingStore>()(
           // Mirror the record button's start preconditions (record-button.tsx): require a live
           // connection and at least one selected topic, with feedback when a start is refused.
           if (getConnectionStatus() !== "connected") {
-            showMessage("Cannot start recording while disconnected", "error");
+            toast.error("Cannot start recording while disconnected");
             return;
           }
           if (useLiveTopicsStore.getState().selectedTopics.size === 0) {
-            showMessage("Select at least one topic to record", "error");
+            toast.error("Select at least one topic to record");
             return;
           }
           startRecording();
-        },
-
-        clearMessage: () => {
-          clearMessageTimer();
-          set({ message: null }, false, "clearMessage");
         },
 
         dismissFinishedRecording: () => set({ finishedRecording: null }, false, "dismissFinishedRecording"),

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { createRootRoute, Outlet } from "@tanstack/react-router";
 import { Header } from "@/components/layout/header";
 import { StatusBar } from "@/components/layout/StatusBar";
+import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useJobsStream } from "@/hooks/use-jobs-stream";
 import { isDevMode } from "@/lib/dev-mode";
@@ -33,6 +34,7 @@ function RootLayoutInner() {
         {/* StatusBar is shown only in dev mode (VITE_DEV_MODE=true). */}
         {isDevMode() && <StatusBar />}
       </div>
+      <Toaster />
     </TooltipProvider>
   );
 }

--- a/frontend/src/stores/__tests__/toast-store.test.ts
+++ b/frontend/src/stores/__tests__/toast-store.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { TOAST_DURATION_MS, TOAST_LIMIT, toast, useToastStore } from "../toast-store";
+
+describe("useToastStore", () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  describe("add", () => {
+    it("pushes a toast and returns its id", () => {
+      const id = useToastStore.getState().add({ title: "Hello", variant: "info", duration: 1000 });
+
+      const { toasts } = useToastStore.getState();
+      expect(toasts).toHaveLength(1);
+      expect(toasts[0]).toMatchObject({ id, title: "Hello", variant: "info", duration: 1000 });
+    });
+
+    it("assigns a unique id to each toast", () => {
+      const first = useToastStore.getState().add({ title: "a", variant: "info", duration: 1000 });
+      const second = useToastStore.getState().add({ title: "b", variant: "info", duration: 1000 });
+
+      expect(first).not.toBe(second);
+    });
+
+    it("caps the stack at TOAST_LIMIT, dropping the oldest", () => {
+      for (let i = 0; i < TOAST_LIMIT + 2; i++) {
+        useToastStore.getState().add({ title: `t${i}`, variant: "info", duration: 1000 });
+      }
+
+      const { toasts } = useToastStore.getState();
+      expect(toasts).toHaveLength(TOAST_LIMIT);
+      expect(toasts[0].title).toBe("t2");
+      expect(toasts[TOAST_LIMIT - 1].title).toBe(`t${TOAST_LIMIT + 1}`);
+    });
+  });
+
+  describe("remove", () => {
+    it("removes the toast with the given id and leaves the rest", () => {
+      const keep = useToastStore.getState().add({ title: "keep", variant: "info", duration: 1000 });
+      const drop = useToastStore.getState().add({ title: "drop", variant: "info", duration: 1000 });
+
+      useToastStore.getState().remove(drop);
+
+      const { toasts } = useToastStore.getState();
+      expect(toasts).toHaveLength(1);
+      expect(toasts[0].id).toBe(keep);
+    });
+  });
+
+  describe("toast helper", () => {
+    it("success adds a success toast with the default duration", () => {
+      toast.success("Done", "details");
+
+      expect(useToastStore.getState().toasts[0]).toMatchObject({
+        title: "Done",
+        description: "details",
+        variant: "success",
+        duration: TOAST_DURATION_MS,
+      });
+    });
+
+    it("error adds an error toast", () => {
+      toast.error("Boom");
+
+      expect(useToastStore.getState().toasts[0]).toMatchObject({ title: "Boom", variant: "error" });
+    });
+
+    it("info adds an info toast", () => {
+      toast.info("FYI");
+
+      expect(useToastStore.getState().toasts[0]).toMatchObject({ title: "FYI", variant: "info" });
+    });
+  });
+});

--- a/frontend/src/stores/toast-store.ts
+++ b/frontend/src/stores/toast-store.ts
@@ -1,0 +1,53 @@
+/** Global toast notification store.
+ *
+ * Holds the active toast stack and exposes an imperative `toast` helper so
+ * non-React callers (mutation observers, other stores) can raise notifications.
+ * The <Toaster /> component subscribes to this store and renders each toast with
+ * Radix Toast, which owns the auto-dismiss timer, pause-on-hover, and swipe-to-dismiss.
+ */
+import { create } from "zustand";
+
+export type ToastVariant = "success" | "error" | "info";
+
+/** Default auto-dismiss duration in milliseconds. */
+export const TOAST_DURATION_MS = 5000;
+/** Maximum number of toasts shown at once (older toasts drop off the stack). */
+export const TOAST_LIMIT = 4;
+
+export interface ToastItem {
+  id: string;
+  title: string;
+  description?: string;
+  variant: ToastVariant;
+  duration: number;
+}
+
+interface ToastStore {
+  toasts: ToastItem[];
+  /** Push a toast onto the stack and return its id. */
+  add: (toast: Omit<ToastItem, "id">) => string;
+  /** Remove a toast (called once Radix reports it closed). */
+  remove: (id: string) => void;
+}
+
+let counter = 0;
+
+export const useToastStore = create<ToastStore>((set) => ({
+  toasts: [],
+  add: (toast) => {
+    const id = `toast-${++counter}`;
+    set((state) => ({ toasts: [...state.toasts, { ...toast, id }].slice(-TOAST_LIMIT) }));
+    return id;
+  },
+  remove: (id) => set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
+}));
+
+/** Imperative helper usable from anywhere (React components or plain modules). */
+export const toast = {
+  success: (title: string, description?: string) =>
+    useToastStore.getState().add({ title, description, variant: "success", duration: TOAST_DURATION_MS }),
+  error: (title: string, description?: string) =>
+    useToastStore.getState().add({ title, description, variant: "error", duration: TOAST_DURATION_MS }),
+  info: (title: string, description?: string) =>
+    useToastStore.getState().add({ title, description, variant: "info", duration: TOAST_DURATION_MS }),
+};

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -21,6 +21,7 @@ export default mergeConfig(
           "src/features/**/quality-utils.tsx",
           "src/features/recording/store.ts",
           "src/stores/quality-history-store.ts",
+          "src/stores/toast-store.ts",
         ],
         exclude: ["src/api/generated/**", "src/lib/utils.ts", "src/lib/query-client.ts"],
         thresholds: {


### PR DESCRIPTION
## Summary

Recording feedback on the top page was shown inconsistently: start/stop used an inline text message in the control bar (auto-clearing after 5s), while delete only wrote to the log panel. This PR unifies all of it behind **toast notifications**, rendered top-center overlapping the header so they don't cover the LOSS RATE chart.

Built on the **existing `radix-ui` dependency** (Radix Toast) — no new package added.

## Changes

- **New toaster UI** (`components/ui/toast.tsx` + `toaster.tsx`): shadcn-style wrapper over Radix Toast, with `success` / `error` / `info` variants. Radix owns auto-dismiss, pause-on-hover, and swipe-to-dismiss.
- **New global toast store** (`stores/toast-store.ts`): imperative `toast.success/error/info` helper usable from non-React code (mutation observers, the recording store); stack capped at 4, 5s default duration.
- **Mounted `<Toaster />`** once at the app root (`routes/__root.tsx`).
- **Migrated recording feedback** to toasts: start / stop / completion / errors, countdown-cancel, and start preconditions (disconnected / no topic selected); plus a toast on **delete success/failure** (previously log-only).
- **Removed** the now-unused inline `message` state, `RecordingMessage` type, and `clearMessage` plumbing from the recording store.
- **Placement**: top-center, overlapping the header (`top-2 left-1/2 -translate-x-1/2`), slide-in from top, swipe-up to dismiss.

## Testing

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec biome check src/` — clean
- `pnpm exec vitest run --coverage` — **227 tests pass, 100% coverage** (statements/branches/functions/lines)
- Updated recording mutation/store tests to assert on the toast helper; added a `toast-store` test.
- Verified visually in the dev environment (recording start / delete).

## Notes

- `toast.tsx` / `toaster.tsx` are shadcn-derived and live under `frontend/src/components/ui/*.tsx`. This branch's `NOTICE` does not yet carry the third-party file-attribution section (existing shadcn files like `alert-dialog.tsx` are also unlisted here), so no `NOTICE` edit was made; once that section lands, the `components/ui/*.tsx` wildcard will cover these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
