### PR TITLE
fix(live-topics): memoize TopicItem to stop full-list re-renders every SSE tick

### DIFF
--- a/frontend/src/features/live-topics/ui/topic-item.tsx
+++ b/frontend/src/features/live-topics/ui/topic-item.tsx
@@ -1,5 +1,6 @@
 /** Row component for the topic list (single-line layout). */
 
+import { memo } from "react";
 import type { TopicInfo } from "@/api/generated/schemas";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useIsRecording, useUpdateSubscriptions } from "@/hooks/use-api";
@@ -44,7 +45,16 @@ function HzLabel({ topic }: { topic: TopicInfo }) {
   return <span>{actual_hz.toFixed(0)}Hz</span>;
 }
 
-export function TopicItem({ topic, isMissing = false }: { topic: TopicInfo; isMissing?: boolean }) {
+/** Memoized: SSE writes go through TanStack Query structural sharing, so the
+ * `topic` reference only changes for rows whose values actually changed —
+ * memo keeps the other ~100 rows from re-rendering on every 1Hz tick. */
+export const TopicItem = memo(function TopicItem({
+  topic,
+  isMissing = false,
+}: {
+  topic: TopicInfo;
+  isMissing?: boolean;
+}) {
   const isSelected = useLiveTopicsStore((s) => s.selectedTopics.has(topic.name));
   const isPreviewed = useLiveTopicsStore((s) => s.previewedTopics.includes(topic.name));
   const isLive = useLiveTopicsStore((s) => s.isLive);
@@ -98,4 +108,4 @@ export function TopicItem({ topic, isMissing = false }: { topic: TopicInfo; isMi
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
## Problem

Part 1/3 of the tab-memory-growth fix (split from #81; see #81 for the full investigation). On a DDS domain with ~120 topics, every 1Hz SSE tick re-rendered all ~120 `TopicItem` rows even though only a handful of rows actually changed, contributing to the Blink-side render churn behind the ~50MB/min tab RSS growth observed in a customer environment.

## Change

Wrap `TopicItem` in `React.memo`. SSE writes reach the rows through TanStack Query structural sharing, so the `topic` prop reference is stable for rows whose values did not change — memo limits the per-second re-render to the rows that actually changed. No behavior change.

## Verification

- Regression-checked against a reproduction of the customer topology (119 rows: 8 simulator topics + 111 load-test topics): Hz label updates, selection toggle, and no-publisher (`idle`) rows all behave as before.
- Tab renderer RSS stayed flat over a 30-minute plain-Chrome soak with the three fixes combined (slope −0.15MB/min; details in #81).
- `make lint` clean; frontend 293 tests passed with 100% coverage.

Related: #81 (original combined PR), #83, and #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
