### PR TITLE
fix: stop browser tab memory growth on large DDS domains (~120 topics)

### DIFF
--- a/backend/app/features/topics/router.py
+++ b/backend/app/features/topics/router.py
@@ -16,6 +16,7 @@ from app.features.topics.schemas import (
     SubscriptionResponse,
     TopicsResponse,
 )
+from app.features.topics.stream import TopicStreamDiffer, build_topic_rows
 from app.shared.log_manager import get_log_manager
 
 logger = logging.getLogger(__name__)
@@ -169,34 +170,25 @@ async def topic_stream(request: Request, monitor: MonitorDep) -> StreamingRespon
     """SSE stream for real-time topic monitoring.
 
     Event types:
-      - topic_stats: topic statistics (1Hz)
+      - topic_stats: full topic-statistics snapshot (on connect + periodically)
+      - topic_stats_delta: rows changed/removed since the previous tick (1Hz)
       - log: new log entries (as they occur)
     """
     log_manager = get_log_manager()
 
     async def event_generator() -> AsyncGenerator[str, None]:
         last_log_id = 0
+        differ = TopicStreamDiffer()
 
         while True:
             if await request.is_disconnected():
                 break
 
-            # Send subscribed + discovered topics together (once per second).
-            stats = monitor.get_topic_stats()
-            discovered = monitor.get_discovered_topics()
-            # Merge unsubscribed topics as inactive entries.
-            all_topics = [s.model_dump(mode="json") for s in stats] + [
-                {
-                    "name": d.name,
-                    "msg_type": d.msg_type,
-                    "actual_hz": 0,
-                    "status": "inactive",
-                    "message_count": 0,
-                    "is_subscribed": False,
-                }
-                for d in discovered
-            ]
-            yield f"event: topic_stats\ndata: {json.dumps(all_topics)}\n\n"
+            # Send subscribed + discovered topics together (once per second):
+            # a full snapshot on connect and every few ticks, deltas in between.
+            rows = build_topic_rows(monitor.get_topic_stats(), monitor.get_discovered_topics())
+            event_name, payload = differ.next_event(rows)
+            yield f"event: {event_name}\ndata: {json.dumps(payload)}\n\n"
 
             # Send any new logs that arrived since the last check.
             new_logs = log_manager.get_logs_since(last_log_id)

--- a/backend/app/features/topics/service.py
+++ b/backend/app/features/topics/service.py
@@ -284,20 +284,31 @@ class TopicMonitorService:
             return sorted(self._subscribed_set)
 
     def on_discover_tick(self) -> None:
-        """Discover all topics on the DDS domain and subscribe to new ones."""
+        """Discover all topics on the DDS domain, subscribe to new ones, and prune vanished ones."""
         if self._subscriber is None:
             return
         topic_names_and_types = self._subscriber.discover_topics()
 
         with self._lock:
+            seen: set[str] = set()
             for name, types in topic_names_and_types:
                 if name in _SYSTEM_TOPICS or any(name.startswith(p) for p in _SYSTEM_TOPIC_PREFIXES):
                     continue
+                seen.add(name)
                 msg_type = types[0] if types else "unknown"
                 self._discovered_topics[name] = msg_type
 
                 if name in self._subscribed_topic_names and name not in self._subscribed_set:
                     self._subscribe_to_topic(name, msg_type)
+
+            # Prune topics that disappeared from DDS so the topic list (and the
+            # SSE payload built from it) does not grow for the process lifetime.
+            # Selected or config-declared topics are kept: their rows must stay
+            # visible, and their msg_type is still needed to resubscribe.
+            for name in list(self._discovered_topics):
+                if name in seen or name in self._subscribed_set or name in self._subscribed_topic_names:
+                    continue
+                del self._discovered_topics[name]
 
     def on_gap_check_tick(self) -> None:
         """Periodically check for topics that have stalled."""

--- a/backend/app/features/topics/stream.py
+++ b/backend/app/features/topics/stream.py
@@ -1,0 +1,71 @@
+"""Diff computation for the topic-stats SSE stream.
+
+The stream keeps the "one row per topic" contract of GET /api/topics, but
+sending every row every second is redundant: idle rows are byte-identical
+tick after tick. A per-connection ``TopicStreamDiffer`` therefore emits a
+full snapshot periodically (and on connect) and, in between, only the rows
+that changed plus the names of rows that disappeared.
+"""
+
+from typing import Any
+
+from app.features.topics.schemas import DiscoveredTopic, TopicInfo
+
+# Ticks between full snapshots (1 tick = 1 second in the SSE loop). Snapshots
+# bound how long a client that missed a delta can stay stale.
+SNAPSHOT_INTERVAL_TICKS = 10
+
+
+def build_topic_rows(stats: list[TopicInfo], discovered: list[DiscoveredTopic]) -> list[dict[str, Any]]:
+    """Merge subscribed stats and discovered-but-unsubscribed topics into one row list.
+
+    Discovered topics carry no measurements yet, so they are rendered as
+    minimal inactive rows (same shape the frontend has always received).
+    """
+    return [s.model_dump(mode="json") for s in stats] + [
+        {
+            "name": d.name,
+            "msg_type": d.msg_type,
+            "actual_hz": 0,
+            "status": "inactive",
+            "message_count": 0,
+            "is_subscribed": False,
+        }
+        for d in discovered
+    ]
+
+
+class TopicStreamDiffer:
+    """Per-connection state that turns full row lists into snapshot/delta events.
+
+    ``next_event`` is called once per tick with the current full row list and
+    returns ``(event_name, payload)``:
+
+    - ``("topic_stats", rows)``: full snapshot — first tick and every
+      ``SNAPSHOT_INTERVAL_TICKS`` ticks thereafter. The client replaces its
+      whole list.
+    - ``("topic_stats_delta", {"changed": rows, "removed": names})``: all other
+      ticks. ``changed`` holds rows that differ from the previous tick
+      (including brand-new topics); ``removed`` holds names of rows that
+      vanished. The client merges into its list.
+    """
+
+    def __init__(self, snapshot_interval: int = SNAPSHOT_INTERVAL_TICKS) -> None:
+        self._snapshot_interval = snapshot_interval
+        self._tick = 0
+        self._last_rows: dict[str, dict[str, Any]] = {}
+
+    def next_event(self, rows: list[dict[str, Any]]) -> tuple[str, Any]:
+        """Compute the SSE event for this tick and remember the rows for the next one."""
+        current = {row["name"]: row for row in rows}
+        is_snapshot = self._tick % self._snapshot_interval == 0
+        self._tick += 1
+
+        if is_snapshot:
+            self._last_rows = current
+            return ("topic_stats", rows)
+
+        changed = [row for name, row in current.items() if self._last_rows.get(name) != row]
+        removed = [name for name in self._last_rows if name not in current]
+        self._last_rows = current
+        return ("topic_stats_delta", {"changed": changed, "removed": removed})

--- a/backend/tests/features/topics/test_service.py
+++ b/backend/tests/features/topics/test_service.py
@@ -116,6 +116,52 @@ class TestOnDiscoverTick:
         service = TopicMonitorService(subscribed_topics=[], log_manager=log_manager)
         service.on_discover_tick()  # No exception raised
 
+    def test_prunes_vanished_unsubscribed_topic(
+        self, monitor: TopicMonitorService, mock_subscriber: MagicMock
+    ) -> None:
+        """An unsubscribed topic that disappears from DDS is dropped from the list."""
+        mock_subscriber.discover_topics.return_value = [
+            ("/camera/image", ["sensor_msgs/msg/Image"]),
+        ]
+        monitor.on_discover_tick()
+        assert len(monitor.get_discovered_topics()) == 1
+
+        mock_subscriber.discover_topics.return_value = []
+        monitor.on_discover_tick()
+        assert monitor.get_discovered_topics() == []
+
+    def test_keeps_vanished_selected_topic(self, monitor: TopicMonitorService, mock_subscriber: MagicMock) -> None:
+        """A selected (config-declared) topic keeps its discovered entry when its publisher vanishes.
+
+        The monitor fixture declares /joint_states as a subscribe target; a
+        failed subscribe leaves it discovered-but-unsubscribed, and pruning
+        must not make its row disappear.
+        """
+        mock_subscriber.subscribe_topic.return_value = None  # Subscribe fails
+        mock_subscriber.discover_topics.return_value = [
+            ("/joint_states", ["sensor_msgs/msg/JointState"]),
+        ]
+        monitor.on_discover_tick()
+        assert [d.name for d in monitor.get_discovered_topics()] == ["/joint_states"]
+
+        mock_subscriber.discover_topics.return_value = []
+        monitor.on_discover_tick()
+        assert [d.name for d in monitor.get_discovered_topics()] == ["/joint_states"]
+
+    def test_keeps_stats_row_for_vanished_subscribed_topic(
+        self, monitor: TopicMonitorService, mock_subscriber: MagicMock
+    ) -> None:
+        """A subscribed topic whose publisher vanishes keeps its stats row (it will show as stalled)."""
+        mock_subscriber.discover_topics.return_value = [
+            ("/joint_states", ["sensor_msgs/msg/JointState"]),
+        ]
+        monitor.on_discover_tick()
+        assert len(monitor.get_topic_stats()) == 1
+
+        mock_subscriber.discover_topics.return_value = []
+        monitor.on_discover_tick()
+        assert [s.name for s in monitor.get_topic_stats()] == ["/joint_states"]
+
 
 # ---------------------------------------------------------------------------
 # on_message

--- a/backend/tests/features/topics/test_stream.py
+++ b/backend/tests/features/topics/test_stream.py
@@ -1,0 +1,119 @@
+"""Unit tests for the topic-stats SSE diff computation."""
+
+from typing import Any
+
+from app.features.topics.schemas import DiscoveredTopic, TopicInfo
+from app.features.topics.stream import SNAPSHOT_INTERVAL_TICKS, TopicStreamDiffer, build_topic_rows
+
+
+def _row(name: str, **overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "name": name,
+        "msg_type": "std_msgs/msg/String",
+        "actual_hz": 0,
+        "status": "inactive",
+        "message_count": 0,
+        "is_subscribed": False,
+    }
+    row.update(overrides)
+    return row
+
+
+class TestBuildTopicRows:
+    """Tests for build_topic_rows()."""
+
+    def test_merges_stats_and_discovered(self) -> None:
+        """Subscribed stats come first, discovered topics follow as inactive rows."""
+        stats = [
+            TopicInfo(
+                name="/joint_states",
+                msg_type="sensor_msgs/msg/JointState",
+                actual_hz=99.3,
+                status="ok",
+                message_count=5230,
+                is_subscribed=True,
+                baseline_hz=100.0,
+                baseline_fixed=True,
+                loss_rate=0.0,
+                drop_count=0,
+                continuity_score=1.0,
+                qos_reliability="RELIABLE",
+            ),
+        ]
+        discovered = [DiscoveredTopic(name="/idle", msg_type="std_msgs/msg/String", is_subscribed=False)]
+
+        rows = build_topic_rows(stats, discovered)
+
+        assert [r["name"] for r in rows] == ["/joint_states", "/idle"]
+        assert rows[0]["is_subscribed"] is True
+        assert rows[0]["baseline_hz"] == 100.0
+        assert rows[1] == _row("/idle")
+
+    def test_empty_inputs(self) -> None:
+        assert build_topic_rows([], []) == []
+
+
+class TestTopicStreamDiffer:
+    """Tests for TopicStreamDiffer.next_event()."""
+
+    def test_first_tick_is_snapshot(self) -> None:
+        differ = TopicStreamDiffer()
+        rows = [_row("/a")]
+        assert differ.next_event(rows) == ("topic_stats", rows)
+
+    def test_unchanged_tick_yields_empty_delta(self) -> None:
+        differ = TopicStreamDiffer()
+        rows = [_row("/a"), _row("/b")]
+        differ.next_event(rows)
+        assert differ.next_event([_row("/a"), _row("/b")]) == (
+            "topic_stats_delta",
+            {"changed": [], "removed": []},
+        )
+
+    def test_changed_row_appears_in_delta(self) -> None:
+        differ = TopicStreamDiffer()
+        differ.next_event([_row("/a"), _row("/b")])
+        changed = _row("/a", actual_hz=10.0, status="ok")
+        event_name, payload = differ.next_event([changed, _row("/b")])
+        assert event_name == "topic_stats_delta"
+        assert payload == {"changed": [changed], "removed": []}
+
+    def test_new_row_appears_in_delta(self) -> None:
+        differ = TopicStreamDiffer()
+        differ.next_event([_row("/a")])
+        event_name, payload = differ.next_event([_row("/a"), _row("/new")])
+        assert event_name == "topic_stats_delta"
+        assert payload == {"changed": [_row("/new")], "removed": []}
+
+    def test_removed_row_appears_in_delta(self) -> None:
+        differ = TopicStreamDiffer()
+        differ.next_event([_row("/a"), _row("/gone")])
+        event_name, payload = differ.next_event([_row("/a")])
+        assert event_name == "topic_stats_delta"
+        assert payload == {"changed": [], "removed": ["/gone"]}
+
+    def test_snapshot_repeats_every_interval(self) -> None:
+        differ = TopicStreamDiffer(snapshot_interval=3)
+        rows = [_row("/a")]
+        assert differ.next_event(rows)[0] == "topic_stats"
+        assert differ.next_event(rows)[0] == "topic_stats_delta"
+        assert differ.next_event(rows)[0] == "topic_stats_delta"
+        assert differ.next_event(rows)[0] == "topic_stats"
+
+    def test_delta_after_snapshot_diffs_against_snapshot(self) -> None:
+        """A snapshot resets the comparison base, so the next delta is relative to it."""
+        differ = TopicStreamDiffer(snapshot_interval=2)
+        differ.next_event([_row("/a")])  # snapshot
+        differ.next_event([_row("/a"), _row("/b")])  # delta: /b new
+        differ.next_event([_row("/a"), _row("/b")])  # snapshot
+        event_name, payload = differ.next_event([_row("/a"), _row("/b")])
+        assert event_name == "topic_stats_delta"
+        assert payload == {"changed": [], "removed": []}
+
+    def test_default_interval_matches_constant(self) -> None:
+        differ = TopicStreamDiffer()
+        rows = [_row("/a")]
+        events = [differ.next_event(rows)[0] for _ in range(SNAPSHOT_INTERVAL_TICKS + 1)]
+        assert events[0] == "topic_stats"
+        assert all(e == "topic_stats_delta" for e in events[1:SNAPSHOT_INTERVAL_TICKS])
+        assert events[SNAPSHOT_INTERVAL_TICKS] == "topic_stats"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -299,8 +299,10 @@ Two state-management approaches are used:
 
 ```
 SSE (/api/topics/stream)
-  ├─ topic_stats event (every second)
+  ├─ topic_stats event (full snapshot: on connect + every 10s)
   │   └─ queryClient.setQueryData(sseKeys.topicStats(), data)
+  ├─ topic_stats_delta event (every second: changed/removed rows only)
+  │   └─ queryClient.setQueryData(sseKeys.topicStats(), mergeTopicStatsDelta(prev, delta))
   └─ log event (as they occur)
       └─ queryClient.setQueryData(sseKeys.logs(), ...)
 

--- a/docs/domain/quality_analysis.md
+++ b/docs/domain/quality_analysis.md
@@ -108,7 +108,7 @@ A real-time graph of loss rate rendered with uPlot. The Y axis is inverted (0% a
 | Item | Details |
 |---|---|
 | Implementation | `TopicMonitor` (rclpy node) |
-| Delivery | SSE `topic_stats` event (every 1s) |
+| Delivery | SSE `topic_stats` snapshot + per-second `topic_stats_delta` diffs (see [sse.md](sse.md)) |
 | Gap detection | Emits a log immediately on occurrence (bottom Log tab) |
 
 #### When each metric updates

--- a/docs/domain/sse.md
+++ b/docs/domain/sse.md
@@ -12,8 +12,11 @@ For the REST API endpoint spec, see the Swagger UI that FastAPI generates automa
 
 | Event name | Frequency | Contents |
 |---|---|---|
-| `topic_stats` | Every 1s | Statistics for all topics (Hz, status, loss_rate, etc.) |
+| `topic_stats` | On connect + every 10s | Full snapshot: statistics for all topics (Hz, status, loss_rate, etc.) |
+| `topic_stats_delta` | Every 1s (between snapshots) | `{ changed, removed }`: rows that changed since the previous tick (including newly discovered topics) and names of rows that vanished |
 | `log` | On occurrence | New log entry (severity, message, timestamp) |
+
+Together, `topic_stats` + `topic_stats_delta` preserve the "one row per topic" contract of `GET /api/topics`: replaying the latest snapshot plus subsequent deltas always yields the current full list. The periodic snapshot also bounds staleness after a missed delta. The diff is computed per connection (`backend/app/features/topics/stream.py`), so a reconnect always starts with a fresh snapshot.
 
 ## Connection example
 
@@ -22,7 +25,13 @@ const es = new EventSource("/api/topics/stream");
 
 es.addEventListener("topic_stats", (e) => {
   const stats = JSON.parse(e.data);
-  // { "/topic_name": { actual_hz, status, loss_rate, ... }, ... }
+  // [ { name, actual_hz, status, loss_rate, ... }, ... ] — replace the local list
+});
+
+es.addEventListener("topic_stats_delta", (e) => {
+  const { changed, removed } = JSON.parse(e.data);
+  // changed: [ { name, actual_hz, ... }, ... ] — upsert into the local list
+  // removed: [ "/topic_name", ... ] — drop from the local list
 });
 
 es.addEventListener("log", (e) => {

--- a/frontend/src/features/live-topics/ui/topic-item.tsx
+++ b/frontend/src/features/live-topics/ui/topic-item.tsx
@@ -1,5 +1,6 @@
 /** Row component for the topic list (single-line layout). */
 
+import { memo } from "react";
 import type { TopicInfo } from "@/api/generated/schemas";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useIsRecording, useUpdateSubscriptions } from "@/hooks/use-api";
@@ -44,7 +45,16 @@ function HzLabel({ topic }: { topic: TopicInfo }) {
   return <span>{actual_hz.toFixed(0)}Hz</span>;
 }
 
-export function TopicItem({ topic, isMissing = false }: { topic: TopicInfo; isMissing?: boolean }) {
+/** Memoized: SSE writes go through TanStack Query structural sharing, so the
+ * `topic` reference only changes for rows whose values actually changed —
+ * memo keeps the other ~100 rows from re-rendering on every 1Hz tick. */
+export const TopicItem = memo(function TopicItem({
+  topic,
+  isMissing = false,
+}: {
+  topic: TopicInfo;
+  isMissing?: boolean;
+}) {
   const isSelected = useLiveTopicsStore((s) => s.selectedTopics.has(topic.name));
   const isPreviewed = useLiveTopicsStore((s) => s.previewedTopics.includes(topic.name));
   const isLive = useLiveTopicsStore((s) => s.isLive);
@@ -98,4 +108,4 @@ export function TopicItem({ topic, isMissing = false }: { topic: TopicInfo; isMi
       </div>
     </div>
   );
-}
+});

--- a/frontend/src/features/monitor/loss-rate-chart.tsx
+++ b/frontend/src/features/monitor/loss-rate-chart.tsx
@@ -171,7 +171,6 @@ function thresholdPlugin(): uPlot.Plugin {
 export function LossRateChart() {
   const containerRef = useRef<HTMLDivElement>(null);
   const uplotRef = useRef<uPlot | null>(null);
-  const prevKeyRef = useRef("");
   const snapshots = useQualityHistoryStore((state) => state.snapshots);
   const allTopicNames = useQualityHistoryStore((state) => state.topicNames);
   const markers = useQualityHistoryStore((state) => state.markers);
@@ -184,20 +183,16 @@ export function LossRateChart() {
 
   const scrollOffsetRef = useRef<number | null>(null);
 
+  // The instance is recreated only when the series composition changes, so the
+  // effect keys off this string instead of the array/data references (per-second
+  // snapshot pushes must not destroy and rebuild the canvas — data updates go
+  // through the setData effect below).
+  const topicsKey = topicNames.join(",");
+
   // Create/recreate the uPlot instance
+  // biome-ignore lint/correctness/useExhaustiveDependencies: topicNames is fully represented by topicsKey; initial data is read from the store on purpose
   useEffect(() => {
     if (!containerRef.current || topicNames.length === 0) return;
-
-    const key = topicNames.join(",");
-    if (uplotRef.current && prevKeyRef.current === key) {
-      return;
-    }
-    prevKeyRef.current = key;
-
-    if (uplotRef.current) {
-      uplotRef.current.destroy();
-      uplotRef.current = null;
-    }
 
     const series: uPlot.Series[] = [
       { label: "Time", value: (_u, v) => (v != null ? fmtElapsed(v) : "--") },
@@ -242,14 +237,17 @@ export function LossRateChart() {
       legend: { show: false },
     };
 
-    uplotRef.current = new uPlot(opts, buildLossRateData(snapshots, topicNames), containerRef.current);
+    uplotRef.current = new uPlot(
+      opts,
+      buildLossRateData(useQualityHistoryStore.getState().snapshots, topicNames),
+      containerRef.current,
+    );
 
     return () => {
       uplotRef.current?.destroy();
       uplotRef.current = null;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [topicNames, snapshots]);
+  }, [topicsKey]);
 
   // Data updates + 30-second window control
   useEffect(() => {

--- a/frontend/src/hooks/use-topics-stream.ts
+++ b/frontend/src/hooks/use-topics-stream.ts
@@ -18,6 +18,7 @@ export interface LogEntry {
 }
 
 import { sseKeys } from "@/lib/query-keys";
+import { mergeTopicStatsDelta, type TopicStatsDelta } from "@/lib/topic-stats-delta";
 import { useQualityHistoryStore } from "@/stores/quality-history-store";
 
 /** SSE connection status. */
@@ -46,11 +47,21 @@ export function useTopicsStream(enabled = true) {
 
     es.onopen = () => setStatus("connected");
 
+    // Full snapshot (on connect + periodically): replace the whole list.
     es.addEventListener("topic_stats", (e) => {
       const data: TopicInfo[] = JSON.parse(e.data);
       queryClient.setQueryData(sseKeys.topicStats(), data);
       // Accumulate quality time-series data.
       useQualityHistoryStore.getState().push(data);
+    });
+
+    // Per-tick delta: merge changed/removed rows into the cached list.
+    es.addEventListener("topic_stats_delta", (e) => {
+      const delta: TopicStatsDelta = JSON.parse(e.data);
+      const merged = mergeTopicStatsDelta(queryClient.getQueryData<TopicInfo[]>(sseKeys.topicStats()) ?? [], delta);
+      queryClient.setQueryData(sseKeys.topicStats(), merged);
+      // The quality history advances every tick, even when no row changed.
+      useQualityHistoryStore.getState().push(merged);
     });
 
     es.addEventListener("log", (e) => {

--- a/frontend/src/lib/__tests__/topic-stats-delta.test.ts
+++ b/frontend/src/lib/__tests__/topic-stats-delta.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { TopicInfo } from "@/api/generated/schemas";
+import { mergeTopicStatsDelta } from "../topic-stats-delta";
+
+function makeTopic(name: string, overrides: Partial<TopicInfo> = {}): TopicInfo {
+  return {
+    name,
+    msg_type: "std_msgs/msg/String",
+    actual_hz: 0,
+    status: "inactive",
+    message_count: 0,
+    is_subscribed: false,
+    baseline_hz: null,
+    baseline_fixed: false,
+    loss_rate: 0,
+    drop_count: 0,
+    continuity_score: 1,
+    qos_reliability: "",
+    ...overrides,
+  };
+}
+
+describe("mergeTopicStatsDelta", () => {
+  it("replaces changed rows in place and keeps their position", () => {
+    const a = makeTopic("/a");
+    const b = makeTopic("/b");
+    const changedA = makeTopic("/a", { actual_hz: 10, status: "ok" });
+
+    const merged = mergeTopicStatsDelta([a, b], { changed: [changedA], removed: [] });
+
+    expect(merged).toEqual([changedA, b]);
+    expect(merged[0]).toBe(changedA);
+  });
+
+  it("keeps object identity for unchanged rows", () => {
+    const a = makeTopic("/a");
+    const b = makeTopic("/b");
+
+    const merged = mergeTopicStatsDelta([a, b], { changed: [makeTopic("/a", { actual_hz: 5 })], removed: [] });
+
+    expect(merged[1]).toBe(b);
+  });
+
+  it("removes vanished rows", () => {
+    const merged = mergeTopicStatsDelta([makeTopic("/a"), makeTopic("/gone")], { changed: [], removed: ["/gone"] });
+
+    expect(merged.map((t) => t.name)).toEqual(["/a"]);
+  });
+
+  it("appends rows first seen in a delta (newly discovered topics)", () => {
+    const a = makeTopic("/a");
+    const fresh = makeTopic("/new");
+
+    const merged = mergeTopicStatsDelta([a], { changed: [fresh], removed: [] });
+
+    expect(merged).toEqual([a, fresh]);
+  });
+
+  it("returns an equal list for an empty delta", () => {
+    const prev = [makeTopic("/a"), makeTopic("/b")];
+
+    expect(mergeTopicStatsDelta(prev, { changed: [], removed: [] })).toEqual(prev);
+  });
+
+  it("merges from an empty previous list (delta before any snapshot)", () => {
+    const fresh = makeTopic("/new");
+
+    expect(mergeTopicStatsDelta([], { changed: [fresh], removed: ["/stale"] })).toEqual([fresh]);
+  });
+});

--- a/frontend/src/lib/topic-stats-delta.ts
+++ b/frontend/src/lib/topic-stats-delta.ts
@@ -1,0 +1,43 @@
+/** Merging logic for `topic_stats_delta` SSE events.
+ *
+ * The stream sends a full `topic_stats` snapshot on connect and periodically;
+ * in between, `topic_stats_delta` carries only the rows that changed plus the
+ * names of rows that disappeared (see docs/domain/sse.md).
+ */
+
+import type { TopicInfo } from "@/api/generated/schemas";
+
+/** Payload of a `topic_stats_delta` SSE event (outside OpenAPI, so not orval-generated). */
+export interface TopicStatsDelta {
+  /** Rows that differ from the previous tick, including newly discovered topics. */
+  changed: TopicInfo[];
+  /** Names of rows that vanished since the previous tick. */
+  removed: string[];
+}
+
+/** Merge one delta into the previous full row list.
+ *
+ * Unchanged rows keep their object identity so memoized row components can
+ * skip re-rendering; rows first seen in a delta are appended (display order
+ * is imposed by the consumer's sort, not by this list).
+ */
+export function mergeTopicStatsDelta(prev: TopicInfo[], delta: TopicStatsDelta): TopicInfo[] {
+  const changedByName = new Map(delta.changed.map((t) => [t.name, t]));
+  const removed = new Set(delta.removed);
+
+  const merged: TopicInfo[] = [];
+  for (const row of prev) {
+    if (removed.has(row.name)) continue;
+    const next = changedByName.get(row.name);
+    if (next) {
+      merged.push(next);
+      changedByName.delete(row.name);
+    } else {
+      merged.push(row);
+    }
+  }
+  for (const row of changedByName.values()) {
+    merged.push(row);
+  }
+  return merged;
+}


### PR DESCRIPTION
## Problem

In a customer environment (~120 topics on the DDS domain, ~30 recorded), the browser tab's memory grew by ~50MB/min, forcing a reload every 30 minutes. Local reproduction (plain Chrome, no preview tiles open) showed the tab renderer RSS growing monotonically at +6.7MB/min with 120 topics, flat with 9 topics, and immediately recovering when the topic count dropped back — pointing at the per-second full-list SSE delivery and the full-row re-render churn it triggers. JS heap stayed flat throughout (40–54MB); the accumulation was outside the V8 heap.

## Changes

1. **Memoize `TopicItem`** (`frontend/src/features/live-topics/ui/topic-item.tsx`)
   SSE writes go through TanStack Query structural sharing, so the `topic` prop reference is stable for unchanged rows. `React.memo` limits the per-second re-render to rows whose values actually changed instead of all ~120 rows.

2. **Stop recreating the loss-rate chart every second** (`frontend/src/features/monitor/loss-rate-chart.tsx`)
   The uPlot creation effect had the per-second `snapshots` in its deps, so its cleanup destroyed the chart every tick (leaking one ~2.8MB canvas per second at dpr2; the `prevKeyRef` guard was dead because cleanup nulled the ref). The effect now keys off the series composition only; per-tick data updates stay in the existing `setData` effect.

3. **Diff-based SSE delivery** (`backend/app/features/topics/stream.py`, `router.py`, `frontend/src/lib/topic-stats-delta.ts`, `use-topics-stream.ts`)
   `/api/topics/stream` sent every known topic row every second (~38KB/s at 120 topics) even though idle rows are byte-identical tick after tick. A per-connection `TopicStreamDiffer` (pure, unit-tested) now emits a full `topic_stats` snapshot on connect and every 10 ticks, and a `topic_stats_delta` event (`{changed, removed}`) in between. The frontend merges deltas into the cache preserving object identity for unchanged rows. Replaying the latest snapshot plus deltas always yields the current full list, so the one-row-per-topic contract of `GET /api/topics` is unchanged. Docs updated (`docs/domain/sse.md`, `ARCHITECTURE.md`, `quality_analysis.md`).

4. **Prune vanished topics** (`backend/app/features/topics/service.py`)
   `_discovered_topics` was append-only, so topics that disappeared from DDS kept inflating the payload until a backend restart. `on_discover_tick` now drops entries missing from the current discovery result, while keeping subscribed and config/user-selected topics so their rows never disappear (covered by unit tests).

No REST schema changes (SSE is outside OpenAPI), so no orval regeneration was needed.

## Verification

Reproduced the customer topology with 111 `std_msgs/String` publishers inside the backend container (55 publishing at 10Hz, 56 created but silent) on top of the 8 simulator topics = 119 rows, no preview tiles open.

Mechanism level (same environment, `main` vs this branch):

| Metric | Before | After |
|---|---|---|
| Canvases created (MutationObserver, 10s) | 10 | 0 |
| SSE bandwidth | ~21KB/s (full list every second) | ~4.4KB/s (19KB snapshot / 10s + ~2.5KB deltas, ~8 changed rows) |

RSS soak (plain Chrome, dedicated profile, renderer RSS sampled every 30s):

- **After, 30 minutes: flat** — regression slope −0.15MB/min (279MB → 252MB, sawtooth fully recovered by GC down to 169MB).
- Before (`main`, 12 minutes): upward tendency ~+3.0MB/min on this machine (GC noise ±90MB makes the short-window RSS A/B less sharp than the fork-side +6.7MB/min repro; the mechanism metrics above plus the 30-minute flat run are the primary evidence).

Regression checks (all pass): Hz label updates via deltas (subscribe → `idle` → `learning` → `auto 10/10.1Hz`), selection toggle, 111 no-publisher rows visible, loss-rate chart drawing + wheel scroll, LOG tab, and the pruning E2E (killing the publishers removed the 110 unsubscribed rows within one discovery tick while the selected `/loadtest/pub_000` row stayed visible as `danger`).

Quality gates: backend 835 passed with 100% coverage (`make test-cov-backend`), frontend 293 passed with 100% coverage, `make lint` clean.

## Out of scope (separate PRs)

- MJPEG preview rework (separate +8.5MB/min growth, only when tiles are open).
- Issue #71 (`recorder.start()/stop()` via `asyncio.to_thread`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)