### PR TITLE
feat(recording): play notification sounds on countdown/start/stop

### DIFF
--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -135,11 +135,12 @@ frontend/src/
 ├── features/                      # Feature domains (Bulletproof React)
 │   ├── recording/                 # Recording controls
 │   │   ├── index.ts               # Barrel (public API)
-│   │   ├── recording-control.tsx  # Record button + delay settings
+│   │   ├── recording-control.tsx  # Record button + delay / sound-toggle settings
 │   │   ├── completion-banner.tsx  # Latest-record banner (open details / delete / dismiss)
 │   │   ├── timer.tsx              # Timer display
-│   │   ├── store.ts               # Zustand: countdown, start/stop state
+│   │   ├── store.ts               # Zustand: countdown, start/stop state, sound preference
 │   │   ├── mutations.ts           # MutationObserver: recording ops from outside React
+│   │   ├── sounds.ts              # Web Audio notification tones (countdown / start / stop)
 │   │   └── create-timer.ts        # setTimeout/clearTimeout wrapper
 │   ├── live-topics/               # ROS2 topic live quality monitoring + preview (left panel of the recording page)
 │   │   ├── index.ts               # Barrel

--- a/frontend/src/features/recording/__tests__/mutations.test.ts
+++ b/frontend/src/features/recording/__tests__/mutations.test.ts
@@ -2,20 +2,32 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- Mock setup ---
 
-const { mockSetState, mockAddMarker, mockStartRecordingApi, mockStopRecordingApi, mockGetFiles, mockToast } =
-  vi.hoisted(() => {
-    const mockAddMarker = vi.fn();
-    return {
-      mockSetState: vi.fn(),
-      mockAddMarker,
-      mockStartRecordingApi: vi.fn(() => Promise.resolve({ status: 200, data: {} })),
-      mockStopRecordingApi: vi.fn(() =>
-        Promise.resolve({ status: 200, data: { duration_sec: 10.5, output_path: "/data/test.mcap" } }),
-      ),
-      mockGetFiles: vi.fn(),
-      mockToast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
-    };
-  });
+const {
+  mockSetState,
+  mockAddMarker,
+  mockStartRecordingApi,
+  mockStopRecordingApi,
+  mockGetFiles,
+  mockToast,
+  mockSoundEnabled,
+  mockPlayStart,
+  mockPlayStop,
+} = vi.hoisted(() => {
+  const mockAddMarker = vi.fn();
+  return {
+    mockSetState: vi.fn(),
+    mockAddMarker,
+    mockStartRecordingApi: vi.fn(() => Promise.resolve({ status: 200, data: {} })),
+    mockStopRecordingApi: vi.fn(() =>
+      Promise.resolve({ status: 200, data: { duration_sec: 10.5, output_path: "/data/test.mcap" } }),
+    ),
+    mockGetFiles: vi.fn(),
+    mockToast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+    mockSoundEnabled: { current: true },
+    mockPlayStart: vi.fn(),
+    mockPlayStop: vi.fn(),
+  };
+});
 
 vi.mock("@/lib/query-client", async () => {
   const { QueryClient: QC } = await import("@tanstack/react-query");
@@ -44,7 +56,15 @@ vi.mock("@/api/generated/analysis/analysis", () => ({
 vi.mock("../store", () => ({
   useRecordingStore: {
     setState: mockSetState,
+    getState: vi.fn(() => ({ soundEnabled: mockSoundEnabled.current })),
   },
+}));
+
+vi.mock("../sounds", () => ({
+  playStart: mockPlayStart,
+  playStop: mockPlayStop,
+  playTick: vi.fn(),
+  unlock: vi.fn(),
 }));
 
 vi.mock("@/stores/quality-history-store", () => ({
@@ -106,6 +126,7 @@ describe("startRecordingMutation", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    mockSoundEnabled.current = true;
     mockStartRecordingApi.mockResolvedValue({ status: 200, data: {} });
   });
 
@@ -199,6 +220,21 @@ describe("startRecordingMutation", () => {
     expect(mockToast.success).toHaveBeenCalledWith("Recording started");
   });
 
+  it("plays the start chime on success", async () => {
+    startRecordingMutation.mutate(["/topic_a"]);
+    await flushMutation();
+
+    expect(mockPlayStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not play the start chime when sound is disabled", async () => {
+    mockSoundEnabled.current = false;
+    startRecordingMutation.mutate(["/topic_a"]);
+    await flushMutation();
+
+    expect(mockPlayStart).not.toHaveBeenCalled();
+  });
+
   it("onSuccess: invalidates the file list 500ms later", async () => {
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
     startRecordingMutation.mutate(["/topic_a"]);
@@ -245,6 +281,7 @@ describe("stopRecordingMutation", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    mockSoundEnabled.current = true;
     // The useSettingsStore mock persists mockReturnValue across tests, so reset to default each time.
     vi.mocked(useSettingsStore.getState).mockReturnValue({ taskName: "test-task", metadata: {} } as ReturnType<
       typeof useSettingsStore.getState
@@ -338,6 +375,31 @@ describe("stopRecordingMutation", () => {
       return arg.finishedRecording !== undefined;
     });
     expect(finishedCalls).toHaveLength(0);
+  });
+
+  it("plays the stop chime on success", async () => {
+    vi.spyOn(queryClient, "getQueryData").mockReturnValue({ data: { entries: [] } });
+    stopRecordingMutation.mutate(undefined);
+    await flushMutation();
+
+    expect(mockPlayStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not play the stop chime when status!==200", async () => {
+    mockStopRecordingApi.mockResolvedValueOnce({ status: 500, data: { duration_sec: 0, output_path: "" } });
+    stopRecordingMutation.mutate(undefined);
+    await flushMutation();
+
+    expect(mockPlayStop).not.toHaveBeenCalled();
+  });
+
+  it("does not play the stop chime when sound is disabled", async () => {
+    mockSoundEnabled.current = false;
+    vi.spyOn(queryClient, "getQueryData").mockReturnValue({ data: { entries: [] } });
+    stopRecordingMutation.mutate(undefined);
+    await flushMutation();
+
+    expect(mockPlayStop).not.toHaveBeenCalled();
   });
 
   it("invalidates the quality query in stages", async () => {

--- a/frontend/src/features/recording/__tests__/sounds.test.ts
+++ b/frontend/src/features/recording/__tests__/sounds.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Fake Web Audio graph (jsdom has no AudioContext) ---
+
+interface OscStub {
+  type: string;
+  frequency: { setValueAtTime: (freq: number, when: number) => void };
+  connect: (node: unknown) => unknown;
+  start: (when: number) => void;
+  stop: (when: number) => void;
+  freqs: number[];
+}
+
+let contexts: FakeAudioContext[] = [];
+
+class FakeAudioContext {
+  state: "suspended" | "running" = "suspended";
+  currentTime = 0;
+  destination = {};
+  resume = vi.fn(() => {
+    this.state = "running";
+    return Promise.resolve();
+  });
+  oscillators: OscStub[] = [];
+
+  constructor() {
+    contexts.push(this);
+  }
+
+  createOscillator(): OscStub {
+    const osc: OscStub = {
+      type: "sine",
+      freqs: [],
+      frequency: { setValueAtTime: (freq: number) => osc.freqs.push(freq) },
+      connect: (node: unknown) => node,
+      start: vi.fn(),
+      stop: vi.fn(),
+    };
+    this.oscillators.push(osc);
+    return osc;
+  }
+
+  createGain() {
+    return {
+      gain: { setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn() },
+      connect: (node: unknown) => node,
+    };
+  }
+}
+
+function installAudioContext(Ctor: typeof FakeAudioContext | undefined) {
+  window.AudioContext = Ctor as unknown as typeof AudioContext;
+}
+
+async function loadSounds() {
+  vi.resetModules();
+  return import("../sounds");
+}
+
+describe("recording sounds", () => {
+  beforeEach(() => {
+    contexts = [];
+    installAudioContext(FakeAudioContext);
+  });
+
+  afterEach(() => {
+    installAudioContext(undefined);
+  });
+
+  it("unlock resumes a suspended context", async () => {
+    const sounds = await loadSounds();
+    sounds.unlock();
+
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0].resume).toHaveBeenCalledTimes(1);
+    expect(contexts[0].state).toBe("running");
+  });
+
+  it("unlock does not resume an already-running context", async () => {
+    const sounds = await loadSounds();
+    sounds.unlock(); // creates + resumes
+    sounds.unlock(); // already running
+
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0].resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses a single shared context across tones", async () => {
+    const sounds = await loadSounds();
+    sounds.playTick();
+    sounds.playStart();
+
+    expect(contexts).toHaveLength(1);
+  });
+
+  it("playTick emits one blip", async () => {
+    const sounds = await loadSounds();
+    sounds.playTick();
+
+    expect(contexts[0].oscillators.map((o) => o.freqs[0])).toEqual([880]);
+  });
+
+  it("playStart is a rising two-tone chime", async () => {
+    const sounds = await loadSounds();
+    sounds.playStart();
+
+    expect(contexts[0].oscillators.map((o) => o.freqs[0])).toEqual([660, 990]);
+  });
+
+  it("playStop is a falling two-tone chime", async () => {
+    const sounds = await loadSounds();
+    sounds.playStop();
+
+    expect(contexts[0].oscillators.map((o) => o.freqs[0])).toEqual([660, 440]);
+  });
+
+  it("is a no-op when Web Audio is unavailable", async () => {
+    installAudioContext(undefined);
+    const sounds = await loadSounds();
+
+    expect(() => {
+      sounds.unlock();
+      sounds.playStart();
+      sounds.playStop();
+      sounds.playTick();
+    }).not.toThrow();
+    expect(contexts).toHaveLength(0);
+  });
+});

--- a/frontend/src/features/recording/__tests__/store.test.ts
+++ b/frontend/src/features/recording/__tests__/store.test.ts
@@ -2,13 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- Mock setup (initialized via vi.hoisted before vi.mock) ---
 
-const { mockMutateStart, mockMutateStop, mockToast, mockGetQueryData, mockSelectedTopics } = vi.hoisted(() => ({
-  mockMutateStart: vi.fn(),
-  mockMutateStop: vi.fn(),
-  mockToast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
-  mockGetQueryData: vi.fn((_key?: unknown): unknown => undefined),
-  mockSelectedTopics: { current: new Set<string>(["/topic_a", "/topic_b"]) },
-}));
+const { mockMutateStart, mockMutateStop, mockToast, mockGetQueryData, mockSelectedTopics, mockUnlock, mockPlayTick } =
+  vi.hoisted(() => ({
+    mockMutateStart: vi.fn(),
+    mockMutateStop: vi.fn(),
+    mockToast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+    mockGetQueryData: vi.fn((_key?: unknown): unknown => undefined),
+    mockSelectedTopics: { current: new Set<string>(["/topic_a", "/topic_b"]) },
+    mockUnlock: vi.fn(),
+    mockPlayTick: vi.fn(),
+  }));
 
 vi.mock("zustand/middleware", () => ({
   persist: (fn: unknown) => fn,
@@ -18,6 +21,13 @@ vi.mock("zustand/middleware", () => ({
 vi.mock("../mutations", () => ({
   startRecordingMutation: { mutate: mockMutateStart },
   stopRecordingMutation: { mutate: mockMutateStop },
+}));
+
+vi.mock("../sounds", () => ({
+  unlock: mockUnlock,
+  playTick: mockPlayTick,
+  playStart: vi.fn(),
+  playStop: vi.fn(),
 }));
 
 vi.mock("@/stores/toast-store", () => ({
@@ -60,6 +70,7 @@ describe("useRecordingStore", () => {
     useRecordingStore.setState({
       delaySec: 0,
       stopLiveMonitorDuringRecording: false,
+      soundEnabled: true,
       countdownSec: null,
       isStarting: false,
       isStopping: false,
@@ -84,6 +95,22 @@ describe("useRecordingStore", () => {
       expect(state.isStarting).toBe(false);
       expect(state.isStopping).toBe(false);
       expect(state.finishedRecording).toBeNull();
+      expect(state.soundEnabled).toBe(true);
+    });
+  });
+
+  // --- setSoundEnabled ---
+
+  describe("setSoundEnabled", () => {
+    it("turns notification sounds off", () => {
+      useRecordingStore.getState().setSoundEnabled(false);
+      expect(useRecordingStore.getState().soundEnabled).toBe(false);
+    });
+
+    it("turns notification sounds back on", () => {
+      useRecordingStore.getState().setSoundEnabled(false);
+      useRecordingStore.getState().setSoundEnabled(true);
+      expect(useRecordingStore.getState().soundEnabled).toBe(true);
     });
   });
 
@@ -128,12 +155,55 @@ describe("useRecordingStore", () => {
       expect(useRecordingStore.getState().countdownSec).toBeNull();
     });
 
+    it("unlocks audio but does not tick when delay=0", () => {
+      useRecordingStore.getState().setDelay(0);
+      useRecordingStore.getState().startRecording();
+
+      expect(mockUnlock).toHaveBeenCalledTimes(1);
+      expect(mockPlayTick).not.toHaveBeenCalled();
+    });
+
     it("starts a countdown when delay>0", () => {
       useRecordingStore.getState().setDelay(3);
       useRecordingStore.getState().startRecording();
 
       expect(useRecordingStore.getState().countdownSec).toBe(3);
       expect(mockMutateStart).not.toHaveBeenCalled();
+    });
+
+    it("unlocks audio and ticks once for the first count when delay>0", () => {
+      useRecordingStore.getState().setDelay(3);
+      useRecordingStore.getState().startRecording();
+
+      expect(mockUnlock).toHaveBeenCalledTimes(1);
+      expect(mockPlayTick).toHaveBeenCalledTimes(1);
+    });
+
+    it("ticks on each countdown decrement but not on the final handoff", () => {
+      useRecordingStore.getState().setDelay(3);
+      useRecordingStore.getState().startRecording();
+      // 1 tick fired for the initial "3".
+      expect(mockPlayTick).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(1000); // 3 -> 2
+      vi.advanceTimersByTime(1000); // 2 -> 1
+      // Two more ticks for "2" and "1"; three ticks total.
+      expect(mockPlayTick).toHaveBeenCalledTimes(3);
+
+      vi.advanceTimersByTime(1000); // 1 -> start (no tick; start chime takes over)
+      expect(mockPlayTick).toHaveBeenCalledTimes(3);
+      expect(mockMutateStart).toHaveBeenCalled();
+    });
+
+    it("plays no sounds when soundEnabled is false", () => {
+      useRecordingStore.getState().setSoundEnabled(false);
+      useRecordingStore.getState().setDelay(3);
+      useRecordingStore.getState().startRecording();
+
+      vi.advanceTimersByTime(3000);
+
+      expect(mockUnlock).not.toHaveBeenCalled();
+      expect(mockPlayTick).not.toHaveBeenCalled();
     });
 
     it("decrements the countdown by one second", () => {
@@ -206,6 +276,19 @@ describe("useRecordingStore", () => {
       useRecordingStore.getState().stopRecording();
 
       expect(mockMutateStop).toHaveBeenCalledWith(undefined);
+    });
+
+    it("unlocks audio from the stop gesture", () => {
+      useRecordingStore.getState().stopRecording();
+
+      expect(mockUnlock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not unlock audio when soundEnabled is false", () => {
+      useRecordingStore.getState().setSoundEnabled(false);
+      useRecordingStore.getState().stopRecording();
+
+      expect(mockUnlock).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/features/recording/mutations.ts
+++ b/frontend/src/features/recording/mutations.ts
@@ -19,6 +19,7 @@ import { queryClient } from "@/lib/query-client";
 import { sseKeys } from "@/lib/query-keys";
 import { useQualityHistoryStore } from "@/stores/quality-history-store";
 import { toast } from "@/stores/toast-store";
+import * as sounds from "./sounds";
 import { useRecordingStore } from "./store";
 
 // --- Helpers ---
@@ -58,6 +59,7 @@ export const startRecordingMutation = new MutationObserver(queryClient, {
   },
   onSuccess: (_data, topics) => {
     useQualityHistoryStore.getState().addMarker("start");
+    if (useRecordingStore.getState().soundEnabled) sounds.playStart();
     toast.success("Recording started");
     addLog("info", `Recording started (${topics.length} topics)`);
     queryClient.invalidateQueries({ queryKey: getGetRecordingStatusQueryKey() });
@@ -84,6 +86,7 @@ export const stopRecordingMutation = new MutationObserver(queryClient, {
     queryClient.invalidateQueries({ queryKey: getGetRecordingStatusQueryKey() });
     if (resp.status !== 200) return;
     const d = resp.data;
+    if (useRecordingStore.getState().soundEnabled) sounds.playStop();
     toast.success("Recording completed");
     addLog("info", `Recording stopped (${d.duration_sec.toFixed(1)}s) → ${d.output_path}`);
     // Force-refresh the file list to fetch the latest mcap.

--- a/frontend/src/features/recording/recording-control.tsx
+++ b/frontend/src/features/recording/recording-control.tsx
@@ -1,6 +1,6 @@
 /** Recording action bar: record button, delay/REC indicator, robot info, command copy, and task name editor. */
 
-import { AlertTriangle, Bot, ChevronDown, ClipboardCopy } from "lucide-react";
+import { AlertTriangle, Bot, ChevronDown, ClipboardCopy, Volume2, VolumeX } from "lucide-react";
 import { useState } from "react";
 import { RecordingMetadataPanel, TaskNameInlineEditor } from "@/features/settings";
 import { useConfig, useIsRecording } from "@/hooks/use-api";
@@ -21,6 +21,8 @@ export function RecordingControl() {
   const loading = useRecordingStore((s) => s.isStarting || s.isStopping);
   const delaySec = useRecordingStore((s) => s.delaySec);
   const setDelay = useRecordingStore((s) => s.setDelay);
+  const soundEnabled = useRecordingStore((s) => s.soundEnabled);
+  const setSoundEnabled = useRecordingStore((s) => s.setSoundEnabled);
   const [copied, setCopied] = useState(false);
 
   const buttonActive = isRecording || isCountingDown;
@@ -76,6 +78,18 @@ export function RecordingControl() {
             </>
           )}
         </div>
+
+        {/* Notification sound toggle (start/stop/countdown tones for hands-free / foot-pedal use) */}
+        <button
+          type="button"
+          onClick={() => setSoundEnabled(!soundEnabled)}
+          title={soundEnabled ? "Mute start/stop sounds" : "Unmute start/stop sounds"}
+          aria-label={soundEnabled ? "Mute start/stop sounds" : "Unmute start/stop sounds"}
+          aria-pressed={soundEnabled}
+          className="text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {soundEnabled ? <Volume2 size={16} /> : <VolumeX size={16} />}
+        </button>
 
         {/* Divider */}
         <div className="h-12 w-px bg-border/80" />

--- a/frontend/src/features/recording/sounds.ts
+++ b/frontend/src/features/recording/sounds.ts
@@ -1,0 +1,75 @@
+/** Notification tones for recording state changes (Web Audio, no asset files).
+ *
+ * A single AudioContext is created lazily and shared across tones. Browsers keep
+ * it suspended until a user gesture resumes it, so unlock() must run from a gesture
+ * handler (the start/stop press) before the async start/stop chimes can fire.
+ */
+
+/** A single tone in a sequence: a sine wave at `freq` Hz lasting `durationMs`. */
+interface ToneStep {
+  freq: number;
+  durationMs: number;
+}
+
+/** Peak gain of each tone, kept low so the beeps stay unobtrusive. */
+const PEAK_GAIN = 0.15;
+
+let ctx: AudioContext | null = null;
+
+/** Lazily create the shared AudioContext; null when Web Audio is unavailable (SSR / jsdom). */
+function getContext(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  const Ctor =
+    window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!Ctor) return null;
+  ctx ??= new Ctor();
+  return ctx;
+}
+
+/** Resume the audio context from within a user gesture so the later async chimes can play. */
+export function unlock(): void {
+  const c = getContext();
+  if (c?.state === "suspended") void c.resume();
+}
+
+/** Play a sequence of tones back-to-back with a short click-free envelope. */
+function playSequence(steps: ToneStep[]): void {
+  const c = getContext();
+  if (!c) return;
+  let t = c.currentTime;
+  for (const { freq, durationMs } of steps) {
+    const dur = durationMs / 1000;
+    const osc = c.createOscillator();
+    const gain = c.createGain();
+    osc.type = "sine";
+    osc.frequency.setValueAtTime(freq, t);
+    gain.gain.setValueAtTime(0, t);
+    gain.gain.linearRampToValueAtTime(PEAK_GAIN, t + 0.01);
+    gain.gain.linearRampToValueAtTime(0, t + dur);
+    osc.connect(gain).connect(c.destination);
+    osc.start(t);
+    osc.stop(t + dur);
+    t += dur;
+  }
+}
+
+/** Countdown tick: a single short blip. */
+export function playTick(): void {
+  playSequence([{ freq: 880, durationMs: 70 }]);
+}
+
+/** Recording started: a rising two-tone chime. */
+export function playStart(): void {
+  playSequence([
+    { freq: 660, durationMs: 90 },
+    { freq: 990, durationMs: 120 },
+  ]);
+}
+
+/** Recording stopped: a falling two-tone chime. */
+export function playStop(): void {
+  playSequence([
+    { freq: 660, durationMs: 90 },
+    { freq: 440, durationMs: 140 },
+  ]);
+}

--- a/frontend/src/features/recording/store.ts
+++ b/frontend/src/features/recording/store.ts
@@ -14,6 +14,7 @@ import { sseKeys } from "@/lib/query-keys";
 import { toast } from "@/stores/toast-store";
 import { createTimer } from "./create-timer";
 import { startRecordingMutation, stopRecordingMutation } from "./mutations";
+import * as sounds from "./sounds";
 
 /** Available delay options. */
 export const DELAY_OPTIONS = [0, 3, 5, 10] as const;
@@ -39,6 +40,8 @@ interface RecordingStore {
   delaySec: number;
   /** Whether to stop live monitoring while recording is in progress. */
   stopLiveMonitorDuringRecording: boolean;
+  /** Whether to play notification tones on countdown / start / stop. */
+  soundEnabled: boolean;
   /** Seconds remaining in countdown (null = not counting down). */
   countdownSec: number | null;
   /** A start request is in flight. */
@@ -52,6 +55,8 @@ interface RecordingStore {
   setDelay: (sec: number) => void;
   /** Toggle "stop live monitoring while recording" on/off. */
   setStopLiveMonitor: (enabled: boolean) => void;
+  /** Toggle recording notification tones on/off. */
+  setSoundEnabled: (enabled: boolean) => void;
   /** Start recording (honors the delay). */
   startRecording: () => void;
   /** Stop recording (cancels the countdown if one is active). */
@@ -78,13 +83,15 @@ function getConnectionStatus(): SseConnectionStatus | undefined {
 
 /** Countdown one-second tick (recursive setTimeout). */
 function tick() {
-  const { countdownSec } = useRecordingStore.getState();
+  const { countdownSec, soundEnabled } = useRecordingStore.getState();
   if (countdownSec === null) return;
   if (countdownSec <= 1) {
+    // Final handoff: the start chime (mutations.onSuccess) stands in for a tick here.
     useRecordingStore.setState({ countdownSec: null }, false, "tickComplete");
     startRecordingMutation.mutate([...useLiveTopicsStore.getState().selectedTopics]);
     return;
   }
+  if (soundEnabled) sounds.playTick();
   useRecordingStore.setState({ countdownSec: countdownSec - 1 }, false, "tick");
   countdownTimer.set(tick, 1000);
 }
@@ -95,6 +102,7 @@ export const useRecordingStore = create<RecordingStore>()(
       (set, get) => ({
         delaySec: 0,
         stopLiveMonitorDuringRecording: false,
+        soundEnabled: true,
         countdownSec: null,
         isStarting: false,
         isStopping: false,
@@ -102,21 +110,27 @@ export const useRecordingStore = create<RecordingStore>()(
 
         setDelay: (sec) => set({ delaySec: sec }, false, "setDelay"),
         setStopLiveMonitor: (enabled) => set({ stopLiveMonitorDuringRecording: enabled }, false, "setStopLiveMonitor"),
+        setSoundEnabled: (enabled) => set({ soundEnabled: enabled }, false, "setSoundEnabled"),
 
         startRecording: () => {
           // Auto-close any lingering banner from the previous recording.
           set({ finishedRecording: null }, false, "clearFinishedOnStart");
-          const { delaySec } = get();
+          const { delaySec, soundEnabled } = get();
+          // Resume the audio context from within this gesture so the async start chime can play.
+          if (soundEnabled) sounds.unlock();
           if (delaySec <= 0) {
             startRecordingMutation.mutate([...useLiveTopicsStore.getState().selectedTopics]);
             return;
           }
+          if (soundEnabled) sounds.playTick();
           set({ countdownSec: delaySec }, false, "startCountdown");
           countdownTimer.set(tick, 1000);
         },
 
         stopRecording: () => {
-          const { countdownSec } = get();
+          const { countdownSec, soundEnabled } = get();
+          // Resume the audio context from within this gesture so the async stop chime can play.
+          if (soundEnabled) sounds.unlock();
           if (countdownSec !== null) {
             countdownTimer.clear();
             set({ countdownSec: null }, false, "cancelCountdown");
@@ -156,6 +170,7 @@ export const useRecordingStore = create<RecordingStore>()(
         partialize: (state) => ({
           delaySec: state.delaySec,
           stopLiveMonitorDuringRecording: state.stopLiveMonitorDuringRecording,
+          soundEnabled: state.soundEnabled,
         }),
         /* v8 ignore stop */
       },


### PR DESCRIPTION
## Summary

Adds optional notification sounds on the top (recording) screen so operators running hands-free — e.g. with a foot pedal — can confirm **by ear** that recording actually started or stopped, without looking at the screen.

- **Countdown ticks (3-2-1)** during the DELAY countdown, a **rising two-tone start chime** when recording actually begins, and a **falling two-tone stop chime** when it stops.
- Tones are **synthesized via the Web Audio API** — no bundled audio assets, so `NOTICE` is unaffected and there is no licensing footprint.
- Start/stop tones fire on the authoritative start/stop **mutation `onSuccess`**, so both the record button and the Space/foot-pedal shortcut trigger them. DELAY=0 skips the ticks and plays only the start chime. Canceling a countdown stays silent.
- Sound on/off is a **per-browser preference (default on)**, persisted in `localStorage` alongside the delay setting and toggled with a speaker icon (🔊/🔇) in the recording bar.
- The `AudioContext` is **resumed from within the start/stop gesture** so the async chimes satisfy browser autoplay rules.

Purely a client-side UX preference — no backend, `/api/config`, or orval changes.

## Design notes

- New `frontend/src/features/recording/sounds.ts` is a dependency-free Web Audio engine (`unlock` / `playTick` / `playStart` / `playStop`); no-op when Web Audio is unavailable (SSR / jsdom).
- Wiring lives in `store.ts` (unlock + countdown ticks, gated by `soundEnabled`) and `mutations.ts` (start/stop chimes, gated by `soundEnabled`).

## Testing

- `make test-cov-frontend`: 287 tests pass, coverage 100% (statements / branches / functions / lines).
- Added `__tests__/sounds.test.ts` (fake `AudioContext`: resume, tone frequency sequences, no-op path) and extended `store.test.ts` / `mutations.test.ts` (unlock, ticks, start/stop chimes, disabled-path non-firing, status≠200).
- biome clean on the recording feature.
- Manually verified in the browser: countdown "beep-beep-beep → start chime", stop chime, mute toggle, and the DELAY=0 immediate-start path.

Related to hands-free / foot-pedal operation (issue #34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)