### PR TITLE
fix(prod): start the production stack without network access

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Attach fixed attributes — operator ID, target object, and so on — to each re
 | [docs/SETUP.md](docs/SETUP.md) | Setup guide (prerequisites, dev, prod, env vars) |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Architecture (system, data flow, Docker) |
 | [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) | Development guide (style, branching, tests) |
+| [backend/README.md](backend/README.md) | Backend container layout (what a restart picks up, what needs a rebuild) |
+| [frontend/README.md](frontend/README.md) | Frontend container layout (what a restart picks up, what needs a rebuild) |
 | [docs/domain/](docs/domain/index.md) | Domain notes (ROS2, MCAP, LeRobot, quality analysis) |
 | [examples/](examples/) | Reference snippets (e.g. plugging in custom ROS2 message types) |
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,60 @@
+# Backend
+
+FastAPI + ROS 2 service for OpenLUTRA.
+
+- Directory layout: [docs/STRUCTURE.md](../docs/STRUCTURE.md)
+- Feature boundaries and data flow: [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md)
+- Test layout, lint and coverage commands: [docs/DEVELOPMENT.md](../docs/DEVELOPMENT.md)
+
+This file covers only how the container is put together, and which edits are picked up by a restart versus a rebuild.
+
+## Container layout
+
+The repository-root `Dockerfile` builds `open-lutra-backend:latest`, shared by the development and the production stack. Unlike the frontend image, it does contain the application code, the config directory, and a resolved virtualenv:
+
+```console
+$ docker run --rm --entrypoint sh open-lutra-backend:latest -c "ls -a /app"
+.env  .venv  app  config  pyproject.toml  uv.lock
+```
+
+Compose then mounts the working tree over most of that, in development and production alike:
+
+| Host | Container | Mode |
+|---|---|---|
+| `backend/app/` | `/app/app` | rw |
+| `backend/tests/` | `/app/tests` | rw |
+| `config/` | `/app/config` | ro |
+| `backend/pyproject.toml` | `/app/pyproject.toml` | ro |
+
+So the running server reads the working tree, not the code baked into the image. `uv.lock` and `.venv` are **not** mounted — they stay at their build-time state, which is why dependency changes need a rebuild.
+
+### The container ignores `command:`
+
+The image declares `ENTRYPOINT ["/entrypoint.sh"]`, and the script ends with its own `exec uv run --offline uvicorn app.main:app ...` without passing `"$@"` through. The `command:` in `docker-compose.yml` is therefore handed to the entrypoint as arguments and dropped — including its `--reload --reload-dir` flags:
+
+```console
+$ docker exec open-lutra-backend ps -eo args | grep uvicorn
+uv run --offline uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+Editing `backend/app/` updates the files inside the container immediately, but uvicorn runs without autoreload in both stacks, so the server keeps serving the code it imported at start-up until it is restarted.
+
+`uv run --offline` is what keeps start-up working with no network access; the entrypoint also resolves `ROS_DOMAIN_ID` from `RECORDING_CONFIG` before launching.
+
+## What lands where
+
+| You change | Development (`make up`) | Production (`make prod-up`) |
+|---|---|---|
+| `backend/app/**` | Restart the container (`docker compose restart backend`) — the mount is live, but uvicorn has no autoreload | `make prod-restart` |
+| `backend/tests/**` | Nothing to do — `make test-backend` runs pytest inside the running container against the mount | Not applicable |
+| `config/*.yaml` | Restart the container — the YAML is read once and cached (`app/settings.py`), and `ROS_DOMAIN_ID` is resolved at start-up | `make prod-restart` |
+| `.env` and other environment variables | Recreate the container (`make restart`); a plain `docker compose restart` reuses the environment the container was created with | `make prod-restart` |
+| Dependencies in `pyproject.toml` | `make build`, then `make restart` — `uv.lock` and `.venv` live in the image, and `uv run --offline` cannot fetch new packages | `make build`, then `make prod-restart` |
+| apt / ROS 2 packages in `Dockerfile` | `make build`, then `make restart` | `make build`, then `make prod-restart` |
+
+Carrying an updated image to a site without network access:
+
+```bash
+docker save open-lutra-backend:latest | gzip > backend.tar.gz   # online
+docker load < backend.tar.gz                                    # on site
+```

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,26 +6,15 @@
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
-#
-# Production starts from pre-built images so it works without network access.
-# `image:` is pinned on every service that has a `build:` because Compose
-# otherwise derives the tag from the project name (i.e. the directory name);
-# a renamed directory or an image tagged differently by `docker save` would
-# read as "image missing" and trigger a build.
-
 services:
   backend:
-    image: open-lutra-backend:latest
     network_mode: host
     environment:
       DEBUG: "false"
 
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
-    image: open-lutra-frontend:latest
-    # pnpm and node_modules ship inside the image, so this only starts Vite.
+    # node_modules ships inside the image, so drop the install the base file
+    # runs at start and launch Vite directly — production needs no network.
     command: pnpm run dev
     extra_hosts:
       - "backend:host-gateway"  # Host resolution for reaching the backend container on the host network

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,13 +6,26 @@
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
+#
+# Production starts from pre-built images so it works without network access.
+# `image:` is pinned on every service that has a `build:` because Compose
+# otherwise derives the tag from the project name (i.e. the directory name);
+# a renamed directory or an image tagged differently by `docker save` would
+# read as "image missing" and trigger a build.
+
 services:
   backend:
+    image: open-lutra-backend:latest
     network_mode: host
     environment:
       DEBUG: "false"
 
   frontend:
-    command: bash -c "corepack enable && { [ -d node_modules/.vite ] || pnpm install --frozen-lockfile; }; pnpm run dev"
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    image: open-lutra-frontend:latest
+    # pnpm and node_modules ship inside the image, so this only starts Vite.
+    command: pnpm run dev
     extra_hosts:
       - "backend:host-gateway"  # Host resolution for reaching the backend container on the host network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@
 #
 # Production:
 #   make prod-up  - Start production (host network)
+#
+# Every service with a `build:` also pins an `image:` tag. Compose otherwise
+# derives the tag from the project name (i.e. the directory name), so a renamed
+# directory — or an image tagged differently by `docker save` — reads as
+# "image missing" and triggers a build, which fails without network access.
 
 services:
   # --- Robot Simulator (development only) ---
@@ -15,6 +20,7 @@ services:
     build:
       context: ./simulator
       dockerfile: Dockerfile
+    image: open-lutra-simulator:latest
     container_name: ros2-publisher-simulator
     environment:
       - RECORDING_CONFIG=/app/config/simulator.yaml
@@ -41,6 +47,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    image: open-lutra-backend:latest
     container_name: open-lutra-backend
     # Forward .env into the container so optional features can read their
     # settings without each variable needing an explicit `environment:` entry.
@@ -69,10 +76,15 @@ services:
 
   # --- Frontend: Vite dev server ---
   frontend:
-    image: node:22-slim
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    image: open-lutra-frontend:latest
     container_name: open-lutra-frontend
     working_dir: /app
-    command: bash -c "corepack enable && pnpm install --frozen-lockfile && pnpm run dev"
+    # pnpm ships inside the image; the install re-runs on every start so that
+    # dependency changes land without rebuilding the image.
+    command: bash -c "pnpm install --frozen-lockfile && pnpm run dev"
     environment:
       - API_URL=http://backend:8000
       - VITE_DEV_MODE=${VITE_DEV_MODE:-false}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -379,6 +379,7 @@ ignore_missing_imports = true
 
 ### Updating Docker Image Dependencies
 
-1. Python: edit `pyproject.toml` → `make build` to rebuild the image
-2. Node.js: edit `frontend/package.json` → `make build` to rebuild the image
-3. ROS2 packages: edit `apt-get install` in the `Dockerfile` → `make build`
+Which edits are picked up by a restart and which need `make build` differs per component, and differs again between the development and the production stack. See the "What lands where" table in each component's README:
+
+- [backend/README.md](../backend/README.md#what-lands-where) — Python dependencies, ROS 2 / apt packages, config YAML
+- [frontend/README.md](../frontend/README.md#what-lands-where) — Node.js dependencies, the pnpm version, Vite config

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,26 @@
+# Frontend image for the production stack (Vite dev server).
+#
+# The point of this image is to make `make prod-up` work on a site with no
+# internet access: pnpm itself and every dependency are baked in at build time,
+# so starting a container never reaches out to the network.
+
+FROM node:22-slim
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# `corepack install` resolves the version from package.json's `packageManager`
+# field, so the pnpm version is not duplicated here. This caches the pnpm
+# binary inside the image; without it corepack downloads pnpm from
+# registry.npmjs.org on every container start.
+RUN corepack enable && corepack install
+
+RUN pnpm install --frozen-lockfile
+
+# The source tree is bind-mounted at /app by compose, so it is deliberately not
+# copied into the image. The named volume mounted at /app/node_modules is
+# initialized from the image's contents while it is still empty, which is what
+# removes the need for an install at container start.
+
+CMD ["pnpm", "run", "dev"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,60 @@
+# Frontend
+
+React + Vite UI for OpenLUTRA.
+
+- Directory layout: [docs/STRUCTURE.md](../docs/STRUCTURE.md)
+- Feature pattern, lint/test commands, UI conventions: [docs/DEVELOPMENT.md](../docs/DEVELOPMENT.md)
+
+This file covers only how the container is put together, and which edits are picked up by a restart versus a rebuild.
+
+## Container layout
+
+`frontend/Dockerfile` builds `open-lutra-frontend:latest`, shared by the development and the production stack. The image carries pnpm (installed through corepack) and a fully populated `/app/node_modules`; the source tree is deliberately not copied:
+
+```console
+$ docker run --rm --entrypoint sh open-lutra-frontend:latest -c "ls /app"
+node_modules  package.json  pnpm-lock.yaml  pnpm-workspace.yaml
+```
+
+Compose supplies the source instead, as a bind mount of `./frontend` onto `/app`, with the named volume `frontend_node_modules` layered back on top of `/app/node_modules`. Both stacks mount it, so the running server always reads the working tree rather than anything baked into the image.
+
+Both stacks also run the Vite dev server. Production keeps it because `VITE_API_BASE` depends on the site's hostname and is passed as runtime env; a static build would have to be rebuilt per site.
+
+The start-up command is the one real difference:
+
+| Stack | Command |
+|---|---|
+| Development (`make up`) | `pnpm install --frozen-lockfile && pnpm run dev` |
+| Production (`make prod-up`) | `pnpm run dev` |
+
+Development reinstalls on every start so dependency changes land without an image rebuild. Production skips the install because everything already ships inside the image — that is what lets `make prod-up` succeed on a site with no internet access.
+
+## What lands where
+
+| You change | Development (`make up`) | Production (`make prod-up`) |
+|---|---|---|
+| `src/**`, `index.html`, `public/**` | Applied immediately (Vite HMR) | Applied immediately (Vite HMR) |
+| `vite.config.ts`, `tsconfig.json`, `orval.config.ts` | Restart the container (`make restart`) | `make prod-restart` |
+| `VITE_DEV_MODE`, `VITE_API_BASE` and other environment variables | Recreate the container (`make restart` / `make dev-up`); a plain `docker compose restart` reuses the environment the container was created with | `make prod-restart` |
+| Dependencies in `package.json` / `pnpm-lock.yaml` | Restart the container — the start-up install reconciles the volume with the lockfile (needs network) | `make build`, then drop the stale volume (below) |
+| `packageManager` (pnpm version) in `package.json` | Restart the container — corepack fetches the new pnpm (needs network) | `make build`; otherwise corepack tries to fetch pnpm at start and fails without network |
+| `frontend/Dockerfile` | `make build`, then `make restart` | `make build`, then `make prod-restart` |
+
+## Refreshing node_modules in production
+
+A named volume is initialized from the image only while it is still empty, so an existing `frontend_node_modules` keeps serving the previous dependencies even after the image is rebuilt. Drop it explicitly:
+
+```bash
+make prod-down
+docker volume rm <compose project>_frontend_node_modules
+make prod-up
+```
+
+Development needs none of this: its start-up `pnpm install --frozen-lockfile` reconciles the volume with the lockfile on every start.
+
+Carrying an updated image to a site without network access:
+
+```bash
+docker save open-lutra-frontend:latest | gzip > frontend.tar.gz   # online
+docker load < frontend.tar.gz                                     # on site
+```


### PR DESCRIPTION
## Problem

`make prod-up` fails on a site with no internet access, even when all images are already present.

The `frontend` service ran the stock `node:22-slim` image and did its install at container start. `node:22-slim` does not ship pnpm — corepack reads `packageManager: "pnpm@11.0.9"` from `package.json` and fetches it from `registry.npmjs.org`. The prod override skipped `pnpm install` when `node_modules/.vite` existed, but `pnpm run dev` itself goes through the corepack shim, so there was no way around the fetch:

```
Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-11.0.9.tgz
    at async Engine.ensurePackageManager (corepack.cjs)
```

Reproduced on this branch's base with `docker run --rm --network none -v "$PWD/frontend:/app" node:22-slim bash -c "corepack enable && pnpm run dev"`.

Corepack's cache (`/root/.cache/node/corepack`) and the pnpm store lived in the container's writable layer, not in a volume — the only volume is `frontend_node_modules` at `/app/node_modules`. `compose down` deletes the container, so the cache was gone on the next `prod-up` and the network fetch always happened. `stop`/`start` alone works, which is why the symptom looked intermittent.

Secondarily, an image tag for a service with `build:` defaults to `<project name (= directory name)>-<service>`. If the directory is renamed on delivery, or a `docker save`d image carries a different tag, Compose sees no image and starts a build — which then fails on `apt-get` / `astral.sh`.

The backend already started offline: its entrypoint uses `uv run --offline`, and since the script does not reference `"$@"`, the compose `command:` is ignored. Confirmed with `--network none`.

## Fix

Align on "build once online, then just start the existing images".

**New `frontend/Dockerfile`** — single stage for the Vite dev server. `corepack install` reads the version from `package.json`'s `packageManager` field (no duplicated version) and caches the pnpm binary in the image; `pnpm install --frozen-lockfile` bakes in the dependencies. Source is not copied — compose bind-mounts `./frontend:/app`, and the named `/app/node_modules` volume initializes from the image while empty, so no install is needed at container start.

**`docker-compose.yml`** — the frontend is now built here rather than in the overlay, so the build definition lives in one place and the base file describes the real image. Every service with a `build:` pins an `image:` tag, with the reason recorded once at the top of the file. Development keeps its install-at-start (`pnpm install --frozen-lockfile && pnpm run dev`, minus the now-unnecessary `corepack enable`) so dependency changes still land without an image rebuild.

**`docker-compose.prod.yml`** — reduced to production-only differences: `network_mode: host`, `DEBUG: "false"`, `extra_hosts`, and `command: pnpm run dev`, which drops the base file's install because everything already ships in the image.

Out of scope, deliberately: no `prod-build` Make target (`make build` and `make prod-pull` both build the image now, and the first online `make prod-up` auto-builds missing images), no doc updates, and no move to nginx static serving (`VITE_API_BASE` / `VITE_DEV_MODE` are passed as runtime env; `VITE_API_BASE` depends on the site's IP/hostname, so a build-arg design would require a per-site rebuild).

## Verification

- `docker compose build` (base only, i.e. what `make build` runs) — builds `open-lutra-frontend:latest`; the prod overlay build passes too.
- Image sizes: `open-lutra-frontend:latest` 629MB, `open-lutra-backend:latest` 1.39GB.
- Merged configs resolve as intended: dev → `bash -c "pnpm install --frozen-lockfile && pnpm run dev"`, prod → `pnpm run dev`.
- Frontend offline with the production command, through the empty-volume init path:
  ```
  docker volume create offline-test-nm
  docker run --rm --network none -v "$PWD/frontend:/app" -v offline-test-nm:/app/node_modules \
    open-lutra-frontend:latest pnpm run dev
  ```
  → `VITE v8.0.14 ready in 512 ms` / `Local: http://localhost:5173/`. The volume was populated from the image (28 entries, 427MB).
- Frontend with the development command on a fresh volume → `Already up to date / Done in 226ms`, then Vite starts; the install is a no-op because the volume comes from the image.
- Backend offline: `docker run --network none open-lutra-backend:latest` → `Uvicorn running on http://0.0.0.0:8000`.
- Test containers and volumes removed afterwards.

## Operational notes

- **Build the images online first** — `make build`, `make prod-up`, or `make prod-pull` all produce them.
- **Carrying to a site:** `docker save open-lutra-backend:latest open-lutra-frontend:latest` → `docker load`.
- **After updating dependencies and rebuilding**, run `docker volume rm <project>_frontend_node_modules` **for production**. A volume is initialized from the image only while empty, so a stale `node_modules` would otherwise persist. Development is unaffected: its install-at-start reconciles the volume with the lockfile.
- **Disk cost:** `node_modules` now exists both in the image layer and in the volume, roughly +370MB (measured against the current volume at 366.8MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)