### PR TITLE
chore(github): route questions to Discussions Q&A

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,19 +1,35 @@
-name: Question / help
-description: Ask about usage, configuration, or expected behavior
-title: "[Question]: "
-labels: ["question"]
 body:
   - type: markdown
     attributes:
       value: |
         Questions are welcome. **Japanese or English is fine.**
 
-        A couple of places worth checking first:
+        A few places worth checking first:
 
+        - [Existing Q&A discussions](https://github.com/fastlabel/open-lutra/discussions/categories/q-a) — someone may have hit the same thing.
         - [docs/SETUP.md](https://github.com/fastlabel/open-lutra/blob/main/docs/SETUP.md) — prerequisites, environment variables, recording config YAML, and a troubleshooting section
         - [docs/domain/](https://github.com/fastlabel/open-lutra/blob/main/docs/domain/index.md) — ROS2 / DDS gaps, MCAP, quality analysis, metadata, upload, LeRobot export
 
-        **Do not paste your `.env` file** — it can contain credentials. Redact keys and internal hostnames from anything you attach.
+        Two things that do **not** belong here:
+
+        - **Security vulnerabilities** — do not post them publicly. Follow [SECURITY.md](https://github.com/fastlabel/open-lutra/blob/main/SECURITY.md) and report privately by email.
+        - **Bug reports and feature requests** — open an [issue](https://github.com/fastlabel/open-lutra/issues/new/choose) instead, so they can be labeled and tracked.
+
+        **Do not paste your `.env` file.** It can contain credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, …). Redact keys, internal hostnames, and any other confidential values from anything you attach.
+
+        OpenLUTRA is pre-1.0 and **external pull requests are not accepted at this stage** ([CONTRIBUTING.md](https://github.com/fastlabel/open-lutra/blob/main/CONTRIBUTING.md)). Asking here is exactly the right way to engage with the project.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched the existing discussions and issues and did not find an answer.
+          required: true
+        - label: I removed credentials and other confidential information from everything I pasted below.
+          required: true
+        - label: This is not a security vulnerability report.
+          required: true
 
   - type: textarea
     id: question

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,14 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Question / help
+    url: https://github.com/fastlabel/open-lutra/discussions/categories/q-a
+    about: Usage, configuration, or expected behavior — ask in Discussions Q&A rather than opening an issue.
+  - name: Show and tell
+    url: https://github.com/fastlabel/open-lutra/discussions/categories/show-and-tell
+    about: Share your setup, robot configuration, or what you built on top of OpenLUTRA.
   - name: Security vulnerability
     url: https://github.com/fastlabel/open-lutra/blob/main/SECURITY.md
-    about: Report vulnerabilities privately by email. Please do not open a public issue.
+    about: Report vulnerabilities privately by email. Please do not open a public issue or discussion.
   - name: Setup and troubleshooting
     url: https://github.com/fastlabel/open-lutra/blob/main/docs/SETUP.md#troubleshooting
     about: Topics not showing up, Docker build failures, recordings not being saved — start here.
@@ -11,4 +17,4 @@ contact_links:
     about: Architecture, setup, and domain notes (ROS2 / DDS, MCAP, quality analysis, LeRobot export).
   - name: Contributing and pull request policy
     url: https://github.com/fastlabel/open-lutra/blob/main/CONTRIBUTING.md
-    about: Issues are welcome. External pull requests are not accepted at this stage.
+    about: Issues and discussions are welcome. External pull requests are not accepted at this stage.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,23 +2,24 @@
 
 OpenLUTRA is an open-source project published by FastLabel Inc. Thank you for your interest in the project.
 
-> English speakers welcome. Issues may be filed in either Japanese or English.
+> English speakers welcome. Issues and discussions may be written in either Japanese or English.
 
 ## Current Stance
 
 | Category | Status |
 |---|---|
-| **Issues (bug reports / feature requests / questions)** | **Welcome** |
+| **Issues (bug reports / feature requests)** | **Welcome** |
+| **Discussions (questions, use-case sharing)** | **Welcome** |
 | **Pull Requests (from external contributors)** | **Not accepted at this stage** (see below for the reason) |
-| **Security vulnerability reports** | Please follow the procedure in [SECURITY.md](./SECURITY.md) rather than filing a public issue |
+| **Security vulnerability reports** | Please follow the procedure in [SECURITY.md](./SECURITY.md) rather than posting a public issue or discussion |
 
 OpenLUTRA is in an early phase. Many aspects of the project — including its design direction, data formats, APIs, UI, and quality-analysis metric definitions — may still change significantly. In order to build a solid foundation through careful internal discussion of these aspects, we are not yet accepting Pull Requests from external contributors. We plan to open up Pull Request submissions once the codebase has stabilized and we have the processes in place to make full use of external contributions.
 
-That said, **reports, suggestions, and questions submitted as Issues are always very welcome**. Bug reports, feature requests, use-case sharing, compatibility information around ROS2 / MCAP, and other forms of feedback are all enormously helpful in shaping the direction of the project. Even while direct code contributions via Pull Request are not yet open, we strongly encourage you to engage with the project through Issues.
+That said, **reports, suggestions, and questions are always very welcome**. Bug reports, feature requests, use-case sharing, compatibility information around ROS2 / MCAP, and other forms of feedback are all enormously helpful in shaping the direction of the project. Even while direct code contributions via Pull Request are not yet open, we strongly encourage you to engage with the project through Issues and Discussions.
 
 ## Filing an Issue
 
-We welcome any of the following kinds of Issue. Either Japanese or English is fine.
+Issues track work that is planned or in progress. We welcome any of the following. Either Japanese or English is fine.
 
 - Bug reports
 - Feature requests and use-case proposals
@@ -29,7 +30,15 @@ Pick a template on the [New Issue](https://github.com/fastlabel/open-lutra/issue
 
 Because OpenLUTRA runs on your own machine alongside your own robot, the environment section of the bug report template is what most investigations hinge on. Please fill it in even when the problem looks unrelated to your setup.
 
-> **Do not paste your `.env` file into an Issue** — it can contain credentials such as `AWS_ACCESS_KEY_ID`. The templates point at safe alternatives (for example the output of `GET /api/config`), and confidential values should be redacted from any log you attach.
+## Asking a Question
+
+Questions about usage, configuration, or expected behavior belong in [Discussions → Q&A](https://github.com/fastlabel/open-lutra/discussions/categories/q-a), not in the issue tracker. An answer there can be marked as accepted, so the next person with the same question finds it.
+
+The Q&A form asks for your version, how you are running OpenLUTRA, and what is publishing your topics — the same environment axes that decide most answers. Please search the existing discussions and check [Troubleshooting in docs/SETUP.md](./docs/SETUP.md#troubleshooting) first.
+
+[Discussions → Show and tell](https://github.com/fastlabel/open-lutra/discussions/categories/show-and-tell) is the place to share your setup, your robot configuration, or anything you built on top of OpenLUTRA.
+
+> **Do not paste your `.env` file into an Issue or a Discussion** — it can contain credentials such as `AWS_ACCESS_KEY_ID`. The templates point at safe alternatives (for example the output of `GET /api/config`), and confidential values should be redacted from any log you attach.
 
 ## Plans for when Pull Requests are opened
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 > **Release status — pre-1.0 (v0.2.0, beta).** APIs, data formats, and the CLI/UI may change without notice. Pin a specific version for any production use.
 
-[Quickstart](#quickstart) · [Documentation](#documentation) · [Issues](https://github.com/fastlabel/open-lutra/issues) · [Security](./SECURITY.md)
+[Quickstart](#quickstart) · [Documentation](#documentation) · [Issues](https://github.com/fastlabel/open-lutra/issues) · [Discussions](https://github.com/fastlabel/open-lutra/discussions) · [Security](./SECURITY.md)
 
 <!-- TBD: hero screenshot or short demo GIF (recording page in action) -->
 
@@ -137,16 +137,19 @@ Nothing on this list is committed — these are directions we are currently expl
 - **Richer validation and quality analysis** — expand the set of built-in validators and quality metrics, and surface more actionable diagnostics in the UI.
 - **Recording labeling** — attach labels, tags, and review status to recordings to organize datasets for downstream training.
 - **Seamless storage integrations** — first-class support for shipping recorded files to various storage backends (object stores, dataset platforms, etc.).
-- **etc.** — feedback via [issues](https://github.com/fastlabel/open-lutra/issues) is welcome.
+- **etc.** — feedback via [issues](https://github.com/fastlabel/open-lutra/issues) and [discussions](https://github.com/fastlabel/open-lutra/discussions) is welcome.
 
 ## Support
 
-- File an issue at <https://github.com/fastlabel/open-lutra/issues>. Bug reports, feature requests, and questions are welcome in English or Japanese.
-- For security reports, see [SECURITY.md](./SECURITY.md) — please do not open a public issue.
+- **Questions about usage, configuration, or expected behavior** — ask in [Discussions → Q&A](https://github.com/fastlabel/open-lutra/discussions/categories/q-a).
+- **Bugs and feature requests** — file an [issue](https://github.com/fastlabel/open-lutra/issues/new/choose).
+- **Your setup or what you built with OpenLUTRA** — share it in [Discussions → Show and tell](https://github.com/fastlabel/open-lutra/discussions/categories/show-and-tell).
+- English or Japanese is fine for all of the above.
+- For security reports, see [SECURITY.md](./SECURITY.md) — please do not post them publicly.
 
 ## Contributing
 
-External pull requests are **not accepted at this stage**. Issues are welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md).
+External pull requests are **not accepted at this stage**. Issues and discussions are welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 <!-- TBD: add CODE_OF_CONDUCT.md (e.g. Contributor Covenant) and link here before opening external contributions. -->
 <!-- TBD: add GOVERNANCE.md describing the maintainer / decision-making model before opening external contributions. -->


### PR DESCRIPTION
## Summary

Discussions is now enabled on the repository (Wiki disabled at the same time). This wires the repository files to it.

| File | Change |
|---|---|
| `.github/DISCUSSION_TEMPLATE/q-a.yml` | **new** — question intake, ported from the issue form |
| `.github/ISSUE_TEMPLATE/question.yml` | **deleted** |
| `.github/ISSUE_TEMPLATE/config.yml` | contact links now route questions and use-case sharing to Discussions |
| `CONTRIBUTING.md` | stance table gains a Discussions row; new "Asking a Question" section |
| `README.md` | header nav, Support, and Contributing point at Discussions |

## Why questions move out of the issue tracker

With Discussions on, `question.yml` and the Q&A category would be two receivers for the same reports — the reporter has to guess, and both need triage. Splitting them by what the entry *is* rather than what it is *about*:

- **Issue** — work that is planned or in progress (bugs, feature requests). Labels, milestones, and PR links matter.
- **Discussion Q&A** — a question that has an answer, not a task. The accepted-answer marker makes the next reader's search succeed, which an issue cannot do.

No `question`-labeled issue is currently open, so nothing needs converting. The `question` label is kept for triage.

## The discussion form keeps the environment questions

OpenLUTRA runs on the reporter's own machine next to their own robot, so version, run mode (`make up` vs `make prod-up`), and topic source decide most answers. `q-a.yml` requires the same fields `question.yml` did, and adds pre-flight checkboxes that the issue form already had for bug reports:

- searched existing discussions and issues
- removed credentials from everything pasted
- this is not a security vulnerability report

Discussions have no `config.yml` equivalent, so the guardrails that `config.yml` provides on the issue side are stated in the form itself: vulnerabilities go to `SECURITY.md` privately, bugs and feature requests go to the issue tracker, `.env` is never pasted, and external pull requests are not accepted at this stage.

## Notes

- Discussion category forms are matched to a category by filename, so `q-a.yml` binds to the `q-a` slug. They support `body` / `title` / `labels` only — no `name` or `description`, which the category itself provides.
- The form applies no label; the category is the classification, and `area:*` stays a triage action as with issues.

## Test plan

- [x] Both changed YAML files parse; every non-markdown element has a label, dropdowns have options, ids are unique within a file.
- [ ] After merge, confirm the form renders when starting a Q&A discussion and that the `config.yml` links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)