### PR TITLE
docs: add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,87 @@
+# Contributor Covenant Code of Conduct
+
+> An official Japanese translation of Contributor Covenant 2.1 is available at
+> <https://www.contributor-covenant.org/ja/version/2/1/code_of_conduct/>.
+> The English text in this file is the authoritative version for OpenLUTRA.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at `openlutra-contact@fastlabel.ai`. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ OpenLUTRA is an open-source project published by FastLabel Inc. Thank you for yo
 
 > English speakers welcome. Issues and discussions may be written in either Japanese or English.
 
+## Code of Conduct
+
+Everyone taking part in OpenLUTRA's Issues, Discussions, and other community spaces is expected to follow the [Code of Conduct](./CODE_OF_CONDUCT.md), which also covers how to report unacceptable behavior.
+
 ## Current Stance
 
 | Category | Status |

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ Nothing on this list is committed — these are directions we are currently expl
 
 External pull requests are **not accepted at this stage**. Issues and discussions are welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-<!-- TBD: add CODE_OF_CONDUCT.md (e.g. Contributor Covenant) and link here before opening external contributions. -->
+Everyone taking part in these spaces is expected to follow our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
 <!-- TBD: add GOVERNANCE.md describing the maintainer / decision-making model before opening external contributions. -->
 
 ## License


### PR DESCRIPTION
## Summary

Adds `CODE_OF_CONDUCT.md` at the repository root, based on [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), and links it from `README.md` and `CONTRIBUTING.md`.

Closes #101.

Issue forms structure what a reporter writes; a discussion thread does not. Discussions is where an unstructured conversation can actually go wrong, and today there is no document to point at when it does. This is independent of the "external pull requests are not accepted at this stage" policy — the document is needed for the conversation that is already open, not for the code contributions that are not.

## Text

The body is Contributor Covenant 2.1 taken verbatim from the canonical source (`EthicalSource/contributor_covenant`, `release` branch, `content/version/2/1/code_of_conduct.md`), with the TOML front matter stripped. The generated file was diffed against that source; the diff is exactly the two deviations below and nothing else.

The four-step enforcement ladder is kept as published rather than rewritten for a team of this size. Much of the value of adopting a well-known document is that a reader recognizes it and can predict its contents without reading it closely — local edits to the enforcement section spend exactly that, and then have to be explained.

### Deviation 1 — reporting address

`[INSERT CONTACT METHOD]` is filled with `openlutra-contact@fastlabel.ai`, the address `SECURITY.md` already uses.

A conduct report and a vulnerability report do land in different hands internally, so this was a deliberate choice rather than a default. Sharing the address keeps one public contact point to maintain and one that already has an operational owner; the internal routing is our problem, and it is not improved by making a reporter pick the right of two addresses under stress. If the volume or the sensitivity ever justifies a dedicated alias, swapping it is a one-line change.

### Deviation 2 — Japanese translation link

A note directly under the H1 links the [official Japanese translation](https://www.contributor-covenant.org/ja/version/2/1/code_of_conduct/) and states that the English text in this file is authoritative.

The repository is English-only and the body stays English, but the Q&A form and Discussions both accept Japanese. A reader who is invited to participate in Japanese should not have to parse the English original to know what they are agreeing to. Linking the upstream translation rather than vendoring one keeps the file single-source — no second copy to re-sync if the text is ever revised.

## Links

- `README.md` — the `<!-- TBD: add CODE_OF_CONDUCT.md ... -->` placeholder is replaced by a link in the Contributing section.
- `CONTRIBUTING.md` — a short `## Code of Conduct` section above `## Current Stance`.

Neither repeats the reporting address; both link to the document that carries it.

## Deliberately not in scope

- **`GOVERNANCE.md`.** The adjacent `<!-- TBD: add GOVERNANCE.md ... -->` in `README.md` is left in place.
- **`.github/ISSUE_TEMPLATE/config.yml`.** A `contact_links` entry for the Code of Conduct would surface it on the New Issue page, but it is outside the issue's scope. Worth a follow-up if we want it reachable from there — the issue's own framing (Discussions is the risk surface) argues for it.
- **A dedicated conduct alias.** See Deviation 1.

## Verification

- The generated file diffs clean against the canonical 2.1 text apart from the two intended changes.
- Link targets (`./CODE_OF_CONDUCT.md`, `./CONTRIBUTING.md`) exist at the paths referenced.
- GitHub's community-standards checklist can only be confirmed after merge; the file is at the repository root, which is where the checklist looks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
