### PR TITLE
fix(recording): link the completion banner to the just-finished recording

### DIFF
--- a/frontend/src/features/recording/__tests__/mutations.test.ts
+++ b/frontend/src/features/recording/__tests__/mutations.test.ts
@@ -47,6 +47,7 @@ vi.mock("@/api/generated/recording/recording", () => ({
 vi.mock("@/api/generated/recordings/recordings", () => ({
   getRecordings: mockGetFiles,
   getGetRecordingsQueryKey: vi.fn(() => ["recordings"]),
+  getGetRecordingsQueryOptions: vi.fn(() => ({ queryKey: ["recordings"] })),
 }));
 
 vi.mock("@/api/generated/analysis/analysis", () => ({
@@ -308,13 +309,30 @@ describe("stopRecordingMutation", () => {
     await flushMutation();
   });
 
-  it("adds a marker and saves completion info to the store on success", async () => {
-    vi.spyOn(queryClient, "getQueryData").mockReturnValue({
+  it("adds a marker and saves the matched entry's relative path to the store on success", async () => {
+    // The banner must store the entry's output_dir-relative path (so the detail page can match it),
+    // not the absolute output_path. It must match by folder name, not blindly take the newest entry.
+    mockStopRecordingApi.mockResolvedValueOnce({
+      status: 200,
+      data: { duration_sec: 10.5, output_path: "/data/recordings/rec_002" },
+    });
+    vi.spyOn(queryClient, "fetchQuery").mockResolvedValue({
       data: {
         entries: [
           {
-            name: "rec_001",
-            path: "/data/rec_001",
+            name: "rec_003",
+            path: "2026-07-28/rec_003",
+            size: 1,
+            modified_at: 0,
+            topic_count: 1,
+            recording_start_ns: null,
+            duration_ns: null,
+            message_count: 1,
+            has_quality_report: false,
+          },
+          {
+            name: "rec_002",
+            path: "2026-07-28/rec_002",
             size: 2048,
             modified_at: 0,
             topic_count: 3,
@@ -334,8 +352,8 @@ describe("stopRecordingMutation", () => {
     expect(mockSetState).toHaveBeenCalledWith(
       expect.objectContaining({
         finishedRecording: expect.objectContaining({
-          name: "rec_001",
-          path: "/data/rec_001",
+          name: "rec_002",
+          path: "2026-07-28/rec_002",
           durationSec: 10.5,
           messageCount: 500,
           topicCount: 3,
@@ -345,9 +363,8 @@ describe("stopRecordingMutation", () => {
     );
   });
 
-  it("onSuccess: synthesizes from the response and saves when entries is empty", async () => {
-    vi.spyOn(queryClient, "getQueryData").mockReturnValue({ data: { entries: [] } });
-
+  it("onSuccess: synthesizes from the response and saves when the fresh scan is empty", async () => {
+    // fetchQuery defaults to an empty scan (beforeEach), so the path-only fallback runs.
     stopRecordingMutation.mutate(undefined);
     await flushMutation();
 
@@ -378,7 +395,6 @@ describe("stopRecordingMutation", () => {
   });
 
   it("plays the stop chime on success", async () => {
-    vi.spyOn(queryClient, "getQueryData").mockReturnValue({ data: { entries: [] } });
     stopRecordingMutation.mutate(undefined);
     await flushMutation();
 
@@ -395,7 +411,6 @@ describe("stopRecordingMutation", () => {
 
   it("does not play the stop chime when sound is disabled", async () => {
     mockSoundEnabled.current = false;
-    vi.spyOn(queryClient, "getQueryData").mockReturnValue({ data: { entries: [] } });
     stopRecordingMutation.mutate(undefined);
     await flushMutation();
 
@@ -404,9 +419,13 @@ describe("stopRecordingMutation", () => {
 
   it("invalidates the quality query in stages", async () => {
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
-    vi.spyOn(queryClient, "getQueryData").mockReturnValue({
+    mockStopRecordingApi.mockResolvedValueOnce({
+      status: 200,
+      data: { duration_sec: 10.5, output_path: "/data/recordings/rec_001" },
+    });
+    vi.spyOn(queryClient, "fetchQuery").mockResolvedValue({
       data: {
-        entries: [{ name: "rec_001", path: "/data/rec_001" }],
+        entries: [{ name: "rec_001", path: "2026-07-28/rec_001" }],
       },
     });
 
@@ -421,7 +440,7 @@ describe("stopRecordingMutation", () => {
       await vi.advanceTimersByTimeAsync(delayMs);
       expectedQualityCalls = 1;
       expect(invalidateSpy).toHaveBeenCalledTimes(expectedQualityCalls);
-      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["quality", "/data/rec_001"] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["quality", "2026-07-28/rec_001"] });
     }
   });
 

--- a/frontend/src/features/recording/mutations.ts
+++ b/frontend/src/features/recording/mutations.ts
@@ -11,8 +11,8 @@ import {
   startRecording as startRecordingApi,
   stopRecording as stopRecordingApi,
 } from "@/api/generated/recording/recording";
-import { getGetRecordingsQueryKey } from "@/api/generated/recordings/recordings";
-import type { ConfigResponse, FilesResponse } from "@/api/generated/schemas";
+import { getGetRecordingsQueryKey, getGetRecordingsQueryOptions } from "@/api/generated/recordings/recordings";
+import type { ConfigResponse } from "@/api/generated/schemas";
 import { useSettingsStore } from "@/features/settings";
 import type { LogEntry } from "@/hooks/use-topics-stream";
 import { queryClient } from "@/lib/query-client";
@@ -89,14 +89,15 @@ export const stopRecordingMutation = new MutationObserver(queryClient, {
     if (useRecordingStore.getState().soundEnabled) sounds.playStop();
     toast.success("Recording completed");
     addLog("info", `Recording stopped (${d.duration_sec.toFixed(1)}s) → ${d.output_path}`);
-    // Force-refresh the file list to fetch the latest mcap.
-    // invalidateQueries notifies every observer to refetch, ensuring the UI updates.
-    // (Cases existed where fetchQuery alone skipped observer re-renders.)
-    await queryClient.invalidateQueries({ queryKey: getGetRecordingsQueryKey() });
-    const filesResp = queryClient.getQueryData<{ data: FilesResponse }>(getGetRecordingsQueryKey());
-    const filesData = filesResp?.data;
-    // The first entry is always the newest recording (scan_output_dir returns recording_start_ns descending).
-    const firstEntry = filesData?.entries[0];
+    // Fetch a fresh scan and populate the cache. invalidateQueries only refetches queries that have an
+    // active observer, but the recording screen mounts none — so the banner cannot read the cache
+    // directly (it may be empty or stale). fetchQuery guarantees a fresh list and refreshes any list view.
+    const filesResp = await queryClient.fetchQuery(getGetRecordingsQueryOptions());
+    // output_path is absolute, but FileEntry.path is relative to output_dir; match on the folder name
+    // (the unique recording id). split always returns at least one element, so pop returns a string.
+    const finishedName = d.output_path.split("/").pop() as string;
+    // Fall back to the newest entry (scan_output_dir returns recording_start_ns descending).
+    const firstEntry = filesResp.data.entries.find((e) => e.name === finishedName) ?? filesResp.data.entries[0];
 
     // Save the latest recording info to the store for the completion banner (synthesize from the API response if FileEntry is missing).
     if (firstEntry) {
@@ -111,11 +112,10 @@ export const stopRecordingMutation = new MutationObserver(queryClient, {
         },
       });
     } else {
-      // Path-only fallback (entries is empty or unfetched). split always returns at least one element, so pop returns a string.
-      const name = d.output_path.split("/").pop() as string;
+      // Path-only fallback (the fresh scan returned no entries).
       useRecordingStore.setState({
         finishedRecording: {
-          name,
+          name: finishedName,
           path: d.output_path,
           durationSec: d.duration_sec,
           messageCount: null,


### PR DESCRIPTION
## Problem

On the recording screen, clicking the detail link on the recording-completion banner (`frontend/src/features/recording/completion-banner.tsx`) either redirected to the recordings **list** instead of the detail page, or opened the **wrong** (previous) recording.

## Root cause

`stopRecordingMutation.onSuccess` built `finishedRecording.path` from an `invalidateQueries` + `getQueryData` pair:

```ts
await queryClient.invalidateQueries({ queryKey: getGetRecordingsQueryKey() });
const filesData = queryClient.getQueryData(...)?.data;
const firstEntry = filesData?.entries[0];
```

In TanStack Query v5, `invalidateQueries` (default `refetchType: 'active'`) only refetches queries that have an **active observer**. The recordings query (`useFiles`) is observed only on `/recordings` and `/recordings/$folder` — **not** on the recording screen (`/`, `RecorderPage`) where the banner lives. So `await invalidateQueries` resolved immediately without refetching, and `getQueryData` returned:

- **empty cache** (list never opened this session) → the fallback branch stored `path: d.output_path`, which is **absolute** (`str(output_dir / recording_id)`), while `FileEntry.path` is **relative to output_dir** (`str(folder.relative_to(rel_root))`). They never match → the detail page's `currentExists` check fails → `useEffect` redirects to `/recordings`.
- **stale cache** (list opened earlier) → `entries[0]` was a *previous* newest recording → banner name/stats/link all pointed at the **wrong** recording.

## Fix

- Replace `invalidateQueries` + `getQueryData` with **`await queryClient.fetchQuery(getGetRecordingsQueryOptions())`** — this fetches a fresh scan regardless of observers and repopulates the cache (also refreshing any mounted list view).
- Select the entry by **folder name** (the unique recording id from `output_path`'s trailing segment), falling back to the newest entry. The banner now always stores the correct **output_dir-relative** `FileEntry.path`, which the detail page matches.
- The absolute-path fallback is now only reached when the fresh scan is genuinely empty.

## Tests

- `mutations.test.ts`: strengthened the completion-info test to assert the stored path is the entry's **relative** path (not the absolute `output_path`) and that the entry is matched **by name** (not blindly `entries[0]`). Migrated the empty-scan fallback and staged quality-invalidation tests to the `fetchQuery` path.

## Verification

- `tsc --noEmit` → clean
- `biome check src/` → clean
- recording test suite → 104 passed
- `mutations.ts` coverage → 100% (statements / branches / functions / lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)