### PR TITLE
fix(simulator): route fault-mode logs through per-severity call sites

### DIFF
--- a/simulator/robot_simulator.py
+++ b/simulator/robot_simulator.py
@@ -92,10 +92,7 @@ class RobotSimulator(Node):
         self._joint_tick = 0  # tick count of the 100Hz timer
 
         # Fault injection
-        self._fault = FaultInjector(
-            SIM_MODE,
-            log=lambda level, msg: getattr(self.get_logger(), level)(msg),
-        )
+        self._fault = FaultInjector(SIM_MODE, log=self._log_fault)
 
         # Camera frames (per topic)
         self._camera_frames = _load_camera_frames()
@@ -131,6 +128,18 @@ class RobotSimulator(Node):
             self.create_timer(1.0 / CAMERA_HZ, self._publish_cameras)
 
         self._fault.log_config()
+
+    def _log_fault(self, level: str, msg: str) -> None:
+        """Emit a fault-mode log line, one call site per severity.
+
+        rclpy caches a severity per logging call site and raises when the same
+        site is reused at a different level, so a single dispatch expression
+        cannot serve both info and warn.
+        """
+        if level == "warn":
+            self.get_logger().warn(msg)
+        else:
+            self.get_logger().info(msg)
 
     def _make_header(self, frame_id: str) -> Header:
         header = Header()


### PR DESCRIPTION
## Problem

`SIM_MODE=topic_stop` and `SIM_MODE=mixed` crashed the simulator the moment the fault fired:

```
File ".../rclpy/impl/rcutils_logger.py", line 299, in log
    raise ValueError('Logger severity cannot be changed between calls.')
```

Because the compose service uses `restart: unless-stopped`, the container restarted within seconds, the fault timer reset, and publishing resumed as normal — so the fault state was never observable. 2 of the 6 documented simulation modes were effectively broken.

## Cause

All `FaultInjector` logging went through a single-line lambda in `RobotSimulator.__init__`:

```python
log=lambda level, msg: getattr(self.get_logger(), level)(msg),
```

rclpy's `RcutilsLogger` caches one severity per logging **call site** (file/function/line) and raises `ValueError` when the same site is reused at a different level. `fault_modes.py` mixes severities on this path — `log_config()` registers the site as *info* at startup, and the *warn* emitted when the stop fires (`fault_modes.py:84` for `topic_stop`, `:97` for `mixed`) is then rejected.

## Fix

Replace the lambda with a private `_log_fault` method that branches on severity, giving info and warn distinct call sites. `FaultInjector` is unchanged — the injection logic itself was correct; only the log path was broken.

## Manual verification (simulator/ has no test coverage requirement)

Rebuilt the image and ran each failing mode via `docker compose --profile sim up -d --force-recreate simulator`:

**`SIM_MODE=topic_stop SIM_STOP_AFTER_SEC=25 SIM_STOP_TOPICS=/sim/slave_arm_left`**
- The stop warning is emitted exactly once (`grep -c 'stopped publishing'` → 1):
  ```
  [WARN] [robot_simulator]: [topic_stop] stopped publishing /sim/slave_arm_left
  ```
- `docker inspect ros2-publisher-simulator --format '{{.RestartCount}}'` stays **0**, container keeps running (previously it crash-looped).
- Selective stop confirmed with `ros2 topic hz` inside the container: `/sim/master_arm_left` keeps publishing (~76 Hz measured via the CLI; nominal 100 Hz), `/sim/slave_arm_left` produces no messages.

**`SIM_MODE=mixed SIM_STOP_AFTER_SEC=5`** (the harsher case — warn and info alternate on the same path)
```
[INFO] [robot_simulator]: [mixed] publishing of /sim/slave_arm_left recovered
[WARN] [robot_simulator]: [mixed] stopped publishing /sim/slave_arm_left
```
No crash, `RestartCount` stays 0.

`make lint` passes.

## Follow-up (not in this PR)

`restart: unless-stopped` on the simulator service is what hid this crash. For a dev fault-injection container, `restart: "no"` (or `on-failure:0`) would surface failures instead of masking them — left for a separate PR since it changes dev-environment behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)