### PR TITLE
feat(quality-timeline): shade heatmap by count-based rate deficit

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -164,8 +164,8 @@ Located in `backend/app/features/analysis/`. Runs in the background via `asyncio
 
 Located in `backend/app/features/analysis/`. Provides data for the horizontal-bar heatmap and Message Ticks on the MCAP detail page's timeline.
 
-- **Binning**: Aggregates per-topic density into time bins (bin width is adjusted dynamically based on recording length)
-- **Gap marking**: Generates color-coding data using each bin's `has_gap` / `has_minor_loss` flags
+- **Binning**: Aggregates per-topic `count` vs `expected` into time bins (bin width is adjusted dynamically based on recording length); `expected` reflects the configured `expected_hz` when set
+- **Loss marking**: Each bin carries `count` / `expected` (the heatmap shades a smoothed count/expected deficit green→amber→red) plus `has_gap` / `has_minor_loss` flags and gap spans (the discrete IQR dropout overlay)
 - **Message retrieval for rug plot**: Returns individual messages within a specified time range (for accurate display at high zoom). `MCAPReader.iter_messages(topics=, start_time_ns=, end_time_ns=)` in `backend/app/infra/mcap` filters by time and topic ranges using the chunk index, so even ~500MB files respond in tens to hundreds of ms
 - **Clock-skew handling**: Saves the skew between `log_time` (recorder wall clock) and `header.stamp` (sensor side) as `log_time_offset_ns` in the cache, and converts the rug plot's chunk filter into the correct `log_time` range (see [DDS communication and gaps §6.6](domain/dds_gap.md))
 - Caches `timeline_data.json` in the recording folder (includes `recording_start_ns` / `log_time_offset_ns`)

--- a/frontend/src/features/quality-timeline/__tests__/heatmap-utils.test.ts
+++ b/frontend/src/features/quality-timeline/__tests__/heatmap-utils.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { TimelineBin } from "@/api/generated/schemas";
+import { computeSmoothedDeficits, deficitColor } from "../heatmap-utils";
+
+const BIN_WIDTH = 0.05;
+const GREEN = "rgba(52, 211, 153, 0.5)";
+const AMBER = "rgba(251, 191, 36, 0.5)";
+const RED = "rgba(248, 113, 113, 0.5)";
+
+function bin(t: number, count: number, expected: number): TimelineBin {
+  return { t, count, expected, has_gap: false, has_minor_loss: false };
+}
+
+function channels(rgba: string): [number, number, number] {
+  const m = rgba.match(/rgba\((\d+), (\d+), (\d+), [\d.]+\)/);
+  if (!m) throw new Error(`unexpected rgba: ${rgba}`);
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function uniformBins(n: number, count: number, expected: number): TimelineBin[] {
+  return Array.from({ length: n }, (_, i) => bin(i * BIN_WIDTH, count, expected));
+}
+
+describe("computeSmoothedDeficits", () => {
+  it("returns an empty array for no bins", () => {
+    expect(computeSmoothedDeficits([], BIN_WIDTH).length).toBe(0);
+  });
+
+  it("returns all zeros when binWidthSec is 0", () => {
+    const out = computeSmoothedDeficits(uniformBins(40, 2, 5), 0);
+    expect(Array.from(out).every((v) => v === 0)).toBe(true);
+  });
+
+  it("is 0 when every bin is at its expected count", () => {
+    const out = computeSmoothedDeficits(uniformBins(40, 5, 5), BIN_WIDTH);
+    for (const v of out) expect(v).toBeCloseTo(0, 5);
+  });
+
+  it("reflects a steady under-rate", () => {
+    // Received 2 of every 4 expected → 50% deficit everywhere.
+    const out = computeSmoothedDeficits(uniformBins(40, 2, 4), BIN_WIDTH);
+    for (const v of out) expect(v).toBeCloseTo(0.5, 5);
+  });
+
+  it("smooths an isolated empty bin instead of showing 100% loss", () => {
+    const bins = uniformBins(40, 5, 5);
+    bins[20] = bin(20 * BIN_WIDTH, 0, 5); // a single empty bin at t=1.0s
+    const out = computeSmoothedDeficits(bins, BIN_WIDTH);
+    // Averaged over the ~1s window (21 bins): 1 − 100/105 ≈ 0.0476, not 1.0.
+    expect(out[20]).toBeCloseTo(1 - 100 / 105, 4);
+    // A bin far from the dip stays healthy.
+    expect(out[0]).toBeCloseTo(0, 5);
+  });
+});
+
+describe("deficitColor", () => {
+  it("is green at or below the warn threshold", () => {
+    expect(deficitColor(0)).toBe(GREEN);
+    expect(deficitColor(0.02)).toBe(GREEN);
+  });
+
+  it("clamps negative input to green", () => {
+    expect(deficitColor(-1)).toBe(GREEN);
+  });
+
+  it("is amber at the danger threshold", () => {
+    expect(deficitColor(0.05)).toBe(AMBER);
+  });
+
+  it("is fully red at or above the cap", () => {
+    expect(deficitColor(0.2)).toBe(RED);
+    expect(deficitColor(1)).toBe(RED);
+  });
+
+  it("blends green→amber between the warn and danger thresholds", () => {
+    // Between green (52, 211, 153) and amber (251, 191, 36).
+    const c = channels(deficitColor(0.035));
+    expect(c[0]).toBeGreaterThan(52); // red channel rises toward amber
+    expect(c[0]).toBeLessThan(251);
+    expect(c[2]).toBeLessThan(153); // blue channel falls toward amber
+    expect(c[2]).toBeGreaterThan(36);
+  });
+
+  it("blends amber→red between the danger threshold and the cap", () => {
+    // Between amber (251, 191, 36) and red (248, 113, 113).
+    const c = channels(deficitColor(0.125));
+    expect(c[1]).toBeLessThan(191); // green channel falls toward red
+    expect(c[1]).toBeGreaterThan(113);
+    expect(c[2]).toBeGreaterThan(36); // blue channel rises toward red
+    expect(c[2]).toBeLessThan(113);
+  });
+});

--- a/frontend/src/features/quality-timeline/heatmap-utils.ts
+++ b/frontend/src/features/quality-timeline/heatmap-utils.ts
@@ -1,0 +1,71 @@
+/** Pure helpers for the timeline heatmap's count-based deficit shading.
+ *
+ * Each bin is colored by how far its received message count falls below the expected count
+ * (which already reflects the configured expected_hz). The per-bin ratio is noisy at the 50ms
+ * bin scale, so it is smoothed over a ~1s window — matching the Loss Rate chart — before being
+ * mapped to a green→amber→red gradient anchored at the 2% / 5% warn/danger thresholds.
+ */
+
+import type { TimelineBin } from "@/api/generated/schemas";
+
+/** Smoothing window (seconds), matching the Loss Rate chart so both views agree. */
+export const SMOOTH_WINDOW_SEC = 1.0;
+
+/** Deficit at/below which a bin is fully green (warn threshold). */
+const WARN = 0.02;
+/** Deficit at which a bin reaches amber (danger threshold). */
+const DANGER = 0.05;
+/** Deficit at/above which a bin is fully red. */
+const RED_CAP = 0.2;
+
+// Gradient anchor colors (emerald-400 / amber-400 / red-400) and shared alpha.
+const GREEN: [number, number, number] = [52, 211, 153];
+const AMBER: [number, number, number] = [251, 191, 36];
+const RED: [number, number, number] = [248, 113, 113];
+const ALPHA = 0.5;
+
+/** Neutral fill for topics without an expected rate (deficit is undefined). */
+export const NO_RATE_COLOR = "rgba(120, 120, 120, 0.12)";
+
+/** Per-bin smoothed deficit (0..1): 1 − received / expected over a ~SMOOTH_WINDOW_SEC window
+ * centered on each bin. Bins are contiguous with `binWidthSec` spacing, so the window is a
+ * fixed number of bins on each side. */
+export function computeSmoothedDeficits(bins: TimelineBin[], binWidthSec: number): Float64Array {
+  const n = bins.length;
+  const out = new Float64Array(n);
+  if (n === 0 || binWidthSec <= 0) return out;
+
+  const prefReceived = new Float64Array(n + 1);
+  const prefExpected = new Float64Array(n + 1);
+  for (let i = 0; i < n; i++) {
+    prefReceived[i + 1] = prefReceived[i] + bins[i].count;
+    prefExpected[i + 1] = prefExpected[i] + bins[i].expected;
+  }
+
+  const half = Math.max(1, Math.round(SMOOTH_WINDOW_SEC / 2 / binWidthSec));
+  for (let i = 0; i < n; i++) {
+    const lo = Math.max(0, i - half);
+    const hi = Math.min(n, i + half + 1);
+    const received = prefReceived[hi] - prefReceived[lo];
+    const expected = prefExpected[hi] - prefExpected[lo];
+    out[i] = expected > 0 ? Math.max(0, 1 - received / expected) : 0;
+  }
+  return out;
+}
+
+function mix(a: [number, number, number], b: [number, number, number], t: number): string {
+  const r = Math.round(a[0] + (b[0] - a[0]) * t);
+  const g = Math.round(a[1] + (b[1] - a[1]) * t);
+  const bl = Math.round(a[2] + (b[2] - a[2]) * t);
+  return `rgba(${r}, ${g}, ${bl}, ${ALPHA})`;
+}
+
+/** Maps a deficit (0..1) to a gradient color: green up to the 2% warn threshold, blending to
+ * amber at 5% (danger), then to full red by RED_CAP. */
+export function deficitColor(deficit: number): string {
+  const d = Math.max(0, Math.min(1, deficit));
+  if (d <= WARN) return mix(GREEN, GREEN, 0);
+  if (d < DANGER) return mix(GREEN, AMBER, (d - WARN) / (DANGER - WARN));
+  if (d < RED_CAP) return mix(AMBER, RED, (d - DANGER) / (RED_CAP - DANGER));
+  return mix(RED, RED, 0);
+}

--- a/frontend/src/features/quality-timeline/ui/timeline-heatmap.tsx
+++ b/frontend/src/features/quality-timeline/ui/timeline-heatmap.tsx
@@ -1,8 +1,9 @@
-/** Timeline horizontal-bar heatmap: shows per-topic message density with color shading.
+/** Timeline horizontal-bar heatmap: per-topic message-rate deficit shaded green→amber→red.
  *
- * Density is computed from each bin's count/expected, and rendered as a gradient
- * from green (healthy) to red (missing). Gap regions are highlighted with a
- * semi-transparent red overlay.
+ * Each bin is colored by a smoothed count/expected deficit (1 − received / expected over a
+ * ~1s window), using the same 2% / 5% warn/danger thresholds as the Loss Rate chart, so a
+ * stream running steadily below its expected rate shows a sustained warm band — not just the
+ * discrete IQR dropouts, which stay highlighted on top with a semi-transparent gap overlay.
  *
  * The display range is **always the entire recording** (start to end) and does not
  * follow the minimap's viewRange (= it works as a full-overview map). The current
@@ -14,18 +15,8 @@ import { Activity } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import type { TimelineData, TimelineTopic } from "@/api/generated/schemas";
 import { sortTopicsByCategory } from "@/lib/topic-sort";
+import { computeSmoothedDeficits, deficitColor, NO_RATE_COLOR } from "../heatmap-utils";
 import { useQualityTimelineStore } from "../store";
-
-/** Returns the background color for a bin. Decision is based on has_gap; count=0 is also considered.
- * Green = OK, red = gap. Regions without data are gray.
- */
-function binColor(count: number, hasGap: boolean, hasMinorLoss: boolean, hasData: boolean): string {
-  if (!hasData) return "bg-muted/10";
-  if (hasGap) return "bg-red-400/50";
-  if (hasMinorLoss) return "bg-amber-400/50";
-  if (count === 0) return "bg-muted/20";
-  return "bg-emerald-400/40";
-}
 
 /** Shortens a topic name for display. */
 function shortName(name: string): string {
@@ -68,6 +59,11 @@ function TopicRow({
   // Compute bin positions relative to the whole recording (independent of viewRange)
   const safeDuration = totalDuration > 0 ? totalDuration : topic.bins.length * binWidth || 1;
 
+  // Per-bin smoothed count/expected deficit, shaded green→amber→red. Topics without an
+  // expected rate (expected_hz <= 0) can't yield a deficit, so they get a neutral fill.
+  const hasRate = topic.expected_hz > 0;
+  const deficits = useMemo(() => computeSmoothedDeficits(topic.bins, binWidth), [topic.bins, binWidth]);
+
   return (
     <div className="flex items-center gap-2 py-1">
       {/* Topic name */}
@@ -78,14 +74,18 @@ function TopicRow({
       {/* Heatmap bar (always shows the whole recording).
        * overflow-hidden is intentionally removed so the highlight glow / -inset-1 can extend outside. */}
       <div className="relative flex-1 flex h-4 rounded-sm bg-muted/20">
-        {topic.bins.map((bin) => {
+        {topic.bins.map((bin, idx) => {
           const left = (bin.t / safeDuration) * 100;
           const width = (binWidth / safeDuration) * 100;
           return (
             <div
               key={bin.t}
-              className={`absolute top-0 h-full ${binColor(bin.count, bin.has_gap, bin.has_minor_loss, bin.count > 0 || bin.expected > 0)}`}
-              style={{ left: `${left}%`, width: `${Math.max(width, 0.2)}%` }}
+              className="absolute top-0 h-full"
+              style={{
+                left: `${left}%`,
+                width: `${Math.max(width, 0.2)}%`,
+                backgroundColor: hasRate ? deficitColor(deficits[idx]) : NO_RATE_COLOR,
+              }}
             />
           );
         })}
@@ -199,15 +199,19 @@ export function TimelineHeatmap({ data }: { data: TimelineData }) {
       </div>
 
       {/* Legend */}
-      <div className="mt-1.5 flex gap-3 text-[10px] text-muted-foreground">
+      <div className="mt-1.5 flex flex-wrap gap-3 text-[10px] text-muted-foreground">
         <span className="flex items-center gap-1">
-          <span className="inline-block h-2 w-3 rounded-sm bg-emerald-400/40" /> OK
+          <span
+            className="inline-block h-2 w-8 rounded-sm"
+            style={{
+              background:
+                "linear-gradient(to right, rgba(52,211,153,0.5), rgba(251,191,36,0.5), rgba(248,113,113,0.5))",
+            }}
+          />
+          Under rate (2% / 5%+)
         </span>
         <span className="flex items-center gap-1">
-          <span className="inline-block h-2 w-3 rounded-sm bg-amber-400/50" /> 1-2 frame loss
-        </span>
-        <span className="flex items-center gap-1">
-          <span className="inline-block h-2 w-3 rounded-sm bg-red-400/50" /> 3+ frame loss
+          <span className="inline-block h-2 w-3 rounded-sm border-x border-red-500/50 bg-red-500/20" /> Dropout event
         </span>
         <span className="flex items-center gap-1">
           <span className="inline-block h-2 w-3 rounded-sm border-x border-cyan-400/60 bg-cyan-400/10" />


### PR DESCRIPTION
## What

Follow-up to #59. The timeline heatmap colored bins **only** where IQR flagged a gap (`has_gap` / `has_minor_loss`), so a topic recorded at a steady rate *below* its configured `expected_hz` stayed all green — even though the TOPICS row and the LOSS RATE chart (now count-based since #59) reported the deficit.

This shades each heatmap bin by a **smoothed count/expected deficit** (`1 − received / expected` over a ~1s window) with a **green→amber→red gradient** anchored at the same **2% / 5%** warn/danger thresholds as the rest of the quality stack.

- The discrete **IQR dropout overlay bands** are kept on top, so both signals are visible: the sustained under-rate (bin shading) and the exact dropout locations (bands).
- Per-bin ratios are noisy at the 50ms bin scale, so the deficit is smoothed over ~1s (matching the LOSS RATE chart) before coloring — this keeps healthy-but-jittery topics green.
- Topics without an expected rate (`expected_hz <= 0`) get a neutral fill.

Pure helpers (`computeSmoothedDeficits`, `deficitColor`) live in `heatmap-utils.ts` with unit tests.

## Verified against real recording data

For `output/lerobot_dl_test_0629_...` (a `/sim/*` topic configured at 100 Hz but recorded at ~72 Hz):

| Topic | expected_hz | smoothed deficit | shading |
|---|---|---|---|
| `/sim/master_arm_left` | 100 | ~27% | **all bins red** |
| `/chest_depth_cam/.../compressed` | 30 | ~0% | **green** (few faint warm bins at real hiccups) |

## Legend

Updated: the bin gradient now reads "Under rate (2% / 5%+)", the overlay band reads "Dropout event", plus the existing "Viewing" band.

## Docs

Updated `docs/ARCHITECTURE.md` (TimelineAnalyzer binning / loss marking) and the heatmap component doc comment.

## Testing

- Frontend: `vitest` 240 passed (11 new heatmap-utils tests), `tsc` + `biome` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)