### PR TITLE
fix(frontend): give <select> options explicit colors for Linux browsers

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -153,4 +153,12 @@
   body {
     @apply bg-background text-foreground;
   }
+  /* Native <select> dropdowns on Linux/Windows are browser-rendered: the list
+     background follows the OS theme (white on a light desktop) while the text
+     color is inherited from the page (near-white here), leaving the options
+     unreadable. The popup ignores color-scheme, so options need explicit
+     colors. macOS browsers use OS-native menus and are unaffected. */
+  option {
+    @apply bg-popover text-popover-foreground;
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #68 — on the operators' Ubuntu machines, options in native `<select>` dropdowns (metadata panel, metadata edit dialog, DELAY selector) rendered as white text on a white background.

## Root cause

On Linux, Chromium renders the `<select>` popup itself with two independently sourced colors: the option **background** comes from the OS/browser theme (white on a light desktop), while the option **text color** is inherited from the page — near-white on this always-dark UI. See #68 for the full analysis.

## Fix

A global rule in `index.css` (`@layer base`):

```css
option {
  @apply bg-popover text-popover-foreground;
}
```

This covers all three current selects and any future ones in one place. `color-scheme` was verified not to work (the popup ignores it at both root and element level — see the verification matrix in #68), so explicit option colors are the only working fix.

### before



https://github.com/user-attachments/assets/5c844306-f11f-469d-a8a2-cb5d60b2a056





### after



https://github.com/user-attachments/assets/273fee6c-d3b1-4576-850e-b42c84aa61d9





## Verification

- Fix variant verified readable on Linux Chromium (Docker `lscr.io/linuxserver/chromium`, light desktop theme) side by side with the broken control — see #68.
- macOS browsers use OS-native menus that ignore option CSS, so this rule has no effect there.
- `make lint-frontend` passes. No JS/TS changes; no tests cover CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)