### PR TITLE
fix(recording): keep Space bound to recording when a toggle has focus

### DIFF
--- a/frontend/src/features/recording/__tests__/use-record-shortcut.test.ts
+++ b/frontend/src/features/recording/__tests__/use-record-shortcut.test.ts
@@ -11,10 +11,19 @@ vi.mock("../store", () => ({
 
 import { useRecordShortcut } from "../use-record-shortcut";
 
-function dispatchSpace(init: KeyboardEventInit = {}): KeyboardEvent {
-  const event = new KeyboardEvent("keydown", { code: "Space", cancelable: true, ...init });
-  document.dispatchEvent(event);
+function dispatchSpace(init: KeyboardEventInit = {}, target: EventTarget = document): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", { code: "Space", cancelable: true, bubbles: true, ...init });
+  target.dispatchEvent(event);
   return event;
+}
+
+/** Focus a freshly mounted element of the given tag, mirroring a click on a page control. */
+function focusElement(tag: string, attributes: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement(tag);
+  for (const [name, value] of Object.entries(attributes)) el.setAttribute(name, value);
+  document.body.appendChild(el);
+  el.focus();
+  return el;
 }
 
 describe("useRecordShortcut", () => {
@@ -57,25 +66,72 @@ describe("useRecordShortcut", () => {
   });
 
   it("does not fire while a text input is focused", () => {
-    const input = document.createElement("input");
-    document.body.appendChild(input);
-    input.focus();
+    const input = focusElement("input");
     renderHook(() => useRecordShortcut());
 
-    dispatchSpace();
+    dispatchSpace({}, input);
 
     expect(mockToggle).not.toHaveBeenCalled();
   });
 
-  it("does not fire while a button is focused (its native Space click handles it)", () => {
-    const button = document.createElement("button");
-    document.body.appendChild(button);
-    button.focus();
+  it("does not fire while a textarea is focused", () => {
+    const textarea = focusElement("textarea");
     renderHook(() => useRecordShortcut());
 
-    dispatchSpace();
+    dispatchSpace({}, textarea);
 
     expect(mockToggle).not.toHaveBeenCalled();
+  });
+
+  it("does not fire while a contenteditable element is focused", () => {
+    const editable = focusElement("div", { contenteditable: "true", tabindex: "0" });
+    renderHook(() => useRecordShortcut());
+
+    dispatchSpace({}, editable);
+
+    expect(mockToggle).not.toHaveBeenCalled();
+  });
+
+  it("does not fire while focus is inside an open popover or dialog", () => {
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    document.body.appendChild(dialog);
+    const select = document.createElement("select");
+    dialog.appendChild(select);
+    select.focus();
+    renderHook(() => useRecordShortcut());
+
+    dispatchSpace({}, select);
+
+    expect(mockToggle).not.toHaveBeenCalled();
+  });
+
+  it("fires while a button is focused and cancels its native activation", () => {
+    const button = focusElement("button");
+    renderHook(() => useRecordShortcut());
+
+    const event = dispatchSpace({}, button);
+
+    expect(mockToggle).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("fires while a clicked toggle keeps focus (checkbox / switch render as buttons)", () => {
+    const toggle = focusElement("button", { role: "switch", "aria-checked": "false" });
+    renderHook(() => useRecordShortcut());
+
+    dispatchSpace({}, toggle);
+
+    expect(mockToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires while a select is focused, so the delay dropdown does not swallow Space", () => {
+    const select = focusElement("select");
+    renderHook(() => useRecordShortcut());
+
+    dispatchSpace({}, select);
+
+    expect(mockToggle).toHaveBeenCalledTimes(1);
   });
 
   it("removes the listener on unmount", () => {

--- a/frontend/src/features/recording/use-record-shortcut.ts
+++ b/frontend/src/features/recording/use-record-shortcut.ts
@@ -3,23 +3,26 @@
  * Mounted by RecordButton, which renders only on the recorder page, so the shortcut is
  * scoped to that page and torn down on navigation. Targets hands-free operation (e.g. a
  * foot pedal that emits Space) per issue #34.
+ *
+ * Space belongs to the recorder page: the listener runs in the capture phase and cancels the
+ * default, so buttons, checkboxes and switches never consume it — clicking a toggle leaves
+ * focus on it, and the next Space must still reach recording. Cancelling the keydown default
+ * also suppresses the native Space-to-click, so a focused Record button toggles once.
  */
 import { useEffect } from "react";
 import { useRecordingStore } from "./store";
 
-/** True when focus is on an element that natively consumes Space or text input. */
-function isInteractiveTarget(el: Element | null): boolean {
+/** True when focus is on an element that needs Space for its own input. */
+function ownsSpace(el: Element | null): boolean {
   if (!el) return false;
-  if (
-    el instanceof HTMLInputElement ||
-    el instanceof HTMLTextAreaElement ||
-    el instanceof HTMLSelectElement ||
-    el instanceof HTMLButtonElement
-  ) {
-    return true;
-  }
-  if (el instanceof HTMLElement && el.isContentEditable) return true;
-  return el.closest('[role="button"], [role="textbox"]') !== null;
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) return true;
+  // Editable text hosts, plus popovers and dialogs (metadata panel, confirmations) that run
+  // their own keyboard handling — the shortcut would fire behind the open layer.
+  return (
+    el.closest(
+      '[role="textbox"], [contenteditable]:not([contenteditable="false"]), [role="dialog"], [role="alertdialog"]',
+    ) !== null
+  );
 }
 
 export function useRecordShortcut(): void {
@@ -27,14 +30,13 @@ export function useRecordShortcut(): void {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.code !== "Space" || e.repeat) return;
       if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
-      // Skip while typing or when an element already handles Space (also avoids a double-toggle
-      // when the Record button itself is focused — its native Space click handles that case).
-      if (isInteractiveTarget(document.activeElement)) return;
-      // Space owns the recorder page; suppress the default page scroll.
+      // Skip while typing or while an overlay owns the keyboard.
+      if (ownsSpace(document.activeElement)) return;
+      // Suppress the page scroll and any activation of the focused control.
       e.preventDefault();
       useRecordingStore.getState().toggle();
     };
-    document.addEventListener("keydown", onKeyDown);
-    return () => document.removeEventListener("keydown", onKeyDown);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
   }, []);
 }


### PR DESCRIPTION
Closes #92.

## Problem

Clicking or tapping a toggle on the recorder page leaves focus on it, and the Radix Checkbox / Switch primitives render as `<button role="checkbox">` / `<button role="switch">`. The Space shortcut yielded to any focused button, so the browser's native "Space activates the focused button" took the key and the next Space flipped that toggle again instead of starting a recording — reported from the field, and worst for the hands-free foot-pedal operation the shortcut exists for (#34).

Affects the topic checkboxes, the "Stop while recording" switch, and the notification sound toggle.

## Change

**`frontend/src/features/recording/use-record-shortcut.ts`**

- Subscribe `keydown` in the **capture phase** and cancel the default before the focused control sees the key. Cancelling the keydown default also suppresses the native Space-to-click, so a focused Record button toggles exactly once and the previous "skip when the Record button is focused" special case is gone.
- Narrow the exemption list to text entry only — `<input>`, `<textarea>`, `contenteditable`, `role="textbox"` — plus anything inside an open popover or dialog (`role="dialog"` / `role="alertdialog"`: the Metadata panel, confirmations), which runs its own keyboard handling and would otherwise see the shortcut fire behind the open layer.
- `<button>`, `role="button"` and `<select>` (the DELAY dropdown) no longer take Space. The dropdown stays operable with Enter, the arrow keys and the mouse.

Trade-off accepted (see #92 for the alternatives that were rejected): keyboard-only users can no longer activate the topic checkboxes or the "Stop while recording" switch with Space, because Radix disables Enter on those controls per WAI-ARIA. Adding Enter activation to `components/ui/checkbox.tsx` / `components/ui/switch.tsx` restores it later without giving Space back.

## Verification

- `use-record-shortcut.test.ts` rewritten around the new contract: Space fires while a `<button>`, a `role="switch"` toggle or a `<select>` holds focus (and reports `defaultPrevented`), and stays silent for `<input>`, `<textarea>`, `contenteditable`, and focus inside a `role="dialog"`. The old "does not fire while a button is focused" case is inverted.
- `make format-frontend`, `make lint-frontend` (tsc + biome) and `make test-frontend` are clean — 33 files, 294 tests.
- Manual check on the recording page still to do by a reviewer: tap a toggle then press Space (recording starts), type a space in the task name field (a space is inserted), press Space with the Metadata panel open (nothing starts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
