### PR TITLE
feat(analysis): prefer configured expected_hz for quality report loss rate

### DIFF
--- a/backend/app/features/analysis/mcap_analyzer.py
+++ b/backend/app/features/analysis/mcap_analyzer.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from app.features.analysis.models import QualityReport
 from app.infra.mcap import MCAPReader, find_mcap_files, resolve_timestamp_sec
+from app.settings import get_settings
 from app.shared.stamp import extract_stamp_sec
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,7 @@ def _analyze_mcap(directory: Path) -> QualityReport:  # pragma: no cover
         topic_types=topic_types,
         file_size=file_size,
         topic_stamp_sources=topic_stamp_sources,
+        resolve_expected_hz=get_settings().recording.resolve_expected_hz,
     )
 
 

--- a/backend/app/features/analysis/models.py
+++ b/backend/app/features/analysis/models.py
@@ -8,6 +8,7 @@ See docs/domain/quality_analysis.md for details on quality metrics.
 """
 
 import statistics
+from collections.abc import Callable
 
 from pydantic import BaseModel, Field
 
@@ -112,8 +113,17 @@ class TopicQuality(BaseModel):
         recording_start: float,
         duration_sec: float,
         timestamp_source: str = "log_time",
+        config_expected_hz: float | None = None,
     ) -> "TopicQuality":
-        """Compute quality metrics from timestamps and sizes."""
+        """Compute quality metrics from timestamps and sizes.
+
+        When ``config_expected_hz`` is provided (the RECORDING_CONFIG
+        ``expected_hz_patterns`` value for this topic), it is used as the
+        expected frequency instead of the rate estimated from the data. It
+        drives the loss-rate denominator, the gap/loss detection thresholds,
+        and the reported ``expected_frequency_hz``. A ``None`` or non-positive
+        value falls back to snapping the measured rate to a standard frequency.
+        """
         timestamps.sort()
         msg_count = len(timestamps)
         size_stats = MessageSizeStats.from_sizes(sizes)
@@ -123,15 +133,20 @@ class TopicQuality(BaseModel):
         recording_end = recording_start + duration_sec
         end_early = recording_end - timestamps[-1] if timestamps else 0.0
 
-        # Skip frequency analysis when there are too few messages
+        # Skip interval-based analysis when there are too few messages. Interval
+        # metrics need >= 2 samples, but with a config-declared expected Hz the
+        # loss rate can still be computed from the count against the configured
+        # rate, so a near-empty configured topic is not reported as healthy.
         if msg_count < 2:
+            expected_hz = config_expected_hz if config_expected_hz is not None and config_expected_hz > 0 else 0.0
+            loss_rate = cls._count_loss_rate(msg_count, expected_hz, duration_sec)
             return cls(
                 name=name,
                 msg_type=msg_type,
                 message_count=msg_count,
                 actual_frequency_hz=0.0,
-                expected_frequency_hz=0.0,
-                loss_rate=0.0,
+                expected_frequency_hz=expected_hz,
+                loss_rate=round(loss_rate, 4),
                 frequency_std_hz=0.0,
                 data_continuity_score=1.0,
                 gap_count=0,
@@ -145,25 +160,27 @@ class TopicQuality(BaseModel):
                 size_stats=size_stats,
                 start_delay_sec=round(start_delay, 3),
                 end_early_sec=round(max(0.0, end_early), 3),
-                status="ok",
+                status=cls._status_from_loss_rate(loss_rate),
             )
 
         # Frequency calculation (median of message intervals)
         intervals = [timestamps[i + 1] - timestamps[i] for i in range(msg_count - 1)]
         median_interval = statistics.median(intervals)
         actual_hz = 1.0 / median_interval if median_interval > 0 else 0.0
-        expected_hz = cls._estimate_expected_frequency(actual_hz)
+        # A config-declared expected Hz wins; otherwise snap the measured rate to
+        # the nearest standard frequency.
+        expected_hz = (
+            config_expected_hz
+            if config_expected_hz is not None and config_expected_hz > 0
+            else cls._estimate_expected_frequency(actual_hz)
+        )
 
         # Frequency standard deviation
         freq_values = [1.0 / iv if iv > 0 else 0.0 for iv in intervals]
         freq_std = statistics.stdev(freq_values) if len(freq_values) > 1 else 0.0
 
-        # Loss rate
-        if expected_hz > 0 and duration_sec > 0:
-            expected_count = expected_hz * duration_sec
-            loss_rate = max(0.0, 1.0 - (msg_count / expected_count))
-        else:
-            loss_rate = 0.0
+        # Loss rate (message count against the expected frame count)
+        loss_rate = cls._count_loss_rate(msg_count, expected_hz, duration_sec)
 
         expected_interval = 1.0 / expected_hz if expected_hz > 0 else median_interval
 
@@ -320,6 +337,31 @@ class TopicQuality(BaseModel):
         return float(min(_STANDARD_FREQUENCIES, key=lambda f: abs(f - actual_hz)))
 
     @staticmethod
+    def _count_loss_rate(msg_count: int, expected_hz: float, duration_sec: float) -> float:
+        """Count-based loss rate: 1 - actual/expected.
+
+        Returns 0.0 when the expected frame count is unknown (expected_hz or
+        duration is non-positive).
+        """
+        if expected_hz > 0 and duration_sec > 0:
+            expected_count = expected_hz * duration_sec
+            return max(0.0, 1.0 - (msg_count / expected_count))
+        return 0.0
+
+    @staticmethod
+    def _status_from_loss_rate(loss_rate: float) -> str:
+        """Map a count-based loss rate to a quality status.
+
+        Used when there are too few messages for interval-based severity
+        classification but a configured expected Hz still yields a loss rate.
+        """
+        if loss_rate > _LOSS_RATE_DANGER:
+            return "danger"
+        if loss_rate > _LOSS_RATE_WARN:
+            return "warning"
+        return "ok"
+
+    @staticmethod
     def _determine_status(major_loss: int, minor_loss: int, msg_count: int, loss_count: int = 0) -> str:
         """Determine the quality status.
 
@@ -356,8 +398,15 @@ class QualityReport(BaseModel):
         topic_types: dict[str, str],
         file_size: int,
         topic_stamp_sources: dict[str, str] | None = None,
+        resolve_expected_hz: Callable[[str], float | None] | None = None,
     ) -> "QualityReport":
-        """Build a quality report from data extracted from MCAP."""
+        """Build a quality report from data extracted from MCAP.
+
+        ``resolve_expected_hz`` resolves the config-declared expected Hz
+        (RECORDING_CONFIG ``expected_hz_patterns``) for a topic name; when it
+        returns a value, that value overrides the auto-estimated expected Hz
+        for that topic (see ``TopicQuality.from_timestamps``).
+        """
         stamp_sources = topic_stamp_sources or {}
 
         # Overall timestamp range
@@ -380,6 +429,7 @@ class QualityReport(BaseModel):
                 recording_start=recording_start,
                 duration_sec=duration_sec,
                 timestamp_source=stamp_sources.get(topic_name, "log_time"),
+                config_expected_hz=(resolve_expected_hz(topic_name) if resolve_expected_hz else None),
             )
             for topic_name, timestamps in sorted(topic_timestamps.items())
         ]

--- a/backend/app/features/analysis/timeline_analyzer.py
+++ b/backend/app/features/analysis/timeline_analyzer.py
@@ -8,6 +8,7 @@ Also exposes per-message lookups used by the rug plot.
 import json
 import logging
 import math
+from collections.abc import Callable
 from pathlib import Path
 
 from pydantic import ValidationError
@@ -22,6 +23,7 @@ from app.features.analysis.schemas import (
     TimelineTopic,
 )
 from app.infra.mcap import MCAPReader, find_mcap_files, resolve_timestamp_sec
+from app.settings import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +66,12 @@ def build_and_save_timeline(directory: Path) -> TimelineData:  # pragma: no cove
         log_time_min_ns, _ = reader.get_time_range_ns()
 
     topic_timestamps, _topic_sizes, topic_types, _stamp_sources = _read_mcap(mcap_path)
-    data = _build_timeline(topic_timestamps, topic_types, log_time_min_ns=log_time_min_ns)
+    data = _build_timeline(
+        topic_timestamps,
+        topic_types,
+        log_time_min_ns=log_time_min_ns,
+        resolve_expected_hz=get_settings().recording.resolve_expected_hz,
+    )
 
     cache_path = directory / _CACHE_FILENAME
     cache_path.write_text(
@@ -216,6 +223,7 @@ def _build_timeline(
     topic_timestamps: dict[str, list[float]],
     topic_types: dict[str, str],
     log_time_min_ns: int = 0,
+    resolve_expected_hz: Callable[[str], float | None] | None = None,
 ) -> TimelineData:
     """Build timeline data from a topic-to-timestamps dictionary.
 
@@ -223,6 +231,10 @@ def _build_timeline(
         The diff against recording_start_ns (header.stamp based) is stored as
         log_time_offset_ns and used as the log_time filter origin when the
         rug plot scans the MCAP.
+    resolve_expected_hz: resolves the config-declared expected Hz
+        (RECORDING_CONFIG expected_hz_patterns) for a topic name. When it
+        returns a value, that value overrides the auto-estimated expected Hz
+        for that topic (matching the quality report).
     """
     all_ts: list[float] = []
     for ts_list in topic_timestamps.values():
@@ -247,7 +259,9 @@ def _build_timeline(
     topics: list[TimelineTopic] = []
     for topic_name in sorted(topic_timestamps.keys()):
         timestamps = sorted(topic_timestamps[topic_name])
-        expected_hz = _estimate_hz(timestamps)
+        # A config-declared expected Hz wins; otherwise estimate from the data.
+        config_hz = resolve_expected_hz(topic_name) if resolve_expected_hz else None
+        expected_hz = config_hz if config_hz is not None and config_hz > 0 else _estimate_hz(timestamps)
         msg_type = topic_types.get(topic_name, "unknown")
 
         # Binning (keep expected as float; rounding introduces quantization noise)

--- a/backend/tests/features/analysis/test_models.py
+++ b/backend/tests/features/analysis/test_models.py
@@ -1,5 +1,7 @@
 """Tests for file-quality analysis domain models."""
 
+import pytest
+
 from app.features.analysis.models import MessageSizeStats, QualityReport, TopicQuality
 
 
@@ -298,3 +300,146 @@ class TestLossEvents:
         # Tail is end_early (max timestamp_sec ~ 8.2, just before the 10 s recording end)
         assert tq.loss_events[-1].timestamp_sec > 7.0
         assert tq.loss_events[-1].timestamp_sec < 10.0
+
+
+# ---------------------------------------------------------------------------
+# Config-declared expected Hz (RECORDING_CONFIG expected_hz_patterns)
+# ---------------------------------------------------------------------------
+
+
+class TestCountLossRate:
+    """Tests for TopicQuality._count_loss_rate()."""
+
+    def test_computes_deficit(self) -> None:
+        """1 - actual/expected against the configured frame count."""
+        # expected = 100 Hz * 1 s = 100 frames; 25 received -> 75% loss
+        assert TopicQuality._count_loss_rate(25, 100.0, 1.0) == 0.75
+
+    def test_no_loss_when_more_than_expected(self) -> None:
+        """Receiving more than expected clamps to 0.0 (no negative loss)."""
+        assert TopicQuality._count_loss_rate(150, 100.0, 1.0) == 0.0
+
+    def test_zero_when_expected_hz_unknown(self) -> None:
+        assert TopicQuality._count_loss_rate(10, 0.0, 1.0) == 0.0
+
+    def test_zero_when_duration_unknown(self) -> None:
+        assert TopicQuality._count_loss_rate(10, 100.0, 0.0) == 0.0
+
+
+class TestStatusFromLossRate:
+    """Tests for TopicQuality._status_from_loss_rate()."""
+
+    def test_danger(self) -> None:
+        assert TopicQuality._status_from_loss_rate(0.1) == "danger"
+
+    def test_warning(self) -> None:
+        assert TopicQuality._status_from_loss_rate(0.03) == "warning"
+
+    def test_ok(self) -> None:
+        assert TopicQuality._status_from_loss_rate(0.0) == "ok"
+
+
+class TestConfigExpectedHz:
+    """Tests for the config-declared expected Hz overriding the auto estimate."""
+
+    def test_config_hz_drives_expected_and_loss_rate(self) -> None:
+        """A configured Hz becomes expected_frequency_hz and the loss-rate denominator."""
+        ts = [i * 0.1 for i in range(11)]  # 10 Hz measured, over 1.0 s
+        tq = TopicQuality.from_timestamps(
+            name="/cam",
+            msg_type="sensor_msgs/msg/CompressedImage",
+            timestamps=ts,
+            sizes=[100] * len(ts),
+            recording_start=0.0,
+            duration_sec=1.0,
+            config_expected_hz=20.0,
+        )
+        # Not snapped to the nearest standard frequency (10.0) -> the config value wins
+        assert tq.expected_frequency_hz == 20.0
+        # 11 received against 20 expected -> 45% loss
+        assert tq.loss_rate == pytest.approx(0.45)
+
+    def test_falls_back_to_estimate_when_config_hz_absent(self) -> None:
+        """Without a configured Hz, expected_frequency_hz is the auto estimate."""
+        ts = [i * 0.1 for i in range(11)]  # 10 Hz measured
+        tq = TopicQuality.from_timestamps(
+            name="/cam",
+            msg_type="sensor_msgs/msg/CompressedImage",
+            timestamps=ts,
+            sizes=[100] * len(ts),
+            recording_start=0.0,
+            duration_sec=1.0,
+            config_expected_hz=None,
+        )
+        assert tq.expected_frequency_hz == 10.0
+        assert tq.loss_rate == 0.0
+
+    def test_falls_back_to_estimate_when_config_hz_non_positive(self) -> None:
+        """A non-positive configured Hz is ignored (falls back to the auto estimate)."""
+        ts = [i * 0.1 for i in range(11)]  # 10 Hz measured
+        tq = TopicQuality.from_timestamps(
+            name="/cam",
+            msg_type="sensor_msgs/msg/CompressedImage",
+            timestamps=ts,
+            sizes=[100] * len(ts),
+            recording_start=0.0,
+            duration_sec=1.0,
+            config_expected_hz=0.0,
+        )
+        assert tq.expected_frequency_hz == 10.0
+
+    def test_single_message_with_config_hz_reports_loss(self) -> None:
+        """With too few messages, a configured Hz still yields a count-based loss and status."""
+        tq = TopicQuality.from_timestamps(
+            name="/cam",
+            msg_type="sensor_msgs/msg/CompressedImage",
+            timestamps=[0.0],
+            sizes=[100],
+            recording_start=0.0,
+            duration_sec=10.0,
+            config_expected_hz=30.0,
+        )
+        assert tq.expected_frequency_hz == 30.0
+        # 1 received against 30 Hz * 10 s = 300 expected -> ~99.7% loss
+        assert tq.loss_rate == pytest.approx(0.9967)
+        assert tq.status == "danger"
+
+    def test_single_message_without_config_hz_stays_ok(self) -> None:
+        """With too few messages and no configured Hz, the topic is reported as healthy."""
+        tq = TopicQuality.from_timestamps(
+            name="/cam",
+            msg_type="std_msgs/msg/String",
+            timestamps=[0.0],
+            sizes=[100],
+            recording_start=0.0,
+            duration_sec=10.0,
+        )
+        assert tq.expected_frequency_hz == 0.0
+        assert tq.loss_rate == 0.0
+        assert tq.status == "ok"
+
+    def test_resolve_expected_hz_overrides_per_topic(self) -> None:
+        """from_mcap_data forwards the resolved config Hz to each topic."""
+        ts = [i * 0.1 for i in range(11)]  # 10 Hz measured, over 1.0 s
+        report = QualityReport.from_mcap_data(
+            topic_timestamps={"/cam": ts},
+            topic_sizes={"/cam": [100] * len(ts)},
+            topic_types={"/cam": "sensor_msgs/msg/CompressedImage"},
+            file_size=1100,
+            resolve_expected_hz=lambda name: 20.0 if name == "/cam" else None,
+        )
+        tq = report.topics[0]
+        assert tq.expected_frequency_hz == 20.0
+        assert tq.loss_rate == pytest.approx(0.45)
+
+    def test_resolve_expected_hz_none_falls_back(self) -> None:
+        """A resolver that returns None leaves the topic on the auto estimate."""
+        ts = [i * 0.1 for i in range(11)]  # 10 Hz measured
+        report = QualityReport.from_mcap_data(
+            topic_timestamps={"/cam": ts},
+            topic_sizes={"/cam": [100] * len(ts)},
+            topic_types={"/cam": "sensor_msgs/msg/CompressedImage"},
+            file_size=1100,
+            resolve_expected_hz=lambda name: None,
+        )
+        assert report.topics[0].expected_frequency_hz == 10.0

--- a/backend/tests/features/analysis/test_timeline_analyzer.py
+++ b/backend/tests/features/analysis/test_timeline_analyzer.py
@@ -258,6 +258,26 @@ class TestBuildTimeline:
         assert topic.expected_hz == 30.0
         assert len(topic.bins) > 0
 
+    def test_config_expected_hz_overrides_estimate(self) -> None:
+        """A configured Hz overrides the estimated expected_hz (matches the quality report)."""
+        timestamps = [i * 0.033 for i in range(30)]  # ~30 Hz measured
+        data = _build_timeline(
+            {"/cam": timestamps},
+            {"/cam": "sensor_msgs/CompressedImage"},
+            resolve_expected_hz=lambda name: 100.0,
+        )
+        assert data.topics[0].expected_hz == 100.0
+
+    def test_config_expected_hz_none_falls_back_to_estimate(self) -> None:
+        """A resolver returning None leaves the estimated expected_hz in place."""
+        timestamps = [i * 0.033 for i in range(30)]  # ~30 Hz measured
+        data = _build_timeline(
+            {"/cam": timestamps},
+            {"/cam": "sensor_msgs/CompressedImage"},
+            resolve_expected_hz=lambda name: None,
+        )
+        assert data.topics[0].expected_hz == 30.0
+
     def test_unknown_msg_type(self) -> None:
         """A topic missing from topic_types is unknown."""
         timestamps = [i * 0.033 for i in range(30)]

--- a/config/simulator.yaml
+++ b/config/simulator.yaml
@@ -54,10 +54,13 @@ validators:
     min_sec: 5
     max_sec: 30
 
-# Expected Hz for quality monitoring (pattern match, first match wins).
-# Omit `hz` to enable dynamic learning (auto-computed from message intervals
-# after subscribe). Example:
-#   - pattern: "/sensor/*"   # no hz: dynamically learned
+# Expected Hz for quality evaluation (pattern match, first match wins). Used by
+# both live monitoring and the post-recording quality report: a matching `hz`
+# becomes the topic's expected frequency and the loss-rate denominator.
+# Omit `hz` to auto-derive the expected frequency from the measured message
+# intervals instead (live monitoring learns it after subscribe; the report
+# snaps the measured rate to the nearest standard frequency). Example:
+#   - pattern: "/sensor/*"   # no hz: auto-derived
 expected_hz_patterns:
   - pattern: "**/compressed"
     hz: 30

--- a/docs/domain/quality_analysis.md
+++ b/docs/domain/quality_analysis.md
@@ -165,30 +165,31 @@ A table view of each topic's quality.
 
 ### Loss Rate chart (MCAP detail page)
 
-The **QUALITY ANALYTICS** tab on `/recordings/:folder` renders a per-topic loss% time series with uPlot. The Y axis is inverted (0% on top = stable); the warn/danger threshold lines (2% / 5%) match the rest of the quality visualization (see [Quality status determination](#quality-status-determination)).
+The **QUALITY ANALYTICS** tab on `/recordings/:folder` renders a per-topic loss% time series with uPlot. The Y axis is inverted (0% on top = stable); the warn/danger threshold lines (2% / 5%) match the rest of the quality visualization (see [Quality status determination](#quality-status-determination)). The axis keeps a `[0, 10]%` window for the common near-zero case and auto-expands when a topic runs far below its rate, so a large sustained deficit stays on-screen.
 
-**Input**: `TimelineGap` records produced by `TimelineAnalyzer` — gaps whose inter-message interval exceeds `max(Q3 + 1.5 × IQR, expected_interval × 1.5)`. Each gap carries `start_sec`, `end_sec`, `lost_count`, and `severity` (`minor` / `major`).
+**Input**: per-topic timeline bins produced by `TimelineAnalyzer`. Each bin carries `count` (received) and `expected` (frames expected in the bin); `expected` already reflects the configured `expected_hz` when set (see [Baseline Hz](#baseline-hz)).
 
-**Algorithm**: 1-second sliding window with a 0.1-second step, centered on each sample point.
+**Algorithm**: count-based deficit over a 1-second sliding window with a 0.1-second step, centered on each sample point.
 
 Each sample point `x = i × STEP_SEC` represents the loss% inside the window `[x − WINDOW_SEC/2, x + WINDOW_SEC/2)` centered on `x`:
 
 ```
-expected_per_window = expected_hz × WINDOW_SEC
-lost_in_window      = Σ gap.lost_count   # over every gap where gap.end_sec > x − WINDOW_SEC/2 ∧ gap.start_sec < x + WINDOW_SEC/2
-loss_rate(x)        = min(100, lost_in_window / expected_per_window × 100)
+received_in_window = Σ bin.count      # over bins overlapping the window
+expected_in_window = Σ bin.expected
+loss_rate(x)       = min(100, max(0, 1 − received_in_window / expected_in_window) × 100)
 ```
+
+This mirrors the per-topic `loss_rate` in the quality report, so a stream running steadily below its configured rate shows a sustained plateau here (e.g., a 100 Hz-configured topic delivering ~72 Hz plots a flat ~28% line) — not just the discrete IQR dropouts. Those dropouts remain visible as the `minor` / `major` counts and as gap markers on the Timeline heatmap.
 
 | Parameter | Value | Role |
 |---|---|---|
-| `WINDOW_SEC` | 1.0 s | Aggregation-window width. Determines the denominator (`expected_hz × WINDOW_SEC` = frames expected in one window), so the 2% / 5% thresholds keep the same meaning as the rest of the quality stack. |
-| `STEP_SEC` | 0.1 s | Spacing between sample points. The worst-case offset between a loss event and the nearest sample point is `STEP_SEC / 2 = 0.05 s`. |
+| `WINDOW_SEC` | 1.0 s | Aggregation-window width. The denominator (`Σ bin.expected ≈ expected_hz × WINDOW_SEC`) keeps the 2% / 5% thresholds meaningful across the quality stack. |
+| `STEP_SEC` | 0.1 s | Spacing between sample points. |
 
 **How to read the chart**:
 
-- **A single loss appears as a ~1-second-wide "bump"**: the center of the bump corresponds to when the loss occurred. Example: a single-frame loss at `t = 15.9 s` on a 30 Hz topic plots as a 10-point plateau across `x ∈ {15.5, 15.6, …, 16.3, 16.4}` at `1 / (30 × 1.0) × 100 ≈ 3.3%`.
-- **Time-axis precision is ±0.05 s** (= `STEP_SEC / 2`).
-- **Losses that fall inside the same window stack additively**: their `lost_count` values are summed, producing a single taller bump rather than two separate bumps.
+- **A steady under-rate appears as a sustained plateau** at the deficit level (received vs expected).
+- **A localized dropout appears as a ~1-second-wide "bump"** centered on when it occurred (its bins fall short for the windows overlapping them).
 
 Implementation: `frontend/src/features/quality-timeline/loss-rate-utils.ts`.
 

--- a/docs/domain/quality_analysis.md
+++ b/docs/domain/quality_analysis.md
@@ -198,6 +198,7 @@ Implementation: `frontend/src/features/quality-timeline/loss-rate-utils.ts`.
 |---|---|
 | Implementation | `MCAPAnalyzer` (mcap Python library) |
 | Data source | All message timestamps inside the MCAP file |
+| Expected Hz | Config-declared `expected_hz_patterns` value when the topic matches; otherwise the nearest standard frequency estimated from message intervals |
 | Accuracy | More accurate than real-time monitoring (uses the full data, not an approximation) |
 | Persistence | Saved as `quality_report.json` in the same directory as the MCAP (cache) |
 | Execution | Runs in the background via `asyncio.to_thread()` (does not block the UI) |
@@ -260,7 +261,7 @@ expected_hz_patterns:
 | Fixed (YAML config) | Keeps `baseline_hz`. Only resets timing-related metrics |
 | Dynamic learning | Sets `baseline_hz` back to `None` and restarts learning (50 warm-up + 50 accumulation) |
 
-**Scope**: `expected_hz_patterns` is only referenced by live monitoring (Phase 2). Post-recording MCAP analysis (Phase 3) does not use YAML values; instead, it statistically re-estimates from timestamps (see [How MCAP analysis works](#how-mcap-analysis-works)).
+**Scope**: `expected_hz_patterns` is referenced by both live monitoring (Phase 2) and post-recording MCAP analysis (Phase 3). In Phase 3 a matching `hz` overrides the auto-estimated expected Hz for that topic — it becomes the topic's `expected_frequency_hz` and drives the loss-rate denominator, the gap/loss detection thresholds, and the timeline's expected Hz. Topics with no matching `hz` (pattern omitted or `hz:` left blank) fall back to statistical re-estimation from timestamps (see [How MCAP analysis works](#how-mcap-analysis-works)).
 
 ### Loss rate
 

--- a/frontend/src/features/quality-summary/quality-summary.tsx
+++ b/frontend/src/features/quality-summary/quality-summary.tsx
@@ -112,7 +112,7 @@ export function QualitySummary({
       <div>
         <div className="flex items-center gap-2 mb-1.5">
           <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Topics</span>
-          <InfoTip text="Quality status per topic. loss_rate (loss-frame rate) over 2% is warning (yellow); over 5% or any major loss (3+ frames) is danger (red). loss_events are exact losses detected with the IQR statistical threshold (detected from a single frame)." />
+          <InfoTip text="Quality status per topic. loss_rate = 1 − received / expected (against the configured expected_hz when set, otherwise the measured rate); over 2% is warning (yellow), over 5% is danger (red). minor/major are discrete dropout events detected with the IQR statistical threshold (down to a single frame)." />
         </div>
         <div className="rounded-md border border-border overflow-hidden">
           {sortTopicsByCategory(
@@ -142,7 +142,7 @@ export function QualitySummary({
           </span>
           <span className="flex items-center gap-1">
             loss
-            <InfoTip text="loss_rate = loss_count / (msg_count + loss_count). The loss-frame rate detected via IQR statistics (includes leading/trailing empty windows)." />
+            <InfoTip text="loss_rate = 1 − received / (expected_hz × duration). The received-vs-expected frame deficit; expected_hz comes from the recording config when set, otherwise the measured rate." />
           </span>
           <span className="flex items-center gap-1">
             minor / major

--- a/frontend/src/features/quality-summary/ui/topic-metrics.tsx
+++ b/frontend/src/features/quality-summary/ui/topic-metrics.tsx
@@ -18,13 +18,12 @@ export function TopicMetrics({
   /** Chevron click handler. When provided, stops the row click and toggles independently. */
   onChevronClick?: (e: MouseEvent) => void;
 }) {
-  const { minor_loss_count, major_loss_count, loss_count, message_count, start_delay_sec, msg_type } = topic;
+  const { minor_loss_count, major_loss_count, loss_rate, message_count, start_delay_sec, msg_type } = topic;
   const { zero_size_count, avg_bytes } = topic.size_stats;
 
-  // loss_count-based loss rate (actual losses detected by IQR)
-  const totalExpected = message_count + loss_count;
-  const lossRate = totalExpected > 0 ? loss_count / totalExpected : 0;
-  const missClass = major_loss_count > 0 ? "text-red-400" : minor_loss_count > 0 ? "text-amber-400" : "";
+  // Count-based loss rate: received frames vs the expected count (uses the configured
+  // expected_hz when set). Colored by the same 2% / 5% warn/danger thresholds.
+  const missClass = loss_rate > 0.05 ? "text-red-400" : loss_rate > 0.02 ? "text-amber-400" : "";
   const chevronIcon = expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />;
 
   return (
@@ -32,7 +31,7 @@ export function TopicMetrics({
       <span>{shortMsgType(msg_type)}</span>
       <span>Size: {formatSize(avg_bytes)} avg</span>
       <span>{message_count.toLocaleString()} msgs</span>
-      <span className={missClass}>{(lossRate * 100).toFixed(2)}% loss</span>
+      <span className={missClass}>{(loss_rate * 100).toFixed(2)}% loss</span>
       {start_delay_sec > 0.1 && (
         <span className="rounded bg-blue-500/15 px-1 py-0 text-[10px] text-blue-400">
           +{start_delay_sec.toFixed(1)}s delay

--- a/frontend/src/features/quality-timeline/__tests__/loss-rate-utils.test.ts
+++ b/frontend/src/features/quality-timeline/__tests__/loss-rate-utils.test.ts
@@ -1,97 +1,82 @@
 import { describe, expect, it } from "vitest";
-import type { TimelineGap, TimelineTopic } from "@/api/generated/schemas";
-import {
-  buildLossRateData,
-  buildTopicLossRateSeries,
-  LOSS_RATE_STEP_SEC,
-  LOSS_RATE_WINDOW_SEC,
-} from "../loss-rate-utils";
+import type { TimelineBin, TimelineTopic } from "@/api/generated/schemas";
+import { buildLossRateData, buildTopicLossRateSeries, LOSS_RATE_STEP_SEC } from "../loss-rate-utils";
 
-function gap(start: number, lostCount: number, durationSec = 0.05): TimelineGap {
-  return {
-    start_sec: start,
-    end_sec: start + durationSec,
-    duration_sec: durationSec,
-    lost_count: lostCount,
-    severity: lostCount >= 3 ? "major" : "minor",
-  };
+const BIN_WIDTH = 0.05;
+
+function bin(t: number, count: number, expected: number): TimelineBin {
+  return { t, count, expected, has_gap: false, has_minor_loss: false };
 }
 
-function topic(expectedHz: number, gaps: TimelineGap[]): TimelineTopic {
-  return {
-    name: "/test",
-    msg_type: "std_msgs/msg/String",
-    expected_hz: expectedHz,
-    bins: [],
-    gaps,
-  };
+/** N contiguous bins (BIN_WIDTH spacing from t=0) each with the given count/expected. */
+function uniformBins(n: number, count: number, expected: number): TimelineBin[] {
+  return Array.from({ length: n }, (_, i) => bin(i * BIN_WIDTH, count, expected));
+}
+
+function topic(expectedHz: number, bins: TimelineBin[]): TimelineTopic {
+  return { name: "/test", msg_type: "std_msgs/msg/String", expected_hz: expectedHz, bins, gaps: [] };
 }
 
 const step = LOSS_RATE_STEP_SEC; // 0.1
-const window = LOSS_RATE_WINDOW_SEC; // 0.5
 
 describe("buildTopicLossRateSeries", () => {
-  it("returns all zeros when there are no gaps", () => {
-    const ys = buildTopicLossRateSeries(topic(30, []), 50);
+  it("returns all zeros when there are no bins", () => {
+    const ys = buildTopicLossRateSeries(topic(100, []), 50, BIN_WIDTH);
     expect(Array.from(ys)).toEqual(new Array(50).fill(0));
   });
 
-  it("returns all zeros when expected_hz is 0 (avoids division by zero)", () => {
-    const ys = buildTopicLossRateSeries(topic(0, [gap(5.0, 3)]), 100);
+  it("returns all zeros when expected_hz is 0", () => {
+    const ys = buildTopicLossRateSeries(topic(0, uniformBins(40, 3, 5)), 40, BIN_WIDTH);
     expect(Array.from(ys).every((v) => v === 0)).toBe(true);
   });
 
-  it("places a loss at t=15.9s near 15.9s, not at 15.0s", () => {
-    // 30 Hz topic, single 1-frame loss at 15.9s.
-    // Expected per WINDOW_SEC window = 30 × WINDOW_SEC frames.
-    // Plateau spans WINDOW_SEC centered on the gap (±WINDOW_SEC/2).
-    const numPoints = 200; // covers up to 19.9s
-    const ys = buildTopicLossRateSeries(topic(30, [gap(15.9, 1)]), numPoints);
-    const expectedPct = (1 / (30 * window)) * 100;
-
-    // The loss must appear at x=15.9 itself.
-    expect(ys[Math.round(15.9 / step)]).toBeCloseTo(expectedPct, 5);
-
-    // And in the neighboring points well inside the plateau.
-    expect(ys[Math.round(15.8 / step)]).toBeCloseTo(expectedPct, 5);
-    expect(ys[Math.round(16.0 / step)]).toBeCloseTo(expectedPct, 5);
-
-    // The OLD 1-second-bin behavior placed the spike at x=15.0 — this must now be 0.
-    expect(ys[Math.round(15.0 / step)]).toBe(0);
-
-    // Points far outside the 0.5s plateau are 0.
-    expect(ys[Math.round(15.0 / step)]).toBe(0);
-    expect(ys[Math.round(17.0 / step)]).toBe(0);
+  it("returns all zeros when binWidthSec is 0", () => {
+    const ys = buildTopicLossRateSeries(topic(100, uniformBins(40, 3, 5)), 40, 0);
+    expect(Array.from(ys).every((v) => v === 0)).toBe(true);
   });
 
-  it("sums lost_count across multiple gaps inside the same window", () => {
-    // Two gaps very close together — both fall inside any window centered near them.
-    const ys = buildTopicLossRateSeries(topic(30, [gap(10.0, 1), gap(10.05, 2)]), 200);
-    const expectedPct = ((1 + 2) / (30 * window)) * 100;
-    expect(ys[Math.round(10.0 / step)]).toBeCloseTo(expectedPct, 5);
+  it("reports 0% loss when every bin is at its expected count", () => {
+    const ys = buildTopicLossRateSeries(topic(100, uniformBins(40, 5, 5)), 40, BIN_WIDTH);
+    // The window centered at 1.0s is fully inside the bin coverage.
+    expect(ys[Math.round(1.0 / step)]).toBeCloseTo(0, 5);
   });
 
-  it("caps the rate at 100%", () => {
-    // 30 Hz topic, a huge burst of 100 lost frames at t=5s: 100/15 ≈ 666% → clamped to 100.
-    const ys = buildTopicLossRateSeries(topic(30, [gap(5.0, 100)]), 100);
-    expect(ys[Math.round(5.0 / step)]).toBe(100);
+  it("reports a sustained deficit when the stream runs steadily below its rate", () => {
+    // 3 of every 5 expected frames received → 40% loss, held across the whole stream.
+    const ys = buildTopicLossRateSeries(topic(100, uniformBins(40, 3, 5)), 40, BIN_WIDTH);
+    expect(ys[Math.round(1.0 / step)]).toBeCloseTo(40, 5);
+  });
+
+  it("localizes a single-bin loss to the windows overlapping it", () => {
+    const bins = uniformBins(40, 5, 5);
+    bins[20] = bin(20 * BIN_WIDTH, 4, 5); // 1 frame short at t=1.0s
+    const ys = buildTopicLossRateSeries(topic(100, bins), 40, BIN_WIDTH);
+    // Window at t=1.0 spans [0.5, 1.5): 1 missing frame out of 100 expected → 1%.
+    expect(ys[Math.round(1.0 / step)]).toBeCloseTo(1, 5);
+    // A window that does not overlap t=1.0 stays at 0.
+    expect(ys[Math.round(0.1 / step)]).toBe(0);
+  });
+
+  it("caps the loss rate at 100%", () => {
+    const ys = buildTopicLossRateSeries(topic(100, uniformBins(40, 0, 5)), 40, BIN_WIDTH);
+    expect(ys[Math.round(1.0 / step)]).toBe(100);
   });
 });
 
 describe("buildLossRateData", () => {
   it("returns an empty xs array when there are no topics", () => {
-    const result = buildLossRateData([], null, 10);
+    const result = buildLossRateData([], null, 10, BIN_WIDTH);
     expect(result.length).toBe(1);
     expect((result[0] as Float64Array).length).toBe(0);
   });
 
   it("returns an empty xs array when durationSec is 0", () => {
-    const result = buildLossRateData([topic(30, [gap(1, 1)])], null, 0);
+    const result = buildLossRateData([topic(100, uniformBins(40, 3, 5))], null, 0, BIN_WIDTH);
     expect((result[0] as Float64Array).length).toBe(0);
   });
 
   it("emits xs at STEP_SEC intervals covering durationSec", () => {
-    const result = buildLossRateData([topic(30, [])], null, 1.0);
+    const result = buildLossRateData([topic(100, uniformBins(20, 5, 5))], null, 1.0, BIN_WIDTH);
     const xs = result[0] as Float64Array;
     // ceil(1.0 / 0.1) + 1 = 11 points: 0.0, 0.1, ..., 1.0
     expect(xs.length).toBe(11);
@@ -100,17 +85,17 @@ describe("buildLossRateData", () => {
   });
 
   it("filters to the selected topic only", () => {
-    const t1 = { ...topic(30, [gap(1, 1)]), name: "/a" };
-    const t2 = { ...topic(30, [gap(2, 1)]), name: "/b" };
-    const result = buildLossRateData([t1, t2], "/b", 5);
+    const t1 = { ...topic(100, uniformBins(20, 5, 5)), name: "/a" };
+    const t2 = { ...topic(100, uniformBins(20, 5, 5)), name: "/b" };
+    const result = buildLossRateData([t1, t2], "/b", 5, BIN_WIDTH);
     // [xs, ys for /b only]
     expect(result.length).toBe(2);
   });
 
   it("includes one ys series per topic when no topic is selected", () => {
-    const t1 = { ...topic(30, []), name: "/a" };
-    const t2 = { ...topic(30, []), name: "/b" };
-    const result = buildLossRateData([t1, t2], null, 5);
+    const t1 = { ...topic(100, uniformBins(20, 5, 5)), name: "/a" };
+    const t2 = { ...topic(100, uniformBins(20, 5, 5)), name: "/b" };
+    const result = buildLossRateData([t1, t2], null, 5, BIN_WIDTH);
     expect(result.length).toBe(3); // xs + 2 topics
   });
 });

--- a/frontend/src/features/quality-timeline/loss-rate-utils.ts
+++ b/frontend/src/features/quality-timeline/loss-rate-utils.ts
@@ -1,45 +1,54 @@
 /** Pure helpers for Loss Rate chart series construction.
  *
- * Each sample point at x = i * STEP is the loss% inside a WINDOW-wide window centered on x.
- * A loss event at timestamp t shows up near t (within STEP/2) instead of being snapped to a
- * fixed bin's left edge, eliminating the visual offset that 1-second bins previously had.
+ * Each sample point at x = i * STEP is the count-based loss% inside a WINDOW-wide window
+ * centered on x: loss% = 1 − received / expected, aggregated from the per-bin `count` and
+ * `expected` values (which already reflect the configured expected_hz). This mirrors the
+ * per-topic loss_rate in the quality report, so a stream that runs steadily below its
+ * configured rate shows a sustained deficit here — not just the discrete IQR dropouts.
  */
 
 import type uPlot from "uplot";
 import type { TimelineTopic } from "@/api/generated/schemas";
 
-/** Sliding-window length in seconds. Matches the original fixed-bin width so the
- * denominator (expected_hz × WINDOW_SEC) — and therefore the 2% / 5% warn/danger
- * threshold semantics — is unchanged from the pre-sliding-window implementation. */
+/** Sliding-window length in seconds. The denominator (Σ bin.expected over the window ≈
+ * expected_hz × WINDOW_SEC) keeps the 2% / 5% warn/danger threshold semantics. */
 export const LOSS_RATE_WINDOW_SEC = 1.0;
 
 /** Distance between successive sample points in seconds. */
 export const LOSS_RATE_STEP_SEC = 0.1;
 
-/** Builds per-point loss_rate (%) for a single topic.
+/** Builds per-point count-based loss_rate (%) for a single topic.
  *
- * Window i is centered on x = i * STEP_SEC and spans [x - WINDOW/2, x + WINDOW/2).
- * A gap that overlaps the window contributes its full lost_count to that point — the same
- * gap therefore appears in up to ceil(WINDOW/STEP) consecutive points, forming a plateau.
+ * Window i is centered on x = i * STEP_SEC and spans [x - WINDOW/2, x + WINDOW/2). The loss%
+ * is 1 − (received frames in the window) / (expected frames in the window), so a smooth stream
+ * running below its expected rate produces a sustained plateau. Bins are contiguous starting at
+ * t=0 with `binWidthSec` spacing, so window membership is derived directly from the bin index.
  */
-export function buildTopicLossRateSeries(topic: TimelineTopic, numPoints: number): Float64Array {
+export function buildTopicLossRateSeries(topic: TimelineTopic, numPoints: number, binWidthSec: number): Float64Array {
   const ys = new Float64Array(numPoints);
-  const expectedPerWindow = topic.expected_hz * LOSS_RATE_WINDOW_SEC;
-  if (expectedPerWindow <= 0) return ys;
+  const bins = topic.bins;
+  if (topic.expected_hz <= 0 || bins.length === 0 || binWidthSec <= 0) return ys;
+
+  // Prefix sums over bins for O(1) window aggregation. Bin j spans
+  // [j * binWidthSec, (j + 1) * binWidthSec).
+  const n = bins.length;
+  const prefReceived = new Float64Array(n + 1);
+  const prefExpected = new Float64Array(n + 1);
+  for (let j = 0; j < n; j++) {
+    prefReceived[j + 1] = prefReceived[j] + bins[j].count;
+    prefExpected[j + 1] = prefExpected[j] + bins[j].expected;
+  }
 
   const half = LOSS_RATE_WINDOW_SEC / 2;
-  const gaps = topic.gaps;
   for (let i = 0; i < numPoints; i++) {
     const center = i * LOSS_RATE_STEP_SEC;
-    const windowStart = center - half;
-    const windowEnd = center + half;
-    let lostInWindow = 0;
-    for (const gap of gaps) {
-      if (gap.end_sec > windowStart && gap.start_sec < windowEnd) {
-        lostInWindow += gap.lost_count;
-      }
-    }
-    ys[i] = Math.min(100, (lostInWindow / expectedPerWindow) * 100);
+    const lo = Math.max(0, Math.floor((center - half) / binWidthSec));
+    const hi = Math.min(n, Math.ceil((center + half) / binWidthSec));
+    if (hi <= lo) continue;
+    const received = prefReceived[hi] - prefReceived[lo];
+    const expected = prefExpected[hi] - prefExpected[lo];
+    if (expected <= 0) continue;
+    ys[i] = Math.min(100, Math.max(0, 1 - received / expected) * 100);
   }
   return ys;
 }
@@ -49,6 +58,7 @@ export function buildLossRateData(
   topics: TimelineTopic[],
   selectedTopic: string | null,
   durationSec: number,
+  binWidthSec: number,
 ): uPlot.AlignedData {
   const filtered = selectedTopic ? topics.filter((t) => t.name === selectedTopic) : topics;
   if (filtered.length === 0 || durationSec <= 0) return [new Float64Array(0)];
@@ -61,7 +71,7 @@ export function buildLossRateData(
 
   const series: (Float64Array | number[])[] = [xs];
   for (const topic of filtered) {
-    series.push(buildTopicLossRateSeries(topic, numPoints));
+    series.push(buildTopicLossRateSeries(topic, numPoints, binWidthSec));
   }
   return series as uPlot.AlignedData;
 }

--- a/frontend/src/features/quality-timeline/ui/loss-rate-chart.tsx
+++ b/frontend/src/features/quality-timeline/ui/loss-rate-chart.tsx
@@ -1,8 +1,8 @@
-/** Loss Rate static chart: renders loss_rate from MCAP timeline data.
+/** Loss Rate static chart: renders the count-based loss rate from MCAP timeline data.
  *
  * Same UI as the recording page's real-time version (uPlot, inverted Y axis),
  * but the data source is the timeline API instead of SSE, and the full dataset is rendered at once.
- * The per-point series is computed via a sliding window — see `loss-rate-utils.ts`.
+ * The per-point series is a sliding-window "1 − received / expected" — see `loss-rate-utils.ts`.
  */
 
 import { useEffect, useRef } from "react";
@@ -145,7 +145,11 @@ export function LossRateChart({ data }: { data: TimelineData }) {
       plugins: [thresholdPlugin(), playheadPlugin(playheadRef)],
       scales: {
         x: { time: false },
-        y: { dir: -1 as const, range: [0, 10] },
+        // Keep a [0, 10]% window for the common near-zero case, but expand to fit
+        // when a topic runs steadily below its expected rate (count-based loss can
+        // reach tens of %), so a sustained deficit stays on-screen instead of
+        // clipping off the top.
+        y: { dir: -1 as const, range: (_u, _min, max) => [0, Math.max(10, max ?? 10)] },
       },
       axes: [
         {
@@ -167,7 +171,7 @@ export function LossRateChart({ data }: { data: TimelineData }) {
       legend: { show: false },
     };
 
-    const chartData = buildLossRateData(data.topics, selectedTopic, data.duration_sec);
+    const chartData = buildLossRateData(data.topics, selectedTopic, data.duration_sec, data.bin_width_sec);
     uplotRef.current = new uPlot(opts, chartData, el);
 
     return () => {
@@ -179,7 +183,7 @@ export function LossRateChart({ data }: { data: TimelineData }) {
   // selectedTopic change → re-set data
   useEffect(() => {
     if (!uplotRef.current) return;
-    uplotRef.current.setData(buildLossRateData(data.topics, selectedTopic, data.duration_sec));
+    uplotRef.current.setData(buildLossRateData(data.topics, selectedTopic, data.duration_sec, data.bin_width_sec));
   }, [selectedTopic, data]);
 
   // viewRange + playhead → bundle X-axis scale update and plugin redraw into one effect


### PR DESCRIPTION
## What

The per-topic loss rate computed the expected frame count **solely** from the measured message rate (snapped to the nearest standard frequency). `expected_hz_patterns` from `RECORDING_CONFIG` was only used by live monitoring, not by the post-recording report.

This PR makes the report/timeline prefer the configured value, and unifies the recording **detail page** on that same count-based metric so it matches the live screen and the report.

### 1. Backend — config-driven expected Hz (`analysis`)

When a topic matches an `expected_hz_patterns[].hz`, that value becomes the topic's `expected_frequency_hz` and drives the **loss-rate denominator**, the **gap / loss-event thresholds**, the reported **`expected_frequency_hz`**, and the **timeline's** expected Hz. Topics with no matching `hz` fall back to the previous statistical estimation. Resolution reuses the existing `RecordingConfig.resolve_expected_hz`.

- Near-empty topics (< 2 messages) with a configured `hz` now report a count-based loss + status (no longer silently `ok`).

### 2. Frontend — detail page consistency (`quality-summary`, `quality-timeline`)

Before: the detail page (TOPICS loss% and the LOSS RATE chart) derived loss from **IQR dropout events**, so a topic recorded at a steady rate *below* its configured `expected_hz` showed ~1% while the live screen and report showed the ~28% rate deficit.

After:
- **TOPICS row** shows the report's count-based `loss_rate` (received vs expected), colored by the 2% / 5% thresholds.
- **LOSS RATE chart** aggregates per-bin `count` vs `expected` over its sliding window (data already in `timeline_data.json`), so a steady under-rate shows a sustained plateau; the Y axis auto-expands past 10% so large deficits stay visible.
- IQR dropouts remain visible as the minor/major counts and the timeline gap markers.

### Notes

- **Steady-but-slow now surfaces everywhere**: a 100 Hz-configured `/sim/*` topic delivering ~72 Hz shows ~28% on the live screen, the report, the TOPICS row, and the LOSS RATE chart. The timeline **heatmap** intentionally stays a discrete-dropout ("where") view — per-50ms-bin count ratios are too noisy to color reliably.
- **Existing caches**: already-generated `quality_report.json` / `timeline_data.json` keep their old values until re-analyzed.

## Docs

Updated `docs/domain/quality_analysis.md` (Phase 3 expected-Hz source, Loss Rate chart algorithm) and the `expected_hz_patterns` comment in `config/simulator.yaml`.

## Testing

- `make test-cov-backend` → 100% coverage (16 new analysis tests)
- `make lint-backend` (ruff + mypy) → clean
- Frontend: `vitest` 229 passed, `tsc` + `biome` clean (loss-rate-utils tests rewritten for the count-based logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)