### PR TITLE
fix(lerobot-export): disable the toolbar button when no mapping is configured

### DIFF
--- a/frontend/src/features/lerobot-export/__tests__/bulk-export-button.test.tsx
+++ b/frontend/src/features/lerobot-export/__tests__/bulk-export-button.test.tsx
@@ -7,9 +7,10 @@ import { BulkExportButton } from "../ui/bulk-export-button";
 import { ExportDialog } from "../ui/export-dialog";
 
 // Mock the API layer so the test does not depend on generated hooks / network.
-const { mutateMock, jobMock } = vi.hoisted(() => ({
+const { mutateMock, jobMock, configMock } = vi.hoisted(() => ({
   mutateMock: vi.fn(),
   jobMock: vi.fn<() => unknown>(() => undefined),
+  configMock: vi.fn<() => unknown>(),
 }));
 
 vi.mock("@/api/generated/lerobot/lerobot", () => ({
@@ -17,10 +18,7 @@ vi.mock("@/api/generated/lerobot/lerobot", () => ({
 }));
 
 vi.mock("@/hooks/use-api", () => ({
-  useLeRobotConfig: () => ({
-    data: { configured: true, robot_type: "sim", cameras: ["cam"] },
-    isLoading: false,
-  }),
+  useLeRobotConfig: () => configMock(),
 }));
 
 // The dialog tracks the enqueued job via useJob; mock it (no QueryClient in this test).
@@ -36,6 +34,11 @@ beforeEach(() => {
   mutateMock.mockReset();
   jobMock.mockReset();
   jobMock.mockReturnValue(undefined);
+  configMock.mockReset();
+  configMock.mockReturnValue({
+    data: { configured: true, robot_type: "sim", cameras: ["cam"] },
+    isLoading: false,
+  });
 });
 
 afterEach(() => {
@@ -52,6 +55,26 @@ describe("BulkExportButton", () => {
     useRecordingsStore.setState({ checkedFolders: new Set(["rec1", "rec2"]) });
     renderButton();
     expect(screen.getByRole("button", { name: /Export to LeRobot/ })).toBeInTheDocument();
+  });
+
+  it("disables the button when the recording config has no lerobot_export mapping", () => {
+    configMock.mockReturnValue({
+      data: { configured: false, robot_type: null, cameras: [] },
+      isLoading: false,
+    });
+    useRecordingsStore.setState({ checkedFolders: new Set(["rec1"]) });
+    renderButton();
+    const button = screen.getByRole("button", { name: /Export to LeRobot/ });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(screen.queryByRole("heading", { name: "Export to LeRobot" })).not.toBeInTheDocument();
+  });
+
+  it("disables the button while the lerobot config is still loading", () => {
+    configMock.mockReturnValue({ data: undefined, isLoading: true });
+    useRecordingsStore.setState({ checkedFolders: new Set(["rec1"]) });
+    renderButton();
+    expect(screen.getByRole("button", { name: /Export to LeRobot/ })).toBeDisabled();
   });
 
   it("opens the export dialog with the output field", () => {

--- a/frontend/src/features/lerobot-export/ui/bulk-export-button.tsx
+++ b/frontend/src/features/lerobot-export/ui/bulk-export-button.tsx
@@ -1,33 +1,44 @@
-/** Toolbar button that exports the checked recordings to a LeRobot dataset. */
-
 import { Boxes } from "lucide-react";
 import { useState } from "react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useRecordingsStore } from "@/features/recordings";
+import { useLeRobotConfig } from "@/hooks/use-api";
 import { ExportDialog } from "./export-dialog";
 
 export function BulkExportButton() {
+  const { data: config } = useLeRobotConfig();
   const checkedFolders = useRecordingsStore((s) => s.checkedFolders);
   const clearChecked = useRecordingsStore((s) => s.clearChecked);
   const [open, setOpen] = useState(false);
 
   if (checkedFolders.size === 0) return null;
 
+  const configured = config?.configured ?? false;
+
+  const button = (
+    <button
+      type="button"
+      disabled={!configured}
+      onClick={() => setOpen(true)}
+      className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground/80 transition-colors enabled:hover:bg-accent disabled:pointer-events-none disabled:text-muted-foreground/40"
+    >
+      <Boxes size={13} />
+      Export to LeRobot
+    </button>
+  );
+
   return (
     <>
       <Tooltip>
         <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={() => setOpen(true)}
-            className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground/80 transition-colors hover:bg-accent"
-          >
-            <Boxes size={13} />
-            Export to LeRobot
-          </button>
+          {/* The disabled button has pointer-events:none, so wrap it in a span
+              that receives the hover the tooltip needs to open. */}
+          {configured ? button : <span className="cursor-not-allowed">{button}</span>}
         </TooltipTrigger>
         <TooltipContent side="bottom">
-          Export {checkedFolders.size} item{checkedFolders.size === 1 ? "" : "s"} to a LeRobot dataset
+          {configured
+            ? `Export ${checkedFolders.size} item${checkedFolders.size === 1 ? "" : "s"} to a LeRobot dataset`
+            : "No lerobot_export mapping in the active recording config"}
         </TooltipContent>
       </Tooltip>
       <ExportDialog folders={[...checkedFolders]} open={open} onOpenChange={setOpen} onExported={clearChecked} />

--- a/frontend/src/features/lerobot-export/ui/export-dialog.tsx
+++ b/frontend/src/features/lerobot-export/ui/export-dialog.tsx
@@ -20,16 +20,8 @@ import { useLeRobotConfig } from "@/hooks/use-api";
 import { useJob } from "@/hooks/use-jobs-stream";
 
 /** Active robot mapping summary shown above the output-name field. */
-function MappingInfo({ config, loading }: { config: LeRobotConfigResponse | undefined; loading: boolean }) {
-  if (loading) return <div className="text-sm text-muted-foreground">Loading…</div>;
-  if (!config?.configured) {
-    return (
-      <div className="text-sm text-muted-foreground">
-        No <code>lerobot_export</code> mapping in the active recording config. Add one to the recording config YAML to
-        enable export.
-      </div>
-    );
-  }
+function MappingInfo({ config }: { config: LeRobotConfigResponse | undefined }) {
+  if (!config?.configured) return null;
   return (
     <div className="text-sm text-muted-foreground">
       {config.robot_type} · cameras: {config.cameras.join(", ") || "(none)"}
@@ -92,7 +84,7 @@ export function ExportDialog({
   onExported: () => void;
 }) {
   // --- Server state ---
-  const { data: config, isLoading: configLoading } = useLeRobotConfig();
+  const { data: config } = useLeRobotConfig();
   const mutation = useStartLeRobotExport();
 
   // --- Local state (reset each time the dialog opens) ---
@@ -111,8 +103,8 @@ export function ExportDialog({
     }
   }, [open]);
 
-  const configured = config?.configured ?? false;
-  const canSubmit = configured && outputName.trim() !== "" && folders.length > 0 && !mutation.isPending;
+  const canSubmit =
+    (config?.configured ?? false) && outputName.trim() !== "" && folders.length > 0 && !mutation.isPending;
 
   const handleExport = () => {
     setSubmitError(null);
@@ -156,7 +148,7 @@ export function ExportDialog({
             <div className="space-y-4">
               <div className="space-y-1.5">
                 <Label>Mapping</Label>
-                <MappingInfo config={config} loading={configLoading} />
+                <MappingInfo config={config} />
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="lerobot-output">Output name</Label>
@@ -165,7 +157,6 @@ export function ExportDialog({
                   value={outputName}
                   onChange={(e) => setOutputName(e.target.value)}
                   placeholder="e.g. pick_and_place_v1"
-                  disabled={!configured}
                   autoFocus
                 />
                 <p className="text-[13px] text-muted-foreground">Written to _lerobot_exports/&lt;name&gt;/</p>


### PR DESCRIPTION
## Summary

- The "Export to LeRobot" toolbar button is now rendered **disabled** while the active recording config has no `lerobot_export` mapping (or while `GET /api/lerobot/config` is still loading), instead of opening a dialog that only then explains export is unavailable.
- The disabled button carries an explanatory tooltip ("No lerobot_export mapping in the active recording config"), following the existing `BulkUploadButton` pattern — including the span wrapper needed because a disabled button has `pointer-events: none` and would otherwise never open the Radix tooltip.
- `ExportDialog` drops the now-unreachable unconfigured branch: the mapping-info message and the `disabled` prop on the output-name input are removed. The `configured` guard in `canSubmit` stays as a defense in case the config changes while the dialog is open.

<img width="1398" height="308" alt="スクリーンショット 2026-08-24 12 52 18" src="https://github.com/user-attachments/assets/6e49ff7f-867d-4e29-b8e7-5c001eaf85c3" />


## Test plan

- [x] `make lint-frontend` (tsc + biome) passes
- [x] `pnpm exec vitest run` — 33 files / 289 tests pass
- [x] New tests: button is disabled (and the dialog cannot open) when `configured: false`, and while the config is still loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)