### PR TITLE
feat(dev): add a Linux Chromium check environment (make chromium-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ make generate          # Regenerate API types (requires: backend running)
 make build             # Build Docker images
 make minio-up          # Start the local MinIO sandbox + auto-create the bucket (for upload-feature testing)
 make minio-down        # Stop the local MinIO sandbox
+make chromium-up       # Start a Linux Chromium for UI checks in the operators' environment (view at :3000)
+make chromium-down     # Stop the Linux Chromium
 make prod-up           # Production start (host network)
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 .PHONY: help up dev-up down restart logs ps build stream \
 	minio-up minio-down \
+	chromium-up chromium-down \
 	lint lint-backend lint-frontend \
 	test test-backend test-frontend \
 	test-cov test-cov-backend test-cov-frontend \
@@ -27,6 +28,10 @@ help:
 	@echo "Local S3 (MinIO, for testing the upload feature):"
 	@echo "  make minio-up   - Start MinIO + auto-create the bucket"
 	@echo "  make minio-down - Stop MinIO"
+	@echo ""
+	@echo "Linux browser (Chromium, for checking the UI in the operators' environment):"
+	@echo "  make chromium-up   - Start Linux Chromium (view at http://localhost:3000)"
+	@echo "  make chromium-down - Stop Linux Chromium"
 	@echo ""
 	@echo "Dev tools:"
 	@echo "  make lint              - Lint (all: backend + frontend)"
@@ -119,6 +124,22 @@ minio-up:
 # Stop MinIO
 minio-down:
 	docker compose --profile s3 down
+
+# ===== Linux browser (Chromium) =====
+
+# Start a Linux-native Chromium (KasmVNC) for checking the UI in the
+# operators' Ubuntu environment (e.g. browser-rendered <select> popups)
+chromium-up:
+	@echo "=== Starting Linux Chromium ==="
+	docker compose --profile browser up -d chromium
+	@echo "=== Linux Chromium started ==="
+	@echo "  Desktop: http://localhost:3000  (Chromium opens http://frontend:5173)"
+	@echo "  Note: the live video preview (MJPEG) needs the dev server started with"
+	@echo "        VITE_API_BASE=http://host.docker.internal:8000 make up"
+
+# Stop Linux Chromium (stop + remove only this container, leave the rest running)
+chromium-down:
+	docker compose --profile browser rm -sf chromium
 
 # ===== Dev tools =====
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,29 @@ services:
     profiles:
       - s3
 
+  # --- Linux Chromium: browser check environment (development only) ---
+  # Renders the app in a Linux-native Chromium (KasmVNC desktop, reachable at
+  # http://localhost:3000) to verify behavior that differs from macOS browsers,
+  # e.g. browser-rendered <select> popups on the operators' Ubuntu machines.
+  chromium:
+    image: lscr.io/linuxserver/chromium:latest
+    container_name: open-lutra-chromium
+    shm_size: "1gb"
+    security_opt:
+      - seccomp=unconfined
+    environment:
+      # Open the app on startup. `frontend` resolves inside the compose
+      # network, so this works without the host-published port; the hostname
+      # must be listed in Vite's server.allowedHosts (vite.config.ts).
+      - CHROME_CLI=http://frontend:5173
+    ports:
+      - "3000:3000"
+    depends_on:
+      - frontend
+    profiles:
+      - browser
+    restart: unless-stopped
+
 volumes:
   frontend_node_modules:
   minio_data:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -12,6 +12,7 @@
 - [Testing](#testing)
 - [Lint and Type Checking](#lint-and-type-checking)
 - [Frontend Development Notes](#frontend-development-notes)
+- [Checking the UI on Linux (Chromium)](#checking-the-ui-on-linux-chromium)
 - [Common Development Tasks](#common-development-tasks)
 
 ---
@@ -334,6 +335,39 @@ ignore_missing_imports = true
 | Server state | TanStack Query | Recording status, file list |
 | Real-time data | SSE → TanStack Query | Topic statistics, logs |
 | UI state | Zustand | Panel open/close, topic selection |
+
+---
+
+## Checking the UI on Linux (Chromium)
+
+The operators run the frontend on Ubuntu, where browsers draw some widgets
+themselves that macOS delegates to the OS — most notably `<select>` dropdowns,
+whose popup colors come from the OS theme rather than the page CSS. Bugs like
+white-on-white dropdown options (#68) are therefore invisible on macOS.
+
+`make chromium-up` starts a Linux-native Chromium in Docker
+(`lscr.io/linuxserver/chromium`, KasmVNC) attached to the compose network:
+
+```bash
+make up           # dev environment must be running
+make chromium-up  # then open http://localhost:3000 in your browser
+```
+
+The containerized Chromium opens `http://frontend:5173` (the Vite dev server's
+compose-internal hostname, allowed via `server.allowedHosts` in
+`frontend/vite.config.ts`). Stop it with `make chromium-down`.
+
+Notes:
+
+- The KasmVNC desktop uses a light theme by default — the same condition as the
+  operators' stock Ubuntu, which is what triggers OS-theme-dependent bugs.
+- The live video preview (MJPEG) bypasses the Vite proxy and connects to
+  `VITE_API_BASE` (default `http://localhost:8000`), which does not resolve
+  inside the container. To check it from the Linux browser, restart the dev
+  server with `VITE_API_BASE=http://host.docker.internal:8000 make up` (the
+  preview in your macOS browser stops working while this is set).
+- Tablet-like conditions (touch events, screen size) can be approximated with
+  Chrome DevTools device emulation inside the container.
 
 ---
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: 5173,
+    // Allow access from the Linux Chromium check container (`make chromium-up`),
+    // which reaches the dev server via the compose-internal hostname.
+    allowedHosts: ["frontend"],
     proxy: {
       "/api": {
         target: process.env.API_URL || "http://localhost:8000",


### PR DESCRIPTION
## Summary

Adds a one-command Linux browser check environment so UI behavior in the operators' Ubuntu environment can be verified from a Mac at any time.

Ubuntu browsers draw `<select>` popups (and other widgets) themselves using OS-theme colors, while macOS browsers delegate them to the OS — so bugs like the white-on-white dropdown options in #68 are impossible to see on macOS. This was verified while investigating #68: the bug reproduced only in a Linux Chromium container, on none of the macOS browsers.

## Changes

- **docker-compose.yml** — new `chromium` service (`lscr.io/linuxserver/chromium`, KasmVNC desktop on `:3000`) behind a `browser` profile, mirroring the MinIO sandbox pattern. Opens `http://frontend:5173` on startup via the compose network.
- **Makefile** — `make chromium-up` / `make chromium-down` targets (+ help). `chromium-down` uses `compose rm -sf` so it removes only this container and leaves the dev environment running.
- **frontend/vite.config.ts** — `server.allowedHosts: ["frontend"]`; Vite's host check otherwise blocks requests addressed to the compose-internal hostname.
- **docs/DEVELOPMENT.md** — new "Checking the UI on Linux (Chromium)" section: usage, why macOS can't reproduce these bugs, light-theme default, MJPEG preview caveat (`VITE_API_BASE=http://host.docker.internal:8000`), touch/tablet emulation note.
- **CLAUDE.md** — command list updated.

## Usage

```bash
make up           # dev environment must be running
make chromium-up  # then open http://localhost:3000
```

## Verification

- `make chromium-up` with the dev environment running: KasmVNC responds 200 on `:3000`; `curl http://frontend:5173` from inside the container returns the app (allowedHosts effective).
- `make chromium-down` stops/removes only `open-lutra-chromium`; backend/frontend/simulator keep running.
- `make lint-frontend` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)