### PR TITLE
chore(test): run backend tests on the host without Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,8 @@ jobs:
       - name: Type check (mypy)
         run: uv run mypy app/
 
-      - name: Test (pytest)
-        # rclpy-dependent tests are auto-skipped via pytest.importorskip("rclpy")
-        run: uv run pytest tests/ -v
+      - name: Test + coverage (pytest)
+        run: uv run pytest tests/ -v --cov=app --cov-report=term-missing --cov-fail-under=100
 
   frontend:
     name: Frontend (lint + test + build)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,10 @@ make lint              # Lint (everything: backend + frontend)
 make lint-backend      # Lint (ruff + mypy)
 make lint-frontend     # Lint (tsc + biome)
 make test              # Test (everything: backend + frontend)
-make test-backend      # Test (pytest, inside Docker)
+make test-backend      # Test (pytest)
 make test-frontend     # Test (vitest)
 make test-cov          # Test + coverage (everything)
-make test-cov-backend  # Test + coverage (pytest, inside Docker)
+make test-cov-backend  # Test + coverage (pytest)
 make test-cov-frontend # Test + coverage (vitest)
 make format            # Format (everything: backend + frontend)
 make format-backend    # Format (ruff)
@@ -84,10 +84,9 @@ Uses the **Bulletproof React** pattern. See [docs/ARCHITECTURE.md](docs/ARCHITEC
 
 - **Maintain 100% coverage** — verify with `make test-cov`.
 - The test structure mirrors the `backend/app/` directory structure (`backend/tests/features/recording/test_service.py` → `backend/app/features/recording/service.py`).
-- Untestable code (rclpy runtime, Docker-only, MCAP I/O) is excluded via `pragma: no cover` and not tested.
+- Backend tests run on the host without Docker or rclpy (`app.main` imports rclpy lazily inside the lifespan). Untestable code (rclpy runtime, Docker-only, MCAP I/O) is excluded via `pragma: no cover` and not tested.
 - Endpoint functions in `router.py` are HTTP glue code and are excluded with `pragma: no cover`. Pure logic is extracted out of the router and tested (e.g., `scanner.py`).
-- Tests that only run inside Docker (rclpy-dependent) are auto-skipped with `pytest.importorskip("rclpy")`.
-- Tests must not depend on filesystem permissions (chmod); use `unittest.mock.patch` instead (chmod fails as Docker root).
+- Tests must not depend on filesystem permissions (chmod); use `unittest.mock.patch` instead (chmod fails as root in CI / Dev Container).
 
 ## Coding Style
 

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ help:
 	@echo "  make lint-backend      - Lint (ruff + mypy)"
 	@echo "  make lint-frontend     - Lint (tsc + biome)"
 	@echo "  make test              - Test (all: backend + frontend)"
-	@echo "  make test-backend      - Test (pytest, inside Docker)"
+	@echo "  make test-backend      - Test (pytest)"
 	@echo "  make test-frontend     - Test (vitest)"
 	@echo "  make test-cov          - Test + coverage (all)"
-	@echo "  make test-cov-backend  - Test + coverage (pytest, inside Docker)"
+	@echo "  make test-cov-backend  - Test + coverage (pytest)"
 	@echo "  make test-cov-frontend - Test + coverage (vitest)"
 	@echo "  make format            - Format (all: backend + frontend)"
 	@echo "  make format-backend    - Format (ruff)"
@@ -146,10 +146,10 @@ lint-frontend:
 # Test (all)
 test: test-backend test-frontend
 
-# Test (backend, inside Docker: requires rclpy)
+# Test (backend: runs on the host; rclpy is not required)
 test-backend:
-	@echo "=== Tests: Backend (Docker) ==="
-	docker compose exec backend bash -c "source /opt/ros/humble/setup.bash && uv sync --extra dev && uv run pytest tests/ -v"
+	@echo "=== Tests: Backend (pytest) ==="
+	cd backend && uv run pytest tests/ -v
 
 # Test (frontend)
 test-frontend:
@@ -161,10 +161,10 @@ test-frontend:
 # Test + coverage (all)
 test-cov: test-cov-backend test-cov-frontend
 
-# Test + coverage (backend, inside Docker)
+# Test + coverage (backend: runs on the host; rclpy is not required)
 test-cov-backend:
-	@echo "=== Tests + Coverage: Backend (Docker) ==="
-	docker compose exec backend bash -c "source /opt/ros/humble/setup.bash && uv sync --extra dev && uv run pytest tests/ -v --cov=app --cov-report=term-missing --cov-fail-under=100"
+	@echo "=== Tests + Coverage: Backend (pytest) ==="
+	cd backend && uv run pytest tests/ -v --cov=app --cov-report=term-missing --cov-fail-under=100
 
 # Test + coverage (frontend)
 test-cov-frontend:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,18 @@
-"""FastAPI application entry point."""
+"""FastAPI application entry point.
+
+Importing this module must not require the ROS 2 runtime: `create_app()` only
+wires routers and middleware, so tests and tooling (OpenAPI export) can import
+it on a host without rclpy. rclpy-dependent modules are imported inside
+`_initialize_services()`, which runs when uvicorn starts the lifespan.
+"""
+
+from __future__ import annotations
 
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -25,9 +34,11 @@ from app.features.upload.router import router as upload_router
 from app.features.validation import load_custom_validators
 from app.features.validation.router import router as validation_router
 from app.infra.ros2 import ROS2Command
-from app.infra.ros2.thread import TopicMonitorThread
 from app.settings import Settings, get_settings
 from app.shared.log_manager import LogManager, set_log_manager
+
+if TYPE_CHECKING:
+    from app.infra.ros2.thread import TopicMonitorThread
 
 # Path to the built frontend files
 FRONTEND_DIR = Path(__file__).resolve().parent.parent / "frontend" / "dist"
@@ -56,18 +67,12 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     _shutdown_services(recorder, monitor_thread)
 
 
-def create_app(settings: Settings | None = None) -> FastAPI:
+def create_app() -> FastAPI:
     """Create and configure the FastAPI application.
-
-    Args:
-        settings: Optional settings override for tests.
 
     Returns:
         The configured FastAPI application.
     """
-    if settings is None:
-        settings = get_settings()
-
     app = FastAPI(
         title="OpenLUTRA",
         description="ROS2 topic recorder for teleoperation robots (ROS2-standard topics)",
@@ -125,6 +130,9 @@ app = create_app()
 
 def _initialize_services() -> tuple[ROS2BagRecorder, TopicMonitorThread]:
     """Initialize all services and register them in the DI container."""
+    # rclpy is only available inside the ROS 2 image; keep it out of module import.
+    from app.infra.ros2 import thread as ros2_thread
+
     settings = get_settings()
     _configure_log_level(settings)
     logger.info("Starting OpenLUTRA")
@@ -142,7 +150,7 @@ def _initialize_services() -> tuple[ROS2BagRecorder, TopicMonitorThread]:
     recorder = ROS2BagRecorder(settings, ros2)
     set_recorder(recorder)
 
-    monitor_thread = TopicMonitorThread(settings, log_manager)
+    monitor_thread = ros2_thread.TopicMonitorThread(settings, log_manager)
     set_monitor(monitor_thread.start())
 
     # Load custom validators (failures do not abort startup).

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,32 +1,39 @@
 """Shared test configuration."""
 
 import logging
+import os
+import tempfile
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# `Settings` requires these two variables. Docker Compose injects them for the
+# running app; default them here so `pytest` is self-contained on any host
+# (Makefile, CI, IDE test runners). Nothing in the test suite creates OUTPUT_DIR.
+os.environ.setdefault("RECORDING_CONFIG", str(REPO_ROOT / "config" / "simulator.yaml"))
+os.environ.setdefault("OUTPUT_DIR", str(Path(tempfile.gettempdir()) / "open-lutra-test-output"))
 
 
 @pytest.fixture(autouse=True)
 def _restore_log_propagation() -> Iterator[None]:
-    """Keep `caplog` working under the ROS 2 environment.
+    """Keep `caplog` working when tests run inside the ROS 2 image (Dev Container).
 
-    Tests run inside the ROS-enabled image with `/opt/ros/humble/setup.bash`
-    sourced, which auto-loads ROS pytest plugins. Loading them imports
-    `launch.logging`, which calls `logging.setLoggerClass(LaunchLogger)`; every
-    `LaunchLogger` sets `propagate = False` in its constructor. With
-    propagation disabled, `app.*` log records never reach the root logger where
-    pytest's `caplog` handler lives, so log-assertion tests see no records.
+    With `/opt/ros/humble/setup.bash` sourced, pytest auto-loads ROS plugins.
+    Loading them imports `launch.logging`, which calls
+    `logging.setLoggerClass(LaunchLogger)`; every `LaunchLogger` sets
+    `propagate = False` in its constructor. With propagation disabled, `app.*`
+    log records never reach the root logger where pytest's `caplog` handler
+    lives, so log-assertion tests see no records.
 
     Restore the standard logger class (so loggers created later propagate
     normally) and re-enable propagation on the `app.*` loggers that already
-    exist from collection-time imports.
+    exist from collection-time imports. On a plain host this is a no-op.
     """
     logging.setLoggerClass(logging.Logger)
     for name, candidate in logging.Logger.manager.loggerDict.items():
         if isinstance(candidate, logging.Logger) and (name == "app" or name.startswith("app.")):
             candidate.propagate = True
     yield
-
-
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """rclpy-dependent tests that fail to import are auto-skipped (importorskip)."""

--- a/backend/tests/dependencies/test_exception_handlers.py
+++ b/backend/tests/dependencies/test_exception_handlers.py
@@ -1,22 +1,17 @@
 """Tests for the exception handlers.
 
 Verifies that each recording exception is mapped to the correct HTTP status code.
-
-NOTE: app.main requires rclpy, so this can only run inside Docker (make test).
 """
 
+from unittest.mock import MagicMock
+
 import pytest
+from fastapi.testclient import TestClient
 
-rclpy = pytest.importorskip("rclpy", reason="rclpy is required (run via 'make test')")
-
-from unittest.mock import MagicMock  # noqa: E402
-
-from fastapi.testclient import TestClient  # noqa: E402
-
-from app.dependencies import set_recorder  # noqa: E402
-from app.dependencies.services import get_recorder  # noqa: E402
-from app.features.recording import AlreadyRecordingError, NotRecordingError, RecorderError  # noqa: E402
-from app.main import create_app  # noqa: E402
+from app.dependencies import set_recorder
+from app.dependencies.services import get_recorder
+from app.features.recording import AlreadyRecordingError, NotRecordingError, RecorderError
+from app.main import create_app
 
 
 @pytest.fixture

--- a/backend/tests/features/config/test_router.py
+++ b/backend/tests/features/config/test_router.py
@@ -1,18 +1,12 @@
-"""Tests for the configuration and system info API endpoints.
+"""Tests for the configuration and system info API endpoints."""
 
-NOTE: app.main requires rclpy, so this can only run inside Docker (make test).
-"""
+from unittest.mock import MagicMock
 
 import pytest
+from fastapi.testclient import TestClient
 
-rclpy = pytest.importorskip("rclpy", reason="rclpy is required (run via 'make test')")
-
-from unittest.mock import MagicMock  # noqa: E402
-
-from fastapi.testclient import TestClient  # noqa: E402
-
-from app.dependencies import set_monitor, set_recorder  # noqa: E402
-from app.main import create_app  # noqa: E402
+from app.dependencies import set_monitor, set_recorder
+from app.main import create_app
 
 
 @pytest.fixture

--- a/backend/tests/features/recording/test_router.py
+++ b/backend/tests/features/recording/test_router.py
@@ -1,26 +1,20 @@
-"""Tests for the recording API endpoints.
+"""Tests for the recording API endpoints."""
 
-NOTE: app.main requires rclpy, so this can only run inside Docker (make test).
-"""
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
+from fastapi.testclient import TestClient
 
-rclpy = pytest.importorskip("rclpy", reason="rclpy is required (run via 'make test')")
-
-from datetime import datetime  # noqa: E402
-from pathlib import Path  # noqa: E402
-from unittest.mock import MagicMock  # noqa: E402
-
-from fastapi.testclient import TestClient  # noqa: E402
-
-from app.dependencies import set_recorder  # noqa: E402
-from app.features.recording import (  # noqa: E402
+from app.dependencies import set_recorder
+from app.features.recording import (
     AlreadyRecordingError,
     NotRecordingError,
     RecorderStatus,
     StopResult,
 )
-from app.main import create_app  # noqa: E402
+from app.main import create_app
 
 
 @pytest.fixture
@@ -121,9 +115,7 @@ class TestStartRecording:
         )
         response = client.post("/api/recording/start", json={"topics": ["/topic"], "task_name": "pick"})
         assert response.status_code == 200
-        mock_recorder.start.assert_called_with(
-            topics=["/topic"], qos_overrides=None, task_name="pick", metadata=None
-        )
+        mock_recorder.start.assert_called_with(topics=["/topic"], qos_overrides=None, task_name="pick", metadata=None)
 
     def test_start_recording_with_metadata(self, client: TestClient, mock_recorder: MagicMock) -> None:
         mock_recorder.get_status.return_value = RecorderStatus(

--- a/backend/tests/features/topics/test_router.py
+++ b/backend/tests/features/topics/test_router.py
@@ -1,22 +1,16 @@
-"""Tests for the topic monitoring API endpoints.
+"""Tests for the topic monitoring API endpoints."""
 
-NOTE: app.main requires rclpy, so this can only run inside Docker (make test).
-"""
+from unittest.mock import MagicMock
 
 import pytest
+from fastapi.testclient import TestClient
 
-rclpy = pytest.importorskip("rclpy", reason="rclpy is required (run via 'make test')")
-
-from unittest.mock import MagicMock  # noqa: E402
-
-from fastapi.testclient import TestClient  # noqa: E402
-
-from app.dependencies import set_monitor, set_recorder  # noqa: E402
-from app.features.topics import (  # noqa: E402
+from app.dependencies import set_monitor, set_recorder
+from app.features.topics import (
     DiscoveredTopic,
     TopicInfo,
 )
-from app.main import create_app  # noqa: E402
+from app.main import create_app
 
 
 @pytest.fixture

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,7 +25,7 @@ This project supports two development approaches.
 | **Host + `make up`** | o (hot reload) | o (Vite HMR) | x | Full-stack development |
 | **Dev Container** | o (directly inside the container) | x (requires separate startup) | o | Backend-focused development |
 
-**Dev Container is recommended for backend development.** rclpy type completion and go-to-definition work, and tests can be executed directly inside the container.
+**Dev Container is recommended when editing rclpy-dependent code** (`backend/app/infra/ros2/topic_node.py`, `thread.py`): rclpy type completion and go-to-definition work there. Backend tests, lint, and type checks run on the host in either approach (see [Testing](#testing)).
 
 ---
 
@@ -162,14 +162,14 @@ If you changed `pyproject.toml`, running `uv sync` inside the container is enoug
 
 ```bash
 make test              # Everything (backend + frontend)
-make test-backend      # Backend only (pytest, inside Docker)
+make test-backend      # Backend only (pytest)
 make test-frontend     # Frontend only (vitest)
 make test-cov          # Everything + coverage
-make test-cov-backend  # Backend + coverage (inside Docker)
+make test-cov-backend  # Backend + coverage
 make test-cov-frontend # Frontend + coverage
 ```
 
-Backend tests run inside the Docker container (rclpy is required).
+Backend tests run on the host with `uv` alone — neither Docker nor rclpy is required. `app.main` imports the rclpy-dependent modules inside the lifespan, so `create_app()` (and therefore every router) is importable without ROS 2. `tests/conftest.py` defaults the `RECORDING_CONFIG` / `OUTPUT_DIR` variables that `Settings` requires, so plain `uv run pytest` and IDE test runners work without a `.env`. The same suite also runs inside the Dev Container.
 
 ### Test Layout
 
@@ -193,7 +193,7 @@ Maintain 100% coverage. For code that cannot be tested, exclude it from coverage
 
 - Endpoint functions are HTTP glue code, so mark them with `# pragma: no cover` and do not write unit tests for them
 - Extract pure logic from routers into separate modules and test those (e.g., `scanner.py`)
-- Integration tests run only inside Docker via `pytest.importorskip("rclpy")`
+- Endpoint wiring (status codes, exception handlers) is covered by `TestClient` tests against `create_app()` with mocked services (`test_router.py`, `test_exception_handlers.py`)
 
 **Rules for writing tests:**
 

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -255,17 +255,17 @@ backend/tests/
 ├── dependencies/
 │   ├── test_path_validators.py          # Path validation (resolve_safe_path, require_dir, require_file)
 │   ├── test_services.py                 # DI dependency functions (get_recorder, get_monitor)
-│   └── test_exception_handlers.py       # Exception handlers [rclpy-dependent]
+│   └── test_exception_handlers.py       # Exception handlers
 ├── features/
 │   ├── recording/
 │   │   ├── conftest.py                  # Recorder fixtures (settings, mock_ros2)
 │   │   ├── test_service.py              # ROS2BagRecorder (start, stop, status, QoS)
-│   │   └── test_router.py               # Recording API endpoints [rclpy-dependent]
+│   │   └── test_router.py               # Recording API endpoints
 │   ├── topics/
 │   │   ├── conftest.py                  # Monitor fixtures (log_manager, mock_subscriber)
 │   │   ├── test_models.py               # TopicStats properties (actual_hz, status, etc.)
 │   │   ├── test_service.py              # TopicMonitorService (discover, message, gap_check)
-│   │   └── test_router.py               # Topic API endpoints [rclpy-dependent]
+│   │   └── test_router.py               # Topic API endpoints
 │   ├── recordings/
 │   │   └── test_scanner.py              # scan_output_dir, read_metadata_summary
 │   ├── analysis/
@@ -275,7 +275,7 @@ backend/tests/
 │   ├── media/
 │   │   └── test_models.py               # JointStateMapping (topic classification for preview)
 │   └── config/
-│       └── test_router.py               # Config API endpoints [rclpy-dependent]
+│       └── test_router.py               # Config API endpoints
 ├── infra/ros2/
 │   ├── test_message.py                  # sanitize_value (message conversion)
 │   └── test_qos.py                      # QoSOverrideFile (YAML generation / deletion)


### PR DESCRIPTION
## Summary

`make test-backend` / `make test-cov-backend` required a running Docker backend because `app.main` imported `app.infra.ros2.thread` (→ `rclpy`) at module level. `create_app()` could not be imported on the host, four test files were skipped via `pytest.importorskip("rclpy")`, and the router / schemas modules they pull in were never imported — leaving host coverage at 96%.

This PR makes the backend suite run on the host with `uv` alone and lets CI enforce 100% coverage.

## Changes

- **`backend/app/main.py`**: import `TopicMonitorThread` lazily inside `_initialize_services()` (the lifespan composition root); keep the name in a `TYPE_CHECKING` block for annotations. `create_app()` only wires routers / middleware and no longer needs rclpy. Also drop the unused `settings` parameter and `get_settings()` call from `create_app()` — the value was never read, and `get_settings()` is not cached, so nothing else observed it. `import app.main` now needs no environment variables.
- **`backend/tests/conftest.py`**: default `RECORDING_CONFIG` / `OUTPUT_DIR` with `os.environ.setdefault` so plain `uv run pytest` and IDE runners work without `.env`; remove the no-op `pytest_collection_modifyitems`.
- **4 test files** (`test_router.py` ×3, `test_exception_handlers.py`): remove the `importorskip("rclpy")` gate, `# noqa: E402`, and "Docker only" notes.
- **Makefile**: `test-backend` / `test-cov-backend` run `cd backend && uv run pytest ...` on the host.
- **CI**: add `--cov=app --cov-fail-under=100` to the pytest step (previously impossible because the host stopped at 96%).
- **Docs**: CLAUDE.md, docs/DEVELOPMENT.md, docs/STRUCTURE.md updated (no more "inside Docker" / `[rclpy-dependent]` wording; Dev Container is now recommended only when editing rclpy-dependent code).

## Verification

- Host (`make test-cov-backend`, with `RECORDING_CONFIG` / `OUTPUT_DIR` unset): **822 passed, 0 skipped, 100% coverage** (was 797 passed / 4 skipped / 96%).
- `ruff check` / `mypy app/` clean.
- `import app.main` succeeds with no environment variables.
- ⚠️ Not yet verified: backend startup inside Docker (`make up`) — Docker was not running on the machine used for this change. The runtime path is unchanged apart from the import site (`from app.infra.ros2 import thread as ros2_thread` inside `_initialize_services()`), but please confirm "All services initialized successfully" appears in the backend log.

## Out of scope

`make generate` still requires a running backend (orval reads `http://localhost:8000/openapi.json`). Making it file-based is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
