### PR TITLE
fix(monitor): stop destroying and rebuilding the loss-rate chart every second

### DIFF
--- a/frontend/src/features/monitor/loss-rate-chart.tsx
+++ b/frontend/src/features/monitor/loss-rate-chart.tsx
@@ -171,7 +171,6 @@ function thresholdPlugin(): uPlot.Plugin {
 export function LossRateChart() {
   const containerRef = useRef<HTMLDivElement>(null);
   const uplotRef = useRef<uPlot | null>(null);
-  const prevKeyRef = useRef("");
   const snapshots = useQualityHistoryStore((state) => state.snapshots);
   const allTopicNames = useQualityHistoryStore((state) => state.topicNames);
   const markers = useQualityHistoryStore((state) => state.markers);
@@ -184,20 +183,16 @@ export function LossRateChart() {
 
   const scrollOffsetRef = useRef<number | null>(null);
 
+  // The instance is recreated only when the series composition changes, so the
+  // effect keys off this string instead of the array/data references (per-second
+  // snapshot pushes must not destroy and rebuild the canvas — data updates go
+  // through the setData effect below).
+  const topicsKey = topicNames.join(",");
+
   // Create/recreate the uPlot instance
+  // biome-ignore lint/correctness/useExhaustiveDependencies: topicNames is fully represented by topicsKey; initial data is read from the store on purpose
   useEffect(() => {
     if (!containerRef.current || topicNames.length === 0) return;
-
-    const key = topicNames.join(",");
-    if (uplotRef.current && prevKeyRef.current === key) {
-      return;
-    }
-    prevKeyRef.current = key;
-
-    if (uplotRef.current) {
-      uplotRef.current.destroy();
-      uplotRef.current = null;
-    }
 
     const series: uPlot.Series[] = [
       { label: "Time", value: (_u, v) => (v != null ? fmtElapsed(v) : "--") },
@@ -242,14 +237,17 @@ export function LossRateChart() {
       legend: { show: false },
     };
 
-    uplotRef.current = new uPlot(opts, buildLossRateData(snapshots, topicNames), containerRef.current);
+    uplotRef.current = new uPlot(
+      opts,
+      buildLossRateData(useQualityHistoryStore.getState().snapshots, topicNames),
+      containerRef.current,
+    );
 
     return () => {
       uplotRef.current?.destroy();
       uplotRef.current = null;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [topicNames, snapshots]);
+  }, [topicsKey]);
 
   // Data updates + 30-second window control
   useEffect(() => {


### PR DESCRIPTION
## Problem

Part 2/3 of the tab-memory-growth fix (split from #81; see #81 for the full investigation). The uPlot creation effect in `loss-rate-chart.tsx` listed the per-second `snapshots` in its deps, so its cleanup ran every tick: `destroy()` → `new uPlot()`, creating one canvas per second (~2.8MB each at dpr2; 10 canvases observed in 10s via MutationObserver). The `prevKeyRef` guard was dead because the cleanup nulled the ref before the guard could match.

## Change

The creation effect now keys off the series composition only (`topicsKey`, the joined selected-topic names). Per-tick data updates stay in the existing `setData` effect, and the initial data is read from the quality-history store at creation time. `prevKeyRef` is removed.

## Verification

- After the fix: 0 canvases created over 12s (MutationObserver), exactly 1 canvas in the DOM.
- Chart regression checks pass: continuous per-second drawing, REC/STOP markers and threshold lines, wheel-scroll handler active (`defaultPrevented` + redraw confirmed), recreation still happens when the selected-topic set changes.
- Tab renderer RSS stayed flat over a 30-minute plain-Chrome soak with the three fixes combined (slope −0.15MB/min; details in #81).
- `make lint` clean; frontend 293 tests passed with 100% coverage.

Related: #81 (original combined PR), #82, and #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
