### PR TITLE
chore(github): add issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,242 @@
+name: Bug report
+description: Something is broken or behaves differently from what you expected
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. **Japanese or English is fine.**
+
+        Before you start:
+
+        - Search the [existing issues](https://github.com/fastlabel/open-lutra/issues?q=is%3Aissue) for a duplicate.
+        - Check [Troubleshooting in docs/SETUP.md](https://github.com/fastlabel/open-lutra/blob/main/docs/SETUP.md#troubleshooting) — topics not showing up, Docker build failures, and recordings not being saved are covered there.
+        - **Do not paste your `.env` file.** It can contain credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, …). Paste the output of `GET /api/config` instead, and redact keys, internal hostnames, and any other confidential values from the logs you attach.
+        - Found a security vulnerability? **Do not open a public issue** — follow [SECURITY.md](https://github.com/fastlabel/open-lutra/blob/main/SECURITY.md).
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched the existing issues and did not find a duplicate.
+          required: true
+        - label: I removed credentials and other confidential information from everything I pasted below.
+          required: true
+        - label: This is not a security vulnerability report.
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What goes wrong, in one or two sentences.
+      placeholder: Recording stops after ~30 seconds and the UI shows no error.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Pick the closest one. If you are unsure, choose "Other / not sure".
+      options:
+        - Recording (start / stop, ros2 bag record)
+        - Live topic monitoring (Hz, miss rate, SSE)
+        - Quality analysis / timeline
+        - Recordings browser (list, detail, delete)
+        - Preview (MP4 / joint data)
+        - Validation
+        - Upload (S3 / local destination)
+        - LeRobot export
+        - Setup / configuration (.env, config YAML, Docker)
+        - ROS2 / DDS (topic discovery, custom message types)
+        - UI (general layout, shortcuts, appearance)
+        - Documentation
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Number the steps so we can follow them exactly.
+      placeholder: |
+        1. `make prod-up`
+        2. Select the 4 camera topics in the left panel
+        3. Press the record button
+        4. Wait ~30 seconds
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the exact error message or toast text if there is one.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: How often does it happen?
+      options:
+        - Every time
+        - Intermittently
+        - Happened once, could not reproduce
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Environment
+
+        OpenLUTRA runs on your own machine next to your own robot, so this section is where most bugs are actually resolved. Please fill it in even if the problem looks unrelated to your setup.
+
+  - type: input
+    id: version
+    attributes:
+      label: OpenLUTRA version
+      description: "Release tag and the commit you are on (`git rev-parse --short HEAD`). Docker images are not published yet, so the commit is what identifies your build."
+      placeholder: v0.2.0 (4efe813)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: run-mode
+    attributes:
+      label: How are you running it?
+      options:
+        - "Development: make up (bundled simulator, bridge network)"
+        - "Development: make dev-up (VITE_DEV_MODE=true)"
+        - "Production: make prod-up (network_mode: host)"
+        - Other (please describe under "Additional context")
+    validations:
+      required: true
+
+  - type: dropdown
+    id: data-source
+    attributes:
+      label: What is publishing the topics?
+      options:
+        - Bundled simulator
+        - Physical robot
+        - Neither — I am only browsing existing recordings
+        - Other (please describe under "Additional context")
+    validations:
+      required: true
+
+  - type: input
+    id: host-os
+    attributes:
+      label: Host OS and architecture
+      description: The OS running Docker, not the OS inside the container.
+      placeholder: Ubuntu 22.04 / x86_64
+    validations:
+      required: true
+
+  - type: input
+    id: docker
+    attributes:
+      label: Docker and Docker Compose versions
+      description: "Output of `docker version --format '{{.Server.Version}}'` and `docker compose version --short`."
+      placeholder: Docker 27.3.1 / Compose 2.29.7
+    validations:
+      required: true
+
+  - type: textarea
+    id: api-config
+    attributes:
+      label: Output of GET /api/config
+      description: "Run `curl -s localhost:8000/api/config`. This reports `ros_domain_id`, `robot_name`, `stamp_quality`, and `upload_enabled` — it contains no credentials."
+      render: json
+    validations:
+      required: true
+
+  - type: textarea
+    id: recording-config
+    attributes:
+      label: Recording config YAML
+      description: "The `config/*.yaml` selected by `RECORDING_CONFIG`. Strongly recommended for anything involving recording, live monitoring, or quality analysis — `expected_hz_patterns`, `stamp_quality`, and `recording_start_delay_sec` are frequent root causes. Trim topic lists or field names you cannot share."
+      render: yaml
+
+  - type: textarea
+    id: robot
+    attributes:
+      label: Robot and hardware details
+      description: |
+        For reports involving a physical robot. Whatever you can share of:
+        - Robot model / vendor
+        - ROS2 distribution on the robot side
+        - `RMW_IMPLEMENTATION` on the robot side (OpenLUTRA uses `rmw_fastrtps_cpp`)
+        - Cameras: model and count (e.g. RealSense D435 x4 @ 30Hz)
+        - Whether you build custom ROS2 message packages into the image (see `examples/custom_ros2_messages/`)
+      placeholder: |
+        Robot: <vendor/model>
+        ROS2 (robot side): Humble
+        RMW: rmw_fastrtps_cpp
+        Cameras: RealSense D435 x4 @ 30Hz
+        Custom message packages: yes (my_robot_msgs)
+
+  - type: textarea
+    id: scale
+    attributes:
+      label: Machine specs and recording scale
+      description: |
+        Useful for long recordings, preview generation, and export problems. Whatever applies:
+        - CPU / RAM, and free space on `OUTPUT_DIR`
+        - Recording length, number of topics, number of cameras, resulting MCAP size
+      placeholder: |
+        CPU: Core i7-12700 / RAM: 32GB / free space on OUTPUT_DIR: 120GB
+        Recording: 5 min, 8 topics, 4 cameras, ~6GB MCAP
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      description: For UI or live-monitoring (SSE) problems.
+      placeholder: Chrome 141
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: "Backend / frontend logs (`make logs` or `make prod-logs`) and the browser console. Paste the relevant portion around the failure, with confidential values redacted."
+      render: shell
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Additional diagnostics
+      description: |
+        Attach whichever is relevant:
+        - `docker compose exec backend ros2 doctor --report` — for topic discovery / DDS problems
+        - `SIM_MODE` value — when reproducing with the simulator
+        - Upload destination type (`s3` / `local` / MinIO) — **never the credentials**
+        - Variables you changed from their defaults in `.env` (names and non-secret values only)
+        - `recording_meta.json` or the quality report of the affected recording
+
+  - type: input
+    id: regression
+    attributes:
+      label: Last version that worked
+      description: If this used to work, the tag or commit where it did.
+      placeholder: v0.1.0 / 60c01f5
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, screen recordings, a workaround you found, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/fastlabel/open-lutra/blob/main/SECURITY.md
+    about: Report vulnerabilities privately by email. Please do not open a public issue.
+  - name: Setup and troubleshooting
+    url: https://github.com/fastlabel/open-lutra/blob/main/docs/SETUP.md#troubleshooting
+    about: Topics not showing up, Docker build failures, recordings not being saved — start here.
+  - name: Documentation
+    url: https://github.com/fastlabel/open-lutra/blob/main/docs/
+    about: Architecture, setup, and domain notes (ROS2 / DDS, MCAP, quality analysis, LeRobot export).
+  - name: Contributing and pull request policy
+    url: https://github.com/fastlabel/open-lutra/blob/main/CONTRIBUTING.md
+    about: Issues are welcome. External pull requests are not accepted at this stage.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,83 @@
+name: Feature request
+description: Suggest a capability, an improvement, or a use case you want supported
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests and use-case reports are very welcome — they shape the project's direction. **Japanese or English is fine.**
+
+        Two notes before you file:
+
+        - Search the [existing issues](https://github.com/fastlabel/open-lutra/issues?q=is%3Aissue) so we can consolidate related requests.
+        - OpenLUTRA is pre-1.0 and **external pull requests are not accepted at this stage** ([CONTRIBUTING.md](https://github.com/fastlabel/open-lutra/blob/main/CONTRIBUTING.md)). Filing this issue is exactly the right way to contribute the idea.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the difficulty you hit today, before describing a solution. What do you have to do now, and why is that a problem?
+      placeholder: After each session I manually check which recordings are missing a camera topic, because a failed recording only becomes visible when I open it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case and workflow
+      description: Where this sits in your work — teaching, teleoperation, dataset preparation for training, review, handoff to another team, and so on.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like it to do?
+      description: The behavior you have in mind. A rough sketch is fine — no need for an implementation plan.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Related area
+      options:
+        - Recording (start / stop, ros2 bag record)
+        - Live topic monitoring (Hz, miss rate, SSE)
+        - Quality analysis / timeline
+        - Recordings browser (list, detail, delete)
+        - Preview (MP4 / joint data)
+        - Validation
+        - Upload (S3 / local destination)
+        - LeRobot export
+        - Setup / configuration (.env, config YAML, Docker)
+        - ROS2 / DDS (topic discovery, custom message types)
+        - UI (general layout, shortcuts, appearance)
+        - Documentation
+        - Other / new area
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives and current workaround
+      description: Other approaches you considered, and how you cope today (an external script, a manual check, another tool).
+
+  - type: textarea
+    id: scale
+    attributes:
+      label: Operating context
+      description: |
+        Helps us size the request against real usage. Whatever you can share:
+        - Number of topics / Hz / number of cameras
+        - How much data you record per day, and for how long per session
+        - How many people or machines are involved
+        - What consumes the data downstream (LeRobot, a custom training pipeline, an annotation tool, …)
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to related tools or prior art that behave the way you want (rosbag2, Foxglove, LeRobot, MCAP tooling, …), or to related issues.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,87 @@
+name: Question / help
+description: Ask about usage, configuration, or expected behavior
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Questions are welcome. **Japanese or English is fine.**
+
+        A couple of places worth checking first:
+
+        - [docs/SETUP.md](https://github.com/fastlabel/open-lutra/blob/main/docs/SETUP.md) — prerequisites, environment variables, recording config YAML, and a troubleshooting section
+        - [docs/domain/](https://github.com/fastlabel/open-lutra/blob/main/docs/domain/index.md) — ROS2 / DDS gaps, MCAP, quality analysis, metadata, upload, LeRobot export
+
+        **Do not paste your `.env` file** — it can contain credentials. Redact keys and internal hostnames from anything you attach.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to do?
+      description: The task behind the question. Knowing the goal often leads to a better answer than the question alone.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you already read or tried?
+      description: Documentation pages you looked at, settings you changed, commands you ran, and what happened.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: OpenLUTRA version
+      description: "Release tag and commit (`git rev-parse --short HEAD`)."
+      placeholder: v0.2.0 (4efe813)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: run-mode
+    attributes:
+      label: How are you running it?
+      options:
+        - "Development: make up (bundled simulator, bridge network)"
+        - "Development: make dev-up (VITE_DEV_MODE=true)"
+        - "Production: make prod-up (network_mode: host)"
+        - Not running it yet / evaluating
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: data-source
+    attributes:
+      label: What is publishing the topics?
+      options:
+        - Bundled simulator
+        - Physical robot
+        - Neither — I am only browsing existing recordings
+        - Not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant configuration
+      description: "The `config/*.yaml` selected by `RECORDING_CONFIG`, or the output of `curl -s localhost:8000/api/config`. Redact anything you cannot share."
+      render: yaml
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or error messages
+      description: "From `make logs` / `make prod-logs`, or the browser console."
+      render: shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,11 @@ We welcome any of the following kinds of Issue. Either Japanese or English is fi
 - Unclear or incorrect points in the documentation
 - Reports related to ROS2 / MCAP compatibility
 
-### Information that helps with bug reports
+Pick a template on the [New Issue](https://github.com/fastlabel/open-lutra/issues/new/choose) page and fill it in — each template asks for exactly the information we need in order to act on the report.
 
-- Steps to reproduce
-- Expected behavior and actual behavior
-- Environment (OS / Docker version / ROS2 distribution / robot model, and any other relevant details)
-- Logs and error messages (please redact any confidential information)
+Because OpenLUTRA runs on your own machine alongside your own robot, the environment section of the bug report template is what most investigations hinge on. Please fill it in even when the problem looks unrelated to your setup.
+
+> **Do not paste your `.env` file into an Issue** — it can contain credentials such as `AWS_ACCESS_KEY_ID`. The templates point at safe alternatives (for example the output of `GET /api/config`), and confidential values should be redacted from any log you attach.
 
 ## Plans for when Pull Requests are opened
 


### PR DESCRIPTION
## Summary

Adds `.github/ISSUE_TEMPLATE/` with three YAML issue forms and a `config.yml`, and points `CONTRIBUTING.md` at them.

| File | Applied label | Fields | Required |
|---|---|---|---|
| `bug_report.yml` | `bug` | 21 + 3 pre-flight checks | 13 |
| `feature_request.yml` | `enhancement` | 7 | 4 |
| `question.yml` | `question` | 8 | 6 |
| `config.yml` | — | 4 contact links | — |

## Why these fields

OpenLUTRA runs on the reporter's own machine next to their own robot, and Docker images are not published — so the environment is both the main source of variation and the thing a report most often omits. The bug report form requires the axes that actually decide triage:

- **Version and commit** — source distribution means the commit identifies the build, not the tag alone.
- **Run mode** — `make up` (simulator, bridge network) vs `make prod-up` (`network_mode: host`) behaves differently for DDS discovery.
- **Topic source** — simulator / physical robot / browsing existing recordings separates robot-dependent reports in one field.
- **Host OS and Docker versions** — host networking is unavailable on macOS, a recurring DDS pitfall.
- **`GET /api/config` output** — one paste covering `ros_domain_id`, `robot_name`, `stamp_quality`, and `upload_enabled`, and it carries no credentials.

Robot hardware, machine specs and recording scale, browser, logs, and diagnostics (`ros2 doctor --report`, `SIM_MODE`, upload destination type) are optional, with prompts describing what to include. The recording config YAML is optional but flagged as strongly recommended for recording, live-monitoring, and quality reports — `expected_hz_patterns`, `stamp_quality`, and `recording_start_delay_sec` are frequent root causes.

## Notes

- Each form has an **area dropdown** mirroring the `area:*` labels (already created on the repository). Issue forms cannot map a dropdown answer to a label, so `area:*` is applied at triage; the forms statically apply `bug` / `enhancement` / `question` only.
- Forms tell reporters **not to paste `.env`** (it can hold `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) and to redact logs. `config.yml` routes vulnerability reports to `SECURITY.md` so they do not land in public issues.
- `blank_issues_enabled: true` keeps a path open for report types without a dedicated form, such as documentation fixes and ROS2 / MCAP compatibility reports. Documentation is also an option in the area dropdown.
- `CONTRIBUTING.md` no longer repeats the bug-report field list; it links to the forms instead, per the repository's DRY documentation rule. No form invites a pull request, matching the current "issues welcome, external PRs not accepted" stance.

## Test plan

- [x] All four files parse as YAML; every element uses a valid issue-form type, every non-markdown element has a label, dropdowns have options, and field ids are unique within a file.
- [ ] After merge, confirm the forms render on the New Issue page and that the applied labels resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)