### PR TITLE
fix(recording): surface disk-full failures with explicit error messages

### DIFF
--- a/backend/app/dependencies/exception_handlers.py
+++ b/backend/app/dependencies/exception_handlers.py
@@ -1,9 +1,13 @@
 """Application-wide exception handlers."""
 
+import logging
+
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 
 from app.features.recording import AlreadyRecordingError, NotRecordingError, RecorderError
+
+logger = logging.getLogger(__name__)
 
 
 def register_exception_handlers(app: FastAPI) -> None:
@@ -20,3 +24,14 @@ def register_exception_handlers(app: FastAPI) -> None:
     @app.exception_handler(RecorderError)
     async def _recorder_error(_request: Request, exc: RecorderError) -> JSONResponse:
         return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"detail": str(exc)})
+
+    @app.exception_handler(Exception)
+    async def _unexpected_error(request: Request, exc: Exception) -> JSONResponse:
+        # Catch-all so unexpected exceptions reach the UI toast with at least
+        # the exception type instead of a bare "Internal Server Error".
+        logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
+        detail = f"{exc.__class__.__name__}: {exc}" if str(exc) else exc.__class__.__name__
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"detail": f"Unexpected server error ({detail}) — check the backend logs for details."},
+        )

--- a/backend/app/features/recording/router.py
+++ b/backend/app/features/recording/router.py
@@ -9,6 +9,7 @@ from typing import Any
 from fastapi import APIRouter, status
 
 from app.dependencies import RecorderDep
+from app.features.recording.models import RecorderError
 from app.features.recording.schemas import (
     RecordingStartRequest,
     RecordingStartResponse,
@@ -44,8 +45,13 @@ async def start_recording(
         metadata=request.metadata,
     )
     start_time = recorder.get_status().start_time
-    # start_time is guaranteed to be set immediately after recorder.start() (the service stores it right after datetime.now()).
-    assert start_time is not None
+    if start_time is None:
+        # get_status() detected that the recorder died right after start() and
+        # reset the state (crash-at-startup race, e.g. on a full disk).
+        raise RecorderError(
+            "Recorder process exited immediately after starting; no recording is in progress. "
+            "A full disk is the most common cause; check the backend logs for details."
+        )
 
     # Notify the log panel that recording has started.
     topic_count = len(request.topics) if request.topics else 0

--- a/backend/app/features/recording/service.py
+++ b/backend/app/features/recording/service.py
@@ -6,7 +6,9 @@ Memory is isolated to the subprocess, so long recordings stay safe.
 
 from __future__ import annotations
 
+import errno
 import logging
+import shutil
 import signal
 import subprocess
 import time
@@ -27,8 +29,40 @@ from app.infra.ros2 import QoSOverrideFile, ROS2Command, ROS2CommandError
 if TYPE_CHECKING:
     from app.infra.ros2.record_process import RecordProcess
     from app.settings import Settings
+    from app.shared.log_manager import LogSeverity
 
 logger = logging.getLogger(__name__)
+
+
+def _free_disk_bytes(path: Path) -> int | None:
+    """Return the free bytes of the filesystem containing `path`.
+
+    Returns None when the path cannot be inspected (e.g. it does not exist),
+    so callers can skip the disk hint instead of failing.
+    """
+    try:
+        return shutil.disk_usage(path).free
+    except OSError:
+        return None
+
+
+def _format_gb(num_bytes: int) -> str:
+    """Format a byte count as a decimal-GB string (e.g. '0.3 GB')."""
+    return f"{num_bytes / 1_000_000_000:.1f} GB"
+
+
+def _disk_space_suffix(path: Path) -> str:
+    """Suffix naming the free space at `path` for disk-related error messages.
+
+    Recording failures caused by a full disk are hard to diagnose from generic
+    errors, so storage-adjacent messages append the current free space of the
+    output volume. Returns ' — free disk space: X GB at <path>', or '' when
+    the free space cannot be determined.
+    """
+    free = _free_disk_bytes(path)
+    if free is None:
+        return ""
+    return f" — free disk space: {_format_gb(free)} at {path}"
 
 
 class ROS2BagRecorder:
@@ -103,7 +137,13 @@ class ROS2BagRecorder:
         try:
             output_path.parent.mkdir(parents=True, exist_ok=True)
         except OSError as e:
+            if e.errno == errno.ENOSPC:
+                raise RecorderError(
+                    f"Disk full: cannot create the output directory {output_path.parent}. Free up space and try again."
+                ) from e
             raise RecorderError(f"Failed to create output directory: {e}") from e
+
+        self._ensure_disk_not_full()
 
         # Build the QoS override YAML (retained until recording ends).
         self._qos_file = QoSOverrideFile(qos_overrides) if qos_overrides else None
@@ -124,6 +164,20 @@ class ROS2BagRecorder:
         # Wait for DDS discovery to complete before starting recording.
         self._wait_and_resume(record, topics_to_record)
 
+        # A recorder that dies this early failed to create the bag (a full disk
+        # is the most common cause); report it instead of returning success.
+        returncode = record.process.poll()
+        if returncode is not None:
+            record.cleanup()
+            if self._qos_file is not None:
+                self._qos_file.cleanup()
+                self._qos_file = None
+            raise RecorderError(
+                f"Recorder process exited during startup (exit code={returncode}); "
+                f"no recording was started{_disk_space_suffix(self._output_dir)}. "
+                "A full disk is the most common cause; check the backend logs for details."
+            )
+
         # Write app-specific metadata (ros2 bag record has already created output_path).
         # On failure, log a warning only and let recording continue.
         self._write_meta(output_path, task_name, metadata)
@@ -136,10 +190,24 @@ class ROS2BagRecorder:
         logger.info("Recording started: path=%s", output_path)
         return output_path
 
+    def _ensure_disk_not_full(self) -> None:
+        """Refuse to start recording when the output volume has no free space left.
+
+        A recorder on a hard-full disk often survives (creating 0-byte files
+        still succeeds) and silently records nothing, so this is rejected
+        upfront. Skipped when the free space cannot be determined. A
+        configurable threshold (recording_min_free_gb) is planned separately.
+        """
+        if _free_disk_bytes(self._output_dir) == 0:
+            raise RecorderError(
+                f"Disk full: no free disk space left at {self._output_dir}. "
+                "Free up space before starting a recording."
+            )
+
     def _write_meta(
         self, output_path: Path, task_name: str | None, metadata: dict[str, str] | None
     ) -> None:
-        """Write recording_meta.json. Logs a warning on failure."""
+        """Write recording_meta.json. Reports the failure without aborting the recording."""
         try:
             write_recording_meta(
                 output_path,
@@ -151,7 +219,15 @@ class ROS2BagRecorder:
                 ),
             )
         except OSError as e:
-            logger.warning("Failed to write recording_meta.json: %s", e)
+            if e.errno == errno.ENOSPC:
+                message = (
+                    "Disk full: recording_meta.json could not be written; task name and "
+                    f"metadata will be missing{_disk_space_suffix(output_path)}"
+                )
+            else:
+                message = f"Failed to write recording_meta.json: {e}"
+            logger.warning(message)
+            self._notify_log("danger", message)
 
     def stop(self) -> StopResult:
         """Stop the current recording.
@@ -220,29 +296,32 @@ class ROS2BagRecorder:
             return  # Still running
 
         output_name = self._output_path.name if self._output_path else "unknown"
+        # Include free space so a crash caused by a full disk names the cause.
+        disk_hint = _disk_space_suffix(self._output_dir)
         logger.error(
-            "Recorder process exited abnormally (exit code=%s, path=%s)",
+            "Recorder process exited abnormally (exit code=%s, path=%s)%s",
             returncode,
             self._output_path,
+            disk_hint,
         )
 
         self._record.cleanup()
         self._reset_state()
-        self._notify_crash(returncode, output_name)
+        self._notify_log(
+            "danger",
+            f"Recorder process exited abnormally (exit code={returncode}) -> {output_name}{disk_hint}",
+        )
 
     @staticmethod
-    def _notify_crash(returncode: int, output_name: str) -> None:  # pragma: no cover
-        """Report an abnormal termination to LogManager."""
+    def _notify_log(severity: LogSeverity, message: str) -> None:  # pragma: no cover
+        """Report a recording problem to the operator-visible LogManager."""
         try:
             from app.shared.log_manager import get_log_manager
 
-            get_log_manager().add(
-                "danger",
-                f"Recorder process exited abnormally (exit code={returncode}) -> {output_name}",
-            )
+            get_log_manager().add(severity, message)
         except Exception as e:
-            # Skip when LogManager is not initialized (e.g. tests); crash notification is non-critical.
-            logger.debug("Skipping crash notification because LogManager is not initialized: %s", e)
+            # Skip when LogManager is not initialized (e.g. tests); the notification is non-critical.
+            logger.debug("Skipping log notification because LogManager is not initialized: %s", e)
 
     def _wait_and_resume(self, record: RecordProcess, topics: list[str]) -> None:
         """Wait for DDS discovery to complete, then resume the recording.

--- a/backend/app/infra/mcap/__init__.py
+++ b/backend/app/infra/mcap/__init__.py
@@ -8,10 +8,17 @@ from app.infra.mcap.messages import (
     extract_joint_positions,
     is_image_message,
 )
-from app.infra.mcap.reader import MCAPChannel, MCAPMessage, MCAPReader, find_mcap_files
+from app.infra.mcap.reader import (
+    CorruptedMCAPError,
+    MCAPChannel,
+    MCAPMessage,
+    MCAPReader,
+    find_mcap_files,
+)
 from app.infra.mcap.timestamp import resolve_timestamp_ns, resolve_timestamp_sec
 
 __all__ = [
+    "CorruptedMCAPError",
     "MCAPChannel",
     "MCAPMessage",
     "MCAPReader",

--- a/backend/app/infra/mcap/reader.py
+++ b/backend/app/infra/mcap/reader.py
@@ -17,8 +17,29 @@ from pathlib import Path
 from types import TracebackType
 from typing import IO, Any
 
+from mcap.exceptions import McapError
 from mcap.reader import make_reader
 from mcap_ros2.decoder import DecoderFactory
+
+
+class CorruptedMCAPError(Exception):
+    """An MCAP file could not be parsed.
+
+    Raised in place of the mcap library's low-level parse errors so that the
+    message names the file and the typical causes (a recording cut short —
+    full disk, power loss, or a force-killed recorder — truncates the MCAP
+    mid-record).
+    """
+
+    @classmethod
+    def from_cause(cls, path: Path, cause: Exception) -> "CorruptedMCAPError":
+        """Build the user-facing error from a low-level mcap parse error."""
+        detail = str(cause) or cause.__class__.__name__
+        return cls(
+            f"MCAP file is unreadable (truncated or corrupted): {path.name} — {detail}. "
+            "This usually means the recording was cut short — e.g. the disk filled up, "
+            "the machine lost power, or the recorder was forcibly killed."
+        )
 
 
 @dataclass(frozen=True)
@@ -63,7 +84,14 @@ class MCAPReader:
 
     def __enter__(self) -> "MCAPReader":  # pragma: no cover - MCAP I/O boundary
         self._file = self._path.open("rb")
-        self._reader = make_reader(self._file, decoder_factories=[DecoderFactory()])
+        try:
+            self._reader = make_reader(self._file, decoder_factories=[DecoderFactory()])
+        except McapError as e:
+            # e.g. EndOfFile (empty message) for a 0-byte file left by a recorder
+            # that could not write anything.
+            self._file.close()
+            self._file = None
+            raise CorruptedMCAPError.from_cause(self._path, e) from e
         return self
 
     def __exit__(
@@ -83,7 +111,7 @@ class MCAPReader:
         Returns an empty dict if no summary exists (old or truncated MCAP).
         """
         assert self._reader is not None, "MCAPReader must be used as a context manager"
-        summary = self._reader.get_summary()
+        summary = self._get_summary()
         if summary is None or not summary.channels or not summary.schemas:
             return {}
         channels: dict[str, MCAPChannel] = {}
@@ -101,7 +129,7 @@ class MCAPReader:
         Returns (0, 0) if no summary exists.
         """
         assert self._reader is not None, "MCAPReader must be used as a context manager"
-        summary = self._reader.get_summary()
+        summary = self._get_summary()
         if summary is None or summary.statistics is None:
             return (0, 0)
         stats = summary.statistics
@@ -130,14 +158,24 @@ class MCAPReader:
             start_time=start_time_ns,
             end_time=end_time_ns,
         )
-        for schema, channel, message, decoded in iterator:
-            yield MCAPMessage(
-                topic=channel.topic,
-                msg_type=schema.name if schema else "unknown",
-                timestamp_ns=message.log_time,
-                decoded=decoded,
-                size_bytes=len(message.data),
-            )
+        try:
+            for schema, channel, message, decoded in iterator:
+                yield MCAPMessage(
+                    topic=channel.topic,
+                    msg_type=schema.name if schema else "unknown",
+                    timestamp_ns=message.log_time,
+                    decoded=decoded,
+                    size_bytes=len(message.data),
+                )
+        except McapError as e:
+            raise CorruptedMCAPError.from_cause(self._path, e) from e
+
+    def _get_summary(self) -> Any:  # pragma: no cover - MCAP I/O boundary
+        """Read the MCAP summary, translating parse errors of corrupt files."""
+        try:
+            return self._reader.get_summary()
+        except McapError as e:
+            raise CorruptedMCAPError.from_cause(self._path, e) from e
 
 
 def find_mcap_files(folder: Path) -> list[Path]:

--- a/backend/app/infra/ros2/record_process.py
+++ b/backend/app/infra/ros2/record_process.py
@@ -74,6 +74,14 @@ class RecordProcess:  # pragma: no cover
         deadline = time.monotonic() + timeout
 
         while time.monotonic() < deadline:
+            # A dead recorder will never subscribe; stop waiting so the caller
+            # can report the failure immediately instead of after the timeout.
+            if self.process.poll() is not None:
+                logger.warning(
+                    "Recorder process exited while waiting for DDS discovery (exit code=%s)",
+                    self.process.returncode,
+                )
+                break
             text = self._consume_buffer()
             if text:
                 for match in re.finditer(r"Subscribed to topic '([^']+)'", text):

--- a/backend/tests/dependencies/test_exception_handlers.py
+++ b/backend/tests/dependencies/test_exception_handlers.py
@@ -60,3 +60,30 @@ class TestRecorderErrorHandler:
         response = client.post("/api/recording/start")
         assert response.status_code == 500
         assert response.json()["detail"] == "Internal error"
+
+
+class TestCatchAllHandler:
+    """Unexpected exceptions -> 500 naming the exception instead of a bare 'Internal Server Error'."""
+
+    @pytest.fixture
+    def raw_client(self) -> TestClient:
+        """Client that returns the 500 response instead of re-raising server exceptions."""
+        app = create_app()
+        recorder = MagicMock()
+        recorder.is_recording = False
+        set_recorder(recorder)
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_names_exception_type_and_message(self, raw_client: TestClient) -> None:
+        recorder = get_recorder()
+        recorder.start.side_effect = ValueError("boom")
+        response = raw_client.post("/api/recording/start")
+        assert response.status_code == 500
+        assert "ValueError: boom" in response.json()["detail"]
+
+    def test_falls_back_to_type_for_empty_message(self, raw_client: TestClient) -> None:
+        recorder = get_recorder()
+        recorder.start.side_effect = RuntimeError()
+        response = raw_client.post("/api/recording/start")
+        assert response.status_code == 500
+        assert "RuntimeError" in response.json()["detail"]

--- a/backend/tests/features/recording/test_router.py
+++ b/backend/tests/features/recording/test_router.py
@@ -91,6 +91,16 @@ class TestStartRecording:
         assert response.status_code == 200
         assert "output_path" in response.json()
 
+    def test_start_recording_crash_right_after_start_returns_explicit_500(
+        self, client: TestClient, mock_recorder: MagicMock
+    ) -> None:
+        """A recorder that dies between start() and the status read returns a named error, not a bare 500."""
+        # get_status() detected the crash and reset the state (start_time is None).
+        mock_recorder.get_status.return_value = RecorderStatus(is_recording=False)
+        response = client.post("/api/recording/start")
+        assert response.status_code == 500
+        assert "exited immediately after starting" in response.json()["detail"]
+
     def test_start_recording_with_topics(self, client: TestClient, mock_recorder: MagicMock) -> None:
         mock_recorder.get_status.return_value = RecorderStatus(
             is_recording=True,

--- a/backend/tests/features/recording/test_service.py
+++ b/backend/tests/features/recording/test_service.py
@@ -1,5 +1,6 @@
 """Unit tests for ROS2BagRecorder."""
 
+import errno
 import json
 import signal
 import subprocess
@@ -14,6 +15,7 @@ from app.features.recording import (
     RecorderError,
     ROS2BagRecorder,
 )
+from app.features.recording.service import _disk_space_suffix, _format_gb, _free_disk_bytes
 from app.infra.ros2 import ROS2CommandError
 
 
@@ -367,6 +369,132 @@ class TestMetaWrite:
         """
         recorder.start(topics=["/topic"])
         assert recorder.is_recording is True
+
+
+class TestDiskHelpers:
+    """Tests for the free-disk-space helpers."""
+
+    def test_free_disk_bytes_returns_free_bytes_for_existing_path(self, tmp_path: Path) -> None:
+        free = _free_disk_bytes(tmp_path)
+        assert free is not None
+        assert free > 0
+
+    def test_free_disk_bytes_returns_none_for_missing_path(self, tmp_path: Path) -> None:
+        assert _free_disk_bytes(tmp_path / "does-not-exist") is None
+
+    def test_format_gb_formats_decimal_gb(self) -> None:
+        assert _format_gb(300_000_000) == "0.3 GB"
+        assert _format_gb(5_000_000_000) == "5.0 GB"
+        assert _format_gb(0) == "0.0 GB"
+
+    def test_disk_space_suffix_names_free_space_and_path(self) -> None:
+        with patch("app.features.recording.service._free_disk_bytes", return_value=300_000_000):
+            suffix = _disk_space_suffix(Path("/data/output"))
+        assert suffix == " — free disk space: 0.3 GB at /data/output"
+
+    def test_disk_space_suffix_empty_when_free_space_unavailable(self) -> None:
+        with patch("app.features.recording.service._free_disk_bytes", return_value=None):
+            assert _disk_space_suffix(Path("/data/output")) == ""
+
+
+class TestDiskFullErrors:
+    """Tests for surfacing disk-full failures with explicit messages (issue #72)."""
+
+    def test_start_rejected_when_disk_has_no_free_space(
+        self, recorder: ROS2BagRecorder, mock_ros2: MagicMock
+    ) -> None:
+        """start() on a hard-full output volume fails before launching the recorder."""
+        with (
+            patch("app.features.recording.service._free_disk_bytes", return_value=0),
+            pytest.raises(RecorderError, match="Disk full: no free disk space left"),
+        ):
+            recorder.start(topics=["/topic"])
+        mock_ros2.bag_record.assert_not_called()
+
+    def test_start_allowed_when_free_space_unknown(self, recorder: ROS2BagRecorder) -> None:
+        """An uninspectable output volume does not block recording."""
+        with patch("app.features.recording.service._free_disk_bytes", return_value=None):
+            recorder.start(topics=["/topic"])
+        assert recorder.is_recording is True
+
+    def test_start_mkdir_enospc_names_disk_full(self, recorder: ROS2BagRecorder) -> None:
+        """An ENOSPC while creating the output directory is reported as a full disk."""
+        err = OSError(errno.ENOSPC, "No space left on device")
+        with (
+            patch.object(Path, "mkdir", side_effect=err),
+            pytest.raises(RecorderError, match="Disk full: cannot create the output directory"),
+        ):
+            recorder.start(topics=["/topic"])
+
+    def test_start_raises_when_recorder_dies_during_startup(
+        self, recorder: ROS2BagRecorder, mock_ros2: MagicMock
+    ) -> None:
+        """A recorder process that dies before start() returns raises RecorderError."""
+        mock_record = mock_ros2.bag_record.return_value
+        mock_record.process.poll.return_value = 1
+        with pytest.raises(RecorderError, match=r"exited during startup \(exit code=1\)"):
+            recorder.start(topics=["/topic"])
+        assert recorder.is_recording is False
+        mock_record.cleanup.assert_called_once()
+
+    def test_startup_death_message_includes_free_space(
+        self, recorder: ROS2BagRecorder, mock_ros2: MagicMock
+    ) -> None:
+        """The startup-death message names the free space of the output volume.
+
+        Free space is small but non-zero (e.g. exhausted inodes), so the
+        hard-full pre-check passes and the death is detected after launch.
+        """
+        mock_ros2.bag_record.return_value.process.poll.return_value = 1
+        with (
+            patch("app.features.recording.service._free_disk_bytes", return_value=100_000_000),
+            pytest.raises(RecorderError, match=r"free disk space: 0\.1 GB"),
+        ):
+            recorder.start(topics=["/topic"])
+
+    def test_startup_death_cleans_up_qos_file(self, recorder: ROS2BagRecorder, mock_ros2: MagicMock) -> None:
+        """The QoS file is cleaned up when the recorder dies during startup."""
+        mock_ros2.bag_record.return_value.process.poll.return_value = 1
+        with pytest.raises(RecorderError):
+            recorder.start(topics=["/topic"], qos_overrides={"/topic": "reliable"})
+        assert recorder._qos_file is None
+
+    def test_meta_write_enospc_notifies_operator(self, recorder: ROS2BagRecorder) -> None:
+        """An ENOSPC while writing recording_meta.json produces a danger log entry naming the disk."""
+        err = OSError(errno.ENOSPC, "No space left on device")
+        with (
+            patch("app.features.recording.service.write_recording_meta", side_effect=err),
+            patch.object(ROS2BagRecorder, "_notify_log") as notify,
+        ):
+            recorder.start(topics=["/topic"])
+        severity, message = notify.call_args.args
+        assert severity == "danger"
+        assert "Disk full" in message
+        assert recorder.is_recording is True
+
+    def test_meta_write_generic_failure_notifies_operator(self, recorder: ROS2BagRecorder) -> None:
+        """Non-ENOSPC meta-write failures also produce a danger log entry."""
+        with patch.object(ROS2BagRecorder, "_notify_log") as notify:
+            # conftest's mock bag_record does not create the recording dir, so the
+            # write fails with FileNotFoundError.
+            recorder.start(topics=["/topic"])
+        severity, message = notify.call_args.args
+        assert severity == "danger"
+        assert "Failed to write recording_meta.json" in message
+
+    def test_crash_notification_includes_free_space(self, recorder: ROS2BagRecorder, mock_ros2: MagicMock) -> None:
+        """A mid-recording crash notification names the free space of the output volume."""
+        recorder.start(topics=["/topic"])
+        mock_ros2.bag_record.return_value.process.poll.return_value = 1
+        with (
+            patch("app.features.recording.service._free_disk_bytes", return_value=0),
+            patch.object(ROS2BagRecorder, "_notify_log") as notify,
+        ):
+            recorder.get_status()
+        severity, message = notify.call_args.args
+        assert severity == "danger"
+        assert "exited abnormally (exit code=1)" in message
+        assert "free disk space: 0.0 GB" in message
 
 
 class TestDetectCrash:

--- a/backend/tests/infra/mcap/test_reader.py
+++ b/backend/tests/infra/mcap/test_reader.py
@@ -1,0 +1,25 @@
+"""Tests for the MCAP reader's user-facing error translation."""
+
+from pathlib import Path
+
+from mcap.exceptions import McapError
+
+from app.infra.mcap import CorruptedMCAPError
+
+
+class TestCorruptedMCAPError:
+    """Tests for CorruptedMCAPError.from_cause()."""
+
+    def test_names_file_cause_and_typical_reasons(self) -> None:
+        cause = McapError("unknown (opcode 173) record has length 999 that exceeds limit")
+        err = CorruptedMCAPError.from_cause(Path("/data/output/rec/rec_0.mcap"), cause)
+        message = str(err)
+        assert "rec_0.mcap" in message
+        assert "exceeds limit" in message
+        assert "truncated or corrupted" in message
+        assert "recording was cut short" in message
+        assert "disk filled up" in message
+
+    def test_falls_back_to_class_name_for_empty_cause(self) -> None:
+        err = CorruptedMCAPError.from_cause(Path("rec_0.mcap"), McapError())
+        assert "McapError" in str(err)


### PR DESCRIPTION
## Summary

Addresses the error-surfacing half (proposal A) of #72. Disk-full failures previously reached the operator in opaque forms; each path now produces a message that names the problem:

| Failure path | Before | After |
|---|---|---|
| START REC on a hard-full disk (0 bytes free) | `200 OK` — the recorder survives (0-byte file creation still succeeds) and silently records nothing | 500 in ~10 ms: `Disk full: no free disk space left at /data/output. Free up space before starting a recording.` |
| Recorder dies during startup (file creation fails, e.g. inodes exhausted) | Bare `Internal Server Error` after the full 10 s discovery timeout (router `assert start_time` → `AssertionError`) | 500 in ~0.4 s: `Recorder process exited during startup (exit code=1); no recording was started — free disk space: 0.1 GB at /data/output. A full disk is the most common cause; check the backend logs for details.` |
| Disk fills mid-recording → truncated MCAP | Quality job fails with `unknown (opcode 173) record has length … exceeds limit …` — or with an **empty** message for a 0-byte file (`EndOfFile`) | `MCAP file is unreadable (truncated or corrupted): <file> — <detail>. This usually means the recording was cut short — e.g. the disk filled up, the machine lost power, or the recorder was forcibly killed.` |

The response `detail` reaches the UI toast verbatim through the existing `RecorderError` → 500 path, so no frontend changes are needed.

## Changes

- **Hard-full guard**: `start()` rejects the output volume when it has literally no free space. This is deliberately threshold-free; a configurable `recording_min_free_gb` is planned as a follow-up.
- **Startup-death detection**: `start()` polls the recorder after the discovery wait and raises a `RecorderError` (with exit code + free space) instead of returning success; the router's `assert start_time is not None` is replaced with an explicit error for the residual race. `RecordProcess.wait_for_subscriptions()` also aborts as soon as the process dies instead of burning the full timeout.
- **`CorruptedMCAPError`** in `app/infra/mcap`: MCAP parse errors (`McapError`) are translated at the reader boundary — both mid-file parse errors during iteration and `EndOfFile` from `make_reader` on a 0-byte file (whose message is empty). All MCAP consumers (quality, media, timeline, LeRobot export) benefit.
- **ENOSPC call-outs**: creating the output directory and writing `recording_meta.json` name the full disk explicitly; meta-write failures are now posted as a `danger` entry to the operator-visible log panel instead of a log-only warning.
- **Crash notifications** (`_detect_crash`) include the output volume's current free space.
- **Catch-all exception handler**: unexpected exceptions return `Unexpected server error (<type>: <message>) — check the backend logs for details.` instead of a bare `Internal Server Error`.

Note on the reported trace: the field 500 was hypothesized in #72 as `resume()` failing on a dead pty, but reproduction showed `os.write` to a dead pty succeeds; the actual trace was the router's `assert start_time is not None` after `_detect_crash()` reset the state. That assertion path is what this PR removes.

## Verification

Reproduced and verified live by replacing the backend's `/data/output` bind mount with a small tmpfs (compose override, not committed):

```yaml
services:
  backend:
    volumes: !override
      - ./backend/app:/app/app
      - ./backend/tests:/app/tests
      - ./config:/app/config:ro
      - ./backend/pyproject.toml:/app/pyproject.toml:ro
    tmpfs:
      - /data/output:size=32m,nr_inodes=32
```

Note for reproducing: remove the backend container first (`docker rm -f open-lutra-backend`) before `up` with the override — Compose does not apply volume changes when recreating an existing container.

1. Fill the volume (`dd if=/dev/zero of=/data/output/_filler bs=1M count=32`) → START REC returns the hard-full message in ~10 ms; toast shows it.
2. Exhaust inodes only (`touch /data/output/_inode_{1..32}`; bytes free, but file creation fails) → START REC returns the startup-death message in ~0.4 s.
3. Free the fillers, record until the tmpfs fills, stop → quality job fails with the truncated-MCAP message in the jobs panel (also verified with a 0-byte MCAP, which previously failed with an empty error message).

- `make test-cov-backend`: 818 passed, coverage 100%
- `make lint-backend`: ruff + mypy clean

Refs #72 — the configurable free-space threshold (`recording_min_free_gb`) and the early-warning half (proposal B: `GET /api/system/disk` + operator-visible low-disk warning) are intentionally left for follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
