### PR TITLE
docs: fix the .env quickstart comment and unify "recording config" wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ make up      # start dev environment (simulator + backend + frontend)
 ### Production (Ubuntu + real robot)
 
 ```bash
-cp .env.example .env   # set ROS_DOMAIN_ID to match your robot
+cp .env.example .env   # set RECORDING_CONFIG and OUTPUT_DIR; ROS_DOMAIN_ID lives in the YAML that RECORDING_CONFIG selects
 make prod-up           # production start (network_mode: host)
 ```
 

--- a/backend/app/features/jobs/models.py
+++ b/backend/app/features/jobs/models.py
@@ -130,7 +130,7 @@ class LeRobotExportJob(Job):
             `_active_folders` release logic in JobQueue works unchanged).
         source_paths: Recording directories, each exported as one episode.
 
-    The mapping comes from the active robot config's `lerobot_export` section,
+    The mapping comes from the active recording config's `lerobot_export` section,
     read when the job runs.
     """
 

--- a/backend/app/features/jobs/service.py
+++ b/backend/app/features/jobs/service.py
@@ -705,7 +705,7 @@ def _run_export_dataset(  # pragma: no cover
 ) -> None:
     """Thin wrapper around `run_export()` for `asyncio.to_thread`.
 
-    The mapping is read from the active robot config's `lerobot_export` section.
+    The mapping is read from the active recording config's `lerobot_export` section.
     """
     from app.features.lerobot_export import load_active_config, run_export
 

--- a/backend/app/features/lerobot_export/schemas.py
+++ b/backend/app/features/lerobot_export/schemas.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 class LeRobotConfigResponse(BaseModel):
     """The active robot's LeRobot export mapping summary (for the export dialog)."""
 
-    configured: bool = Field(..., description="Whether the active robot config declares a lerobot_export mapping")
+    configured: bool = Field(..., description="Whether the active recording config declares a lerobot_export mapping")
     robot_type: str | None = Field(..., description="Robot type from the mapping (null when not configured)")
     cameras: list[str] = Field(..., description="Camera names produced by the mapping (empty when not configured)")
 

--- a/backend/tests/features/lerobot_export/test_config_loader.py
+++ b/backend/tests/features/lerobot_export/test_config_loader.py
@@ -1,4 +1,4 @@
-"""Tests for loading the LeRobot mapping from the active robot config."""
+"""Tests for loading the LeRobot mapping from the active recording config."""
 
 import pytest
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -59,7 +59,7 @@ Use `RECORDING_CONFIG` in `.env` to select a recording configuration. The topic 
 ```bash
 # .env
 RECORDING_CONFIG=config/simulator.yaml   # Required: use the bundled simulator config
-# RECORDING_CONFIG=config/myrobot.yaml   # Your own physical-robot config (copy simulator.yaml as a template)
+# RECORDING_CONFIG=config/myrobot.yaml   # Your own physical-robot recording config (copy simulator.yaml as a template)
 ```
 
 ### 4. Start the Development Environment
@@ -141,7 +141,7 @@ Runs the Python (ruff) and TypeScript (biome) code formatters.
 ```bash
 # 1. Configure environment variables
 cp .env.example .env
-# Edit .env: set RECORDING_CONFIG to your physical-robot config (copy config/simulator.yaml as a template)
+# Edit .env: set RECORDING_CONFIG to your physical-robot recording config (copy config/simulator.yaml as a template)
 
 # 2. (Optional) Add custom ROS2 message packages
 # If your robot publishes topics that use custom message types, follow
@@ -194,7 +194,7 @@ expected_hz_patterns:
 
 | Preset | File | Use Case |
 |---|---|---|
-| Simulator (default) | `config/simulator.yaml` | 4 cameras (30Hz) + 2 joint-data channels (100Hz); also serves as a template for physical-robot configs |
+| Simulator (default) | `config/simulator.yaml` | 4 cameras (30Hz) + 2 joint-data channels (100Hz); also serves as a template for physical-robot recording configs |
 
 #### YAML Configuration Items
 

--- a/frontend/src/features/lerobot-export/ui/export-dialog.tsx
+++ b/frontend/src/features/lerobot-export/ui/export-dialog.tsx
@@ -1,6 +1,6 @@
 /** Dialog for exporting selected recordings to a LeRobot v3.0 dataset.
  *
- * The topic→feature mapping comes from the active robot config's
+ * The topic→feature mapping comes from the active recording config's
  * `lerobot_export` section, so this dialog only needs an output name. After
  * submission it keeps showing the job's live progress / result (driven by the
  * jobs SSE cache) so there is visible feedback in normal mode too — the
@@ -25,7 +25,8 @@ function MappingInfo({ config, loading }: { config: LeRobotConfigResponse | unde
   if (!config?.configured) {
     return (
       <div className="text-sm text-muted-foreground">
-        No <code>lerobot_export</code> mapping in the active robot config. Add one to the robot's YAML to enable export.
+        No <code>lerobot_export</code> mapping in the active recording config. Add one to the recording config YAML to
+        enable export.
       </div>
     );
   }


### PR DESCRIPTION
Two wording-only documentation fixes around the `.env` / `config/*.yaml` split. No behavior changes, no identifier renames, no config key changes.

## 1. README quickstart pointed at a `.env` key that does not exist

The production quickstart said:

```bash
cp .env.example .env   # set ROS_DOMAIN_ID to match your robot
```

`.env.example` has no `ROS_DOMAIN_ID` key. The domain ID is a key in the recording config YAML (`ros_domain_id` in `config/*.yaml`), which the README itself states a few lines above in the feature list. Following the quickstart as written leaves the domain ID unset.

The comment now points at what `.env` actually needs (`RECORDING_CONFIG`, `OUTPUT_DIR`) and notes that the domain ID lives in the YAML that `RECORDING_CONFIG` selects. Details stay in [docs/SETUP.md](docs/SETUP.md), which the quickstart already links to. The other `ROS_DOMAIN_ID` mention in the README (the feature list) was already correct and is unchanged.

## 2. The recording config YAML had two names

The same file was called both "recording config" and "robot config". Standardized on **"recording config"** — it matches the environment variable (`RECORDING_CONFIG`), the settings model (`RecordingConfig` in `backend/app/settings.py`), the loader, and the majority of existing occurrences.

Updated:

- `backend/app/features/lerobot_export/schemas.py` — `configured` field description (OpenAPI description)
- `backend/app/features/jobs/models.py`, `backend/app/features/jobs/service.py` — docstrings
- `backend/tests/features/lerobot_export/test_config_loader.py` — module docstring
- `frontend/src/features/lerobot-export/ui/export-dialog.tsx` — file header comment and the user-visible empty-state copy (including "the robot's YAML" → "the recording config YAML")
- `docs/SETUP.md` — "physical-robot config(s)" → "physical-robot recording config(s)", so the term is unambiguous in all three spots

### Not regenerated: `frontend/src/api/generated/`

The `configured` field description change needs `make generate` to propagate to `frontend/src/api/generated/schemas/leRobotConfigResponse.ts`. That could not be run here: the `open-lutra-backend` container is crash-looping on a pre-existing dependency failure (`fastlabel[robotics]==0.22.0` unresolvable), so `http://localhost:8000/openapi.json` is unreachable and orval has no input. The generated file was deliberately **not** hand-edited, so it still carries the old wording and is the only remaining `grep -rn "robot config"` hit. Run `make generate` with a working backend before merging.

## Verification

- `grep -rn "robot config" . --exclude-dir=node_modules --exclude-dir=.git` → only `frontend/src/api/generated/schemas/leRobotConfigResponse.ts` (see above)
- `make lint` — passes (ruff, mypy 107 files, tsc, biome 160 files)
- `make lint-frontend` / `make test-frontend` — 33 files, 287 tests passed
- Backend tests: 793 passed, 4 skipped. Run on the host via `uv run pytest tests/` rather than `make test-backend`, since the backend container cannot start (same pre-existing dependency failure). The 4 skips are the usual rclpy `importorskip` ones. No test asserts any of the changed strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)